### PR TITLE
LLVM 4 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,9 @@ install:
 # # mv cannot replace existing files so we need to use cp & rm
 #  - rsync -ac $HOME/llvm-${LLVM_VER}.src/ $HOME/llvm-src
 # Temporarily use a snapshot until there is a release
- - curl -L https://github.com/llvm-mirror/llvm/archive/f7babeb5d8e4d5d3b069fdda72285671fa74a2de.zip -o llvm.zip
+ - curl -L https://github.com/llvm-mirror/llvm/archive/9f6ca5d7e66edccaacd196fdca06a4e788d5e5b7.zip -o llvm.zip
  - unzip -q llvm.zip -d $HOME
- - rsync -ac $HOME/llvm-f7babeb5d8e4d5d3b069fdda72285671fa74a2de/ $HOME/llvm-src
+ - rsync -ac $HOME/llvm-9f6ca5d7e66edccaacd196fdca06a4e788d5e5b7/ $HOME/llvm-src
  - cd $HOME/llvm-src
  - mkdir -p build && cd build
  - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$HOME/llvm-build -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD=X86 ..

--- a/llvm-hs/src/LLVM/Internal/FFI/GlobalValue.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/GlobalValue.hs
@@ -25,8 +25,8 @@ foreign import ccall unsafe "LLVMGetLinkage" getLinkage ::
 foreign import ccall unsafe "LLVMSetLinkage" setLinkage ::
   Ptr GlobalValue -> Linkage -> IO ()
 
-foreign import ccall unsafe "LLVMGetSection" getSection ::
-  Ptr GlobalValue -> IO CString
+foreign import ccall unsafe "LLVM_Hs_GetSection" getSection ::
+  Ptr GlobalValue -> Ptr CSize -> IO CString
 
 foreign import ccall unsafe "LLVMSetSection" setSection ::
   Ptr GlobalValue -> CString -> IO ()

--- a/llvm-hs/src/LLVM/Internal/FFI/GlobalValueC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/GlobalValueC.cpp
@@ -30,6 +30,12 @@ const char *LLVM_Hs_GetCOMDATName(const Comdat &comdat, size_t &size) {
 LLVM_HS_FOR_EACH_COMDAT_SELECTION_KIND(ENUM_CASE)
 #undef ENUM_CASE
 
+const char* LLVM_Hs_GetSection(LLVMValueRef globalVal, size_t* strLength) {
+    const auto& section = unwrap<GlobalValue>(globalVal)->getSection();
+    *strLength = section.size();
+    return section.data();
+}
+
 unsigned LLVM_Hs_GetCOMDATSelectionKind(const Comdat &comdat) {
   return unsigned(comdat.getSelectionKind());
 }

--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp
@@ -139,7 +139,7 @@ static JITSymbolFlags unwrap(LLVMJITSymbolFlags f) {
     return flags;
 }
 
-LLVMJITSymbolFlags wrap(JITSymbolFlags f) {
+static LLVMJITSymbolFlags wrap(JITSymbolFlags f) {
     unsigned r = 0;
 #define ENUM_CASE(x)                                                           \
     if ((char)(f & JITSymbolFlags::x))                                         \

--- a/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
@@ -21,12 +21,19 @@ using namespace llvm;
 
 namespace llvm {
 // Taken from llvm/lib/Target/TargetMachineC.cpp
+// These functions need to be marked as static to avoid undefined behavior
+// due to multiple definitions
 static LLVMTargetRef wrap(const Target *P) {
   return reinterpret_cast<LLVMTargetRef>(const_cast<Target *>(P));
 }
 
-inline TargetLibraryInfoImpl *unwrap(LLVMTargetLibraryInfoRef P) {
+static inline TargetLibraryInfoImpl *unwrap(LLVMTargetLibraryInfoRef P) {
   return reinterpret_cast<TargetLibraryInfoImpl*>(P);
+}
+
+static inline LLVMTargetLibraryInfoRef wrap(const TargetLibraryInfoImpl *P) {
+  TargetLibraryInfoImpl *X = const_cast<TargetLibraryInfoImpl*>(P);
+  return reinterpret_cast<LLVMTargetLibraryInfoRef>(X);
 }
 
 static FloatABI::ABIType unwrap(LLVM_Hs_FloatABI x) {
@@ -218,11 +225,6 @@ char *LLVM_Hs_GetHostCPUFeatures() {
 char *LLVM_Hs_GetTargetMachineDataLayout(LLVMTargetMachineRef t) {
   return strdup(
       unwrap(t)->createDataLayout().getStringRepresentation().c_str());
-}
-
-inline LLVMTargetLibraryInfoRef wrap(const TargetLibraryInfoImpl *P) {
-  TargetLibraryInfoImpl *X = const_cast<TargetLibraryInfoImpl*>(P);
-  return reinterpret_cast<LLVMTargetLibraryInfoRef>(X);
 }
 
 LLVMTargetLibraryInfoRef


### PR DESCRIPTION
Section names are no longer null-terminated. I think this is a bug in LLVM since they explicitely added a null-byte before for the C-API to work correctly. But until this bug is fixed (I’m too lazy to report it right now) I think it makes sense to have this workaround.

The `static` stuff is tricky (at least for me) so take my explanation with a grain of salt. The problem is that with the definition in `OrcJitC.cpp` and the one here, there are two definitions for `wrap` resulting in undefined behavior. In this case it resulted in the OrcJIT wrap function being called in `LLVM_Hs_CreateTargetLibraryInfo` which obviously didn’t work and resulted in a segfault. The bug was present before, it just wasn’t triggered.