### PR TITLE
Adds cross-module Stack build configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ cabal.sandbox.config
 .stack-work
 /dist-newstyle/
 *~
-/stack.yaml
 cabal.project.local
+*.dwo

--- a/README.md
+++ b/README.md
@@ -13,6 +13,25 @@ We love all kinds of contributions so feel free to open issues for
 missing LLVM features, report & fix bugs or report API
 inconveniences.
 
+## Building
+
+Example using Homebrew on Mac OS X:
+
+```bash
+$ brew update
+$ brew install libffi
+$ brew install homebrew/versions/llvm39 --all-targets
+```
+
+For Debian/Ubuntu based Linux distributions, the LLVM.org website provides
+binary distribution packages. Check [apt.llvm.org](apt.llvm.org) for
+instructions for adding the correct package database for your OS version, and
+then:
+
+```bash
+$ apt-get install llvm-3.9-dev
+```
+
 ## Versioning
 
 Trying to represent the version of LLVM in the version number but also

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,10 @@
+resolver: lts-7.8
+
+packages:
+- 'llvm-general'
+- 'llvm-general-pure'
+flags:
+  llvm-general:
+    shared-llvm: true
+
+extra-package-dbs: []


### PR DESCRIPTION
Allows quickly building the project across both the `llvm-general` and `llvm-general-pure` modules using Stack. Also adds build directions to `README.md` for `llvm-3.9`.

```bash
$ stack exec ghci
GHCi, version 8.0.1: http://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /home/sdiehl/.ghci
λ> import LLVM.General.AST
λ> import LLVM.General.OrcJIT
```