### PR TITLE
Fix serialization of cleanupret

### DIFF
--- a/llvm-hs/src/LLVM/Internal/FFI/BuilderC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/BuilderC.cpp
@@ -189,7 +189,11 @@ LLVMValueRef LLVM_Hs_BuildCleanupPad(LLVMBuilderRef b, LLVMValueRef parentPad,
 
 LLVMValueRef LLVM_Hs_BuildCleanupRet(LLVMBuilderRef b, LLVMValueRef cleanupPad,
                                      LLVMBasicBlockRef unwindDest) {
-    return wrap(unwrap(b)->CreateCleanupRet(unwrap<CleanupPadInst>(cleanupPad),
+    // Due to the way name resolution works in llvm-hs, cleanupPad might not
+    // actually be a CleanupPadInst. However, it will later be replaced by one.
+    // Pretending that we have one is thus ok here.
+    auto cleanupPad_ = static_cast<CleanupPadInst*>(unwrap<Value>(cleanupPad));
+    return wrap(unwrap(b)->CreateCleanupRet(cleanupPad_,
                                             unwrap(unwindDest)));
 }
 }

--- a/llvm-hs/test/LLVM/Test/Instructions.hs
+++ b/llvm-hs/test/LLVM/Test/Instructions.hs
@@ -958,7 +958,92 @@ tests = testGroup "Instructions" [
        \exit:                                             ; preds = %entry\n\
        \  ret void\n\
        \}\n"
-            )
+     ), ( -- This testcase is taken from test/Feature/exception.ll in LLVM
+       "cleanupret1",
+       Module {
+         moduleName = "<string>",
+         moduleSourceFileName = "<string>",
+         moduleDataLayout = Nothing,
+         moduleTargetTriple = Nothing,
+         moduleDefinitions = [
+           GlobalDefinition functionDefaults {
+             G.returnType = VoidType,
+             G.name = Name "_Z3quxv"
+           },
+           GlobalDefinition functionDefaults {
+             G.returnType = IntegerType {typeBits = 32},
+             G.name = Name "__gxx_personality_v0",
+             G.parameters = ([], True)
+           },
+           GlobalDefinition functionDefaults {
+             G.returnType = VoidType,
+             G.name = Name "cleanupret1",
+             G.basicBlocks = [
+               G.BasicBlock (Name "entry") [] (
+                 Do Invoke {
+                   callingConvention' = CC.C,
+                   returnAttributes' = [],
+                   function' = Right (
+                     ConstantOperand (
+                       C.GlobalReference PointerType {
+                         pointerReferent = FunctionType {resultType = VoidType, argumentTypes = [], isVarArg = False},
+                         pointerAddrSpace = AddrSpace 0
+                       } (Name "_Z3quxv")
+                     )
+                   ),
+                   arguments' = [],
+                   returnDest = Name "exit",
+                   exceptionDest = Name "pad",
+                   metadata' = [],
+                   functionAttributes' = []
+                 }
+               ),
+               G.BasicBlock
+                 (Name "cleanup")
+                 []
+                 (Do CleanupRet {
+                    cleanupPad = LocalReference TokenType (Name "cp"),
+                    unwindDest = Nothing,
+                    metadata' = []
+                 }),
+               G.BasicBlock
+                 (Name "pad")
+                 [Name "cp" := CleanupPad { parentPad = ConstantOperand C.TokenNone, args = [], metadata = [] }]
+                 (Do Br { dest = Name "cleanup", metadata' = [] }),
+               G.BasicBlock (Name "exit") [] (Do Ret { returnOperand = Nothing, metadata' = [] })
+             ],
+             G.personalityFunction = Just (
+               C.GlobalReference PointerType {
+                 pointerReferent = FunctionType {resultType = IntegerType { typeBits = 32 }, argumentTypes = [], isVarArg = True},
+                 pointerAddrSpace = AddrSpace 0
+               } (Name "__gxx_personality_v0")
+             )
+           }
+         ]
+       },
+       "; ModuleID = '<string>'\n\
+       \source_filename = \"<string>\"\n\
+       \\n\
+       \declare void @_Z3quxv()\n\
+       \\n\
+       \declare i32 @__gxx_personality_v0(...)\n\
+       \\n\
+       \define void @cleanupret1() personality i32 (...)* @__gxx_personality_v0 {\n\
+       \entry:\n\
+       \  invoke void @_Z3quxv()\n\
+       \          to label %exit unwind label %pad\n\
+       \\n\
+       \cleanup:                                          ; preds = %pad\n\
+       \  cleanupret from %cp unwind to caller\n\
+       \\n\
+       \pad:                                              ; preds = %entry\n\
+       \  %cp = cleanuppad within none []\n\
+       \  br label %cleanup\n\
+       \\n\
+       \exit:                                             ; preds = %entry\n\
+       \  ret void\n\
+       \}\n"
+     )
     ]
    ]
  ]


### PR DESCRIPTION
The fix is terrible but everything else would require to completely rewrite the way `llvm-hs` handles forward references. This might be worth exploring at some point but for now, this is the best solution.