### PR TITLE
Support catchret, catchswitch & catchpad

### DIFF
--- a/llvm-hs-pure/llvm-hs-pure.cabal
+++ b/llvm-hs-pure/llvm-hs-pure.cabal
@@ -23,10 +23,20 @@ source-repository head
   location: git://github.com/llvm-hs/llvm-hs.git
   branch: llvm-4
 
+flag semigroups
+  description: Add semigroups to build-depends for Data.List.NonEmpty. This will be selected automatically by cabal.
+  default: False
+
 library
   ghc-options: -fwarn-unused-imports
+  if flag(semigroups)
+    build-depends:
+      base >= 4.7 && < 4.9,
+      semigroups >= 0.18 && < 0.19
+  else
+    build-depends:
+      base >= 4.9 && < 5
   build-depends:
-    base >= 4.6 && < 5,
     transformers >= 0.3 && < 0.6,
     transformers-compat >= 0.4,
     mtl >= 2.1,
@@ -77,8 +87,14 @@ library
 
 test-suite test
   type: exitcode-stdio-1.0
+  if flag(semigroups)
+    build-depends:
+      base >= 4.7 && < 4.9,
+      semigroups >= 0.18 && < 0.19
+  else
+    build-depends:
+      base >= 4.9 && < 5
   build-depends:
-    base >= 4.6 && < 5,
     test-framework >= 0.5,
     test-framework-hunit >= 0.2.7,
     HUnit >= 1.2.4.2,

--- a/llvm-hs-pure/src/LLVM/AST/Instruction.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Instruction.hs
@@ -68,6 +68,17 @@ data Terminator
       unwindDest :: Maybe Name,
       metadata' :: InstructionMetadata
     }
+  | CatchRet {
+      catchPad :: Operand,
+      successor :: Name,
+      metadata' :: InstructionMetadata
+    }
+  | CatchSwitch {
+      parentPad' :: Operand,
+      catchHandlers :: [Name], -- TODO Use Data.List.NonEmpty because this list has to be nonempty
+      defaultUnwindDest :: Maybe Name,
+      metadata' :: InstructionMetadata
+    }
   deriving (Eq, Read, Show, Typeable, Data)
 
 -- | <http://llvm.org/docs/LangRef.html#fast-math-flags>

--- a/llvm-hs-pure/src/LLVM/AST/Instruction.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Instruction.hs
@@ -15,6 +15,8 @@ import LLVM.AST.CallingConvention (CallingConvention)
 import qualified LLVM.AST.ParameterAttribute as PA (ParameterAttribute)
 import qualified LLVM.AST.FunctionAttribute as FA (FunctionAttribute, GroupID)
 
+import Data.List.NonEmpty
+
 -- | <http://llvm.org/docs/LangRef.html#metadata-nodes-and-metadata-strings>
 -- Metadata can be attached to an instruction
 type InstructionMetadata = [(String, MetadataNode)]
@@ -75,7 +77,7 @@ data Terminator
     }
   | CatchSwitch {
       parentPad' :: Operand,
-      catchHandlers :: [Name], -- TODO Use Data.List.NonEmpty because this list has to be nonempty
+      catchHandlers :: NonEmpty Name,
       defaultUnwindDest :: Maybe Name,
       metadata' :: InstructionMetadata
     }

--- a/llvm-hs-pure/src/LLVM/AST/Instruction.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Instruction.hs
@@ -421,8 +421,11 @@ data Instruction
       clauses :: [LandingPadClause],
       metadata :: InstructionMetadata 
     }
-  | CatchPad {type' :: Type,
-              metadata :: InstructionMetadata}
+  | CatchPad {
+      catchSwitch :: Operand,
+      args :: [Operand],
+      metadata :: InstructionMetadata
+    }
   | CleanupPad {
       parentPad :: Operand,
       args :: [Operand],

--- a/llvm-hs-pure/src/LLVM/Internal/PrettyPrint.hs
+++ b/llvm-hs-pure/src/LLVM/Internal/PrettyPrint.hs
@@ -12,6 +12,7 @@ import LLVM.Prelude
 import LLVM.TH 
 import Language.Haskell.TH.Quote
 
+import Data.List.NonEmpty (NonEmpty)
 import Data.Monoid
 import Data.String
 import Data.Maybe
@@ -111,6 +112,8 @@ class Show a => PrettyShow a where
 instance PrettyShow a => PrettyShow [a] where
   prettyShow = prettyShowList
 
+instance PrettyShow a => PrettyShow (NonEmpty a) where
+  prettyShow = prettyShowList . toList
 
 appPrec = 10
 appPrec1 = 11

--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -48,6 +48,10 @@ flag debug
   description: compile C(++) shims with debug info for ease of troubleshooting
   default: False
 
+flag semigroups
+  description: Add semigroups to build-depends for Data.List.NonEmpty. This will be selected automatically by cabal.
+  default: False
+
 custom-setup
   setup-depends: base
                , Cabal
@@ -56,8 +60,14 @@ custom-setup
 library
   build-tools: llvm-config
   ghc-options: -fwarn-unused-imports
+  if flag(semigroups)
+    build-depends:
+      base >= 4.7 && < 4.9,
+      semigroups >= 0.18 && < 0.19
+  else
+    build-depends:
+      base >= 4.9 && < 5
   build-depends:
-    base >= 4.7 && < 5,
     utf8-string >= 0.3.7,
     bytestring >= 0.9.1.10,
     transformers >= 0.3 && < 0.6,
@@ -213,8 +223,14 @@ library
 
 test-suite test
   type: exitcode-stdio-1.0
+  if flag(semigroups)
+    build-depends:
+      base >= 4.7 && < 4.9,
+      semigroups >= 0.18 && < 0.19
+  else
+    build-depends:
+      base >= 4.9 && < 5
   build-depends:
-    base >= 4.7 && < 5,
     test-framework >= 0.5,
     test-framework-hunit >= 0.2.7,
     HUnit >= 1.2.4.2,

--- a/llvm-hs/src/LLVM/Internal/FFI/Builder.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Builder.hs
@@ -65,6 +65,11 @@ foreign import ccall unsafe "LLVMBuildUnreachable" buildUnreachable ::
 foreign import ccall unsafe "LLVM_Hs_BuildCleanupRet" buildCleanupRet ::
   Ptr Builder -> Ptr Value -> Ptr BasicBlock -> IO (Ptr Instruction)
 
+foreign import ccall unsafe "LLVM_Hs_BuildCatchRet" buildCatchRet ::
+  Ptr Builder -> Ptr Value -> Ptr BasicBlock -> IO (Ptr Instruction)
+
+foreign import ccall unsafe "LLVM_Hs_BuildCatchSwitch" buildCatchSwitch ::
+  Ptr Builder -> Ptr Value -> Ptr BasicBlock -> CUInt -> IO (Ptr Instruction)
 
 $(do
   liftM concat $ sequence $ do
@@ -165,6 +170,9 @@ buildLandingPad :: Ptr Builder -> Ptr Type -> CUInt -> CString -> IO (Ptr Instru
 buildLandingPad builder ty numClauses name = buildLandingPad' builder ty nullPtr numClauses name
 
 foreign import ccall unsafe "LLVM_Hs_BuildCleanupPad" buildCleanupPad ::
+  Ptr Builder -> Ptr Value -> Ptr (Ptr Value) -> CUInt -> CString -> IO (Ptr Instruction)
+
+foreign import ccall unsafe "LLVM_Hs_BuildCatchPad" buildCatchPad ::
   Ptr Builder -> Ptr Value -> Ptr (Ptr Value) -> CUInt -> CString -> IO (Ptr Instruction)
 
 foreign import ccall unsafe "LLVM_Hs_SetFastMathFlags" setFastMathFlags ::

--- a/llvm-hs/src/LLVM/Internal/FFI/BuilderC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/BuilderC.cpp
@@ -187,6 +187,14 @@ LLVMValueRef LLVM_Hs_BuildCleanupPad(LLVMBuilderRef b, LLVMValueRef parentPad,
                                           name));
 }
 
+LLVMValueRef LLVM_Hs_BuildCatchPad(LLVMBuilderRef b, LLVMValueRef catchSwitch,
+                                   LLVMValueRef *args, unsigned numArgs,
+                                   const char *name) {
+    return wrap(unwrap(b)->CreateCatchPad(unwrap(catchSwitch),
+                                          makeArrayRef(unwrap(args), numArgs),
+                                          name));
+}
+
 LLVMValueRef LLVM_Hs_BuildCleanupRet(LLVMBuilderRef b, LLVMValueRef cleanupPad,
                                      LLVMBasicBlockRef unwindDest) {
     // Due to the way name resolution works in llvm-hs, cleanupPad might not
@@ -195,5 +203,21 @@ LLVMValueRef LLVM_Hs_BuildCleanupRet(LLVMBuilderRef b, LLVMValueRef cleanupPad,
     auto cleanupPad_ = static_cast<CleanupPadInst*>(unwrap<Value>(cleanupPad));
     return wrap(unwrap(b)->CreateCleanupRet(cleanupPad_,
                                             unwrap(unwindDest)));
+}
+
+LLVMValueRef LLVM_Hs_BuildCatchRet(LLVMBuilderRef b, LLVMValueRef catchPad,
+                                   LLVMBasicBlockRef successor) {
+    // Due to the way name resolution works in llvm-hs, catchPad might not
+    // actually be a CatchPadInst. However, it will later be replaced by one.
+    // Pretending that we have one is thus ok here.
+    auto catchPad_ = static_cast<CatchPadInst *>(unwrap<Value>(catchPad));
+    return wrap(unwrap(b)->CreateCatchRet(catchPad_, unwrap(successor)));
+}
+
+LLVMValueRef LLVM_Hs_BuildCatchSwitch(LLVMBuilderRef b, LLVMValueRef parentPad,
+                                      LLVMBasicBlockRef unwindDest,
+                                      unsigned numHandlers) {
+    return wrap(unwrap(b)->CreateCatchSwitch(unwrap(parentPad),
+                                             unwrap(unwindDest), numHandlers));
 }
 }

--- a/llvm-hs/src/LLVM/Internal/FFI/Instruction.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Instruction.hs
@@ -170,6 +170,9 @@ foreign import ccall unsafe "LLVM_Hs_CatchSwitch_GetNumHandlers" catchSwitchGetN
 foreign import ccall unsafe "LLVM_Hs_CatchSwitch_GetHandler" catchSwitchGetHandler ::
   Ptr Instruction -> CUInt -> IO (Ptr BasicBlock)
 
+foreign import ccall unsafe "LLVM_Hs_CatchSwitch_AddHandler" catchSwitchAddHandler ::
+  Ptr Instruction -> Ptr BasicBlock -> IO ()
+
 foreign import ccall unsafe "LLVM_Hs_CatchRet_GetCatchPad" catchRetGetCatchPad ::
   Ptr Instruction -> IO (Ptr Value)
 

--- a/llvm-hs/src/LLVM/Internal/FFI/Instruction.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Instruction.hs
@@ -157,3 +157,21 @@ foreign import ccall unsafe "LLVM_Hs_GetNumArgOperands" getNumArgOperands ::
 
 foreign import ccall unsafe "LLVM_Hs_GetArgOperand" getArgOperand ::
   Ptr Instruction -> CUInt -> IO (Ptr Value)
+
+foreign import ccall unsafe "LLVM_Hs_CatchSwitch_GetParentPad" catchSwitchGetParentPad ::
+  Ptr Instruction -> IO (Ptr Value)
+
+foreign import ccall unsafe "LLVM_Hs_CatchSwitch_GetUnwindDest" catchSwitchGetUnwindDest ::
+  Ptr Instruction -> IO (Ptr BasicBlock)
+
+foreign import ccall unsafe "LLVM_Hs_CatchSwitch_GetNumHandlers" catchSwitchGetNumHandlers ::
+  Ptr Instruction -> IO CUInt
+
+foreign import ccall unsafe "LLVM_Hs_CatchSwitch_GetHandler" catchSwitchGetHandler ::
+  Ptr Instruction -> CUInt -> IO (Ptr BasicBlock)
+
+foreign import ccall unsafe "LLVM_Hs_CatchRet_GetCatchPad" catchRetGetCatchPad ::
+  Ptr Instruction -> IO (Ptr Value)
+
+foreign import ccall unsafe "LLVM_Hs_CatchRet_GetSuccessor" catchRetGetSuccessor ::
+  Ptr Instruction -> IO (Ptr BasicBlock)

--- a/llvm-hs/src/LLVM/Internal/FFI/InstructionC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/InstructionC.cpp
@@ -294,23 +294,23 @@ LLVMValueRef LLVM_Hs_GetArgOperand(LLVMValueRef i, unsigned op) {
 }
 
 LLVMValueRef LLVM_Hs_CatchSwitch_GetParentPad(LLVMValueRef i) {
-    fprintf(stderr, "getparendpad\n");
     return wrap(unwrap<CatchSwitchInst>(i)->getParentPad());
 }
 
 LLVMBasicBlockRef LLVM_Hs_CatchSwitch_GetUnwindDest(LLVMValueRef i) {
-    fprintf(stderr, "getunwinddest\n");
     return wrap(unwrap<CatchSwitchInst>(i)->getUnwindDest());
 }
 
 unsigned LLVM_Hs_CatchSwitch_GetNumHandlers(LLVMValueRef i) {
-    fprintf(stderr, "getnumhandlers\n");
     return unwrap<CatchSwitchInst>(i)->getNumHandlers();
 }
 
 LLVMBasicBlockRef LLVM_Hs_CatchSwitch_GetHandler(LLVMValueRef instr, unsigned i) {
-    fprintf(stderr, "getHandler\n");
     return wrap(*(unwrap<CatchSwitchInst>(instr)->handler_begin() + i));
+}
+
+void LLVM_Hs_CatchSwitch_AddHandler(LLVMValueRef instr, LLVMBasicBlockRef bb) {
+    unwrap<CatchSwitchInst>(instr)->addHandler(unwrap(bb));
 }
 
 LLVMValueRef LLVM_Hs_CatchRet_GetCatchPad(LLVMValueRef i) {

--- a/llvm-hs/src/LLVM/Internal/FFI/InstructionC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/InstructionC.cpp
@@ -292,4 +292,32 @@ unsigned LLVM_Hs_GetNumArgOperands(LLVMValueRef i) {
 LLVMValueRef LLVM_Hs_GetArgOperand(LLVMValueRef i, unsigned op) {
     return wrap(unwrap<FuncletPadInst>(i)->getArgOperand(op));
 }
+
+LLVMValueRef LLVM_Hs_CatchSwitch_GetParentPad(LLVMValueRef i) {
+    fprintf(stderr, "getparendpad\n");
+    return wrap(unwrap<CatchSwitchInst>(i)->getParentPad());
+}
+
+LLVMBasicBlockRef LLVM_Hs_CatchSwitch_GetUnwindDest(LLVMValueRef i) {
+    fprintf(stderr, "getunwinddest\n");
+    return wrap(unwrap<CatchSwitchInst>(i)->getUnwindDest());
+}
+
+unsigned LLVM_Hs_CatchSwitch_GetNumHandlers(LLVMValueRef i) {
+    fprintf(stderr, "getnumhandlers\n");
+    return unwrap<CatchSwitchInst>(i)->getNumHandlers();
+}
+
+LLVMBasicBlockRef LLVM_Hs_CatchSwitch_GetHandler(LLVMValueRef instr, unsigned i) {
+    fprintf(stderr, "getHandler\n");
+    return wrap(*(unwrap<CatchSwitchInst>(instr)->handler_begin() + i));
+}
+
+LLVMValueRef LLVM_Hs_CatchRet_GetCatchPad(LLVMValueRef i) {
+    return wrap(unwrap<CatchReturnInst>(i)->getCatchPad());
+}
+
+LLVMBasicBlockRef LLVM_Hs_CatchRet_GetSuccessor(LLVMValueRef i) {
+    return wrap(unwrap<CatchReturnInst>(i)->getSuccessor());
+}
 }

--- a/llvm-hs/test/LLVM/Test/Instructions.hs
+++ b/llvm-hs/test/LLVM/Test/Instructions.hs
@@ -1062,7 +1062,7 @@ tests = testGroup "Instructions" [
            },
            GlobalDefinition functionDefaults {
              G.returnType = VoidType,
-             G.name = Name "cleanupret1",
+             G.name = Name "catchret0",
              G.basicBlocks = [
                G.BasicBlock (Name "entry") [] (
                  Do Invoke {
@@ -1083,18 +1083,23 @@ tests = testGroup "Instructions" [
                    functionAttributes' = []
                  }
                ),
+               G.BasicBlock (Name "pad") [] (
+                 Name "cs1" := CatchSwitch {
+                   parentPad' = ConstantOperand C.TokenNone,
+                   catchHandlers = [Name "catch"],
+                   defaultUnwindDest = Nothing,
+                   metadata' = []
+                 }
+               ),
                G.BasicBlock
-                 (Name "cleanup")
-                 []
-                 (Do CleanupRet {
-                    cleanupPad = LocalReference TokenType (Name "cp"),
-                    unwindDest = Nothing,
-                    metadata' = []
-                 }),
-               G.BasicBlock
-                 (Name "pad")
-                 [Name "cp" := CleanupPad { parentPad = ConstantOperand C.TokenNone, args = [], metadata = [] }]
-                 (Do Br { dest = Name "cleanup", metadata' = [] }),
+                 (Name "catch")
+                 [Name "cp" := CatchPad { catchSwitch = LocalReference TokenType (Name "cs1"), args = [ConstantOperand C.Int { C.integerBits = 7, C.integerValue = 4 }], metadata = [] }] (
+                 Do CatchRet {
+                   catchPad = LocalReference TokenType (Name "cp"),
+                   successor = Name "exit",
+                   metadata' = []
+                 }
+               ),
                G.BasicBlock (Name "exit") [] (Do Ret { returnOperand = Nothing, metadata' = [] })
              ],
              G.personalityFunction = Just (
@@ -1115,7 +1120,7 @@ tests = testGroup "Instructions" [
        \\n\
        \define void @catchret0() personality i32 (...)* @__gxx_personality_v0 {\n\
        \entry:\n\
-       \  invoke void @_Z3quxv() #0\n\
+       \  invoke void @_Z3quxv()\n\
        \          to label %exit unwind label %pad\n\
        \\n\
        \pad:                                              ; preds = %entry\n\

--- a/llvm-hs/test/LLVM/Test/Instructions.hs
+++ b/llvm-hs/test/LLVM/Test/Instructions.hs
@@ -1043,6 +1043,91 @@ tests = testGroup "Instructions" [
        \exit:                                             ; preds = %entry\n\
        \  ret void\n\
        \}\n"
+     ), ( -- This testcase is taken from test/Feature/exception.ll in LLVM
+       "catchret0",
+       Module {
+         moduleName = "<string>",
+         moduleSourceFileName = "<string>",
+         moduleDataLayout = Nothing,
+         moduleTargetTriple = Nothing,
+         moduleDefinitions = [
+           GlobalDefinition functionDefaults {
+             G.returnType = VoidType,
+             G.name = Name "_Z3quxv"
+           },
+           GlobalDefinition functionDefaults {
+             G.returnType = IntegerType {typeBits = 32},
+             G.name = Name "__gxx_personality_v0",
+             G.parameters = ([], True)
+           },
+           GlobalDefinition functionDefaults {
+             G.returnType = VoidType,
+             G.name = Name "cleanupret1",
+             G.basicBlocks = [
+               G.BasicBlock (Name "entry") [] (
+                 Do Invoke {
+                   callingConvention' = CC.C,
+                   returnAttributes' = [],
+                   function' = Right (
+                     ConstantOperand (
+                       C.GlobalReference PointerType {
+                         pointerReferent = FunctionType {resultType = VoidType, argumentTypes = [], isVarArg = False},
+                         pointerAddrSpace = AddrSpace 0
+                       } (Name "_Z3quxv")
+                     )
+                   ),
+                   arguments' = [],
+                   returnDest = Name "exit",
+                   exceptionDest = Name "pad",
+                   metadata' = [],
+                   functionAttributes' = []
+                 }
+               ),
+               G.BasicBlock
+                 (Name "cleanup")
+                 []
+                 (Do CleanupRet {
+                    cleanupPad = LocalReference TokenType (Name "cp"),
+                    unwindDest = Nothing,
+                    metadata' = []
+                 }),
+               G.BasicBlock
+                 (Name "pad")
+                 [Name "cp" := CleanupPad { parentPad = ConstantOperand C.TokenNone, args = [], metadata = [] }]
+                 (Do Br { dest = Name "cleanup", metadata' = [] }),
+               G.BasicBlock (Name "exit") [] (Do Ret { returnOperand = Nothing, metadata' = [] })
+             ],
+             G.personalityFunction = Just (
+               C.GlobalReference PointerType {
+                 pointerReferent = FunctionType {resultType = IntegerType { typeBits = 32 }, argumentTypes = [], isVarArg = True},
+                 pointerAddrSpace = AddrSpace 0
+               } (Name "__gxx_personality_v0")
+             )
+           }
+         ]
+       },
+       "; ModuleID = '<string>'\n\
+       \source_filename = \"<string>\"\n\
+       \\n\
+       \declare void @_Z3quxv()\n\
+       \\n\
+       \declare i32 @__gxx_personality_v0(...)\n\
+       \\n\
+       \define void @catchret0() personality i32 (...)* @__gxx_personality_v0 {\n\
+       \entry:\n\
+       \  invoke void @_Z3quxv() #0\n\
+       \          to label %exit unwind label %pad\n\
+       \\n\
+       \pad:                                              ; preds = %entry\n\
+       \  %cs1 = catchswitch within none [label %catch] unwind to caller\n\
+       \\n\
+       \catch:                                            ; preds = %pad\n\
+       \  %cp = catchpad within %cs1 [i7 4]\n\
+       \  catchret from %cp to label %exit\n\
+       \\n\
+       \exit:                                             ; preds = %catch, %entry\n\
+       \  ret void\n\
+       \}\n"
      )
     ]
    ]

--- a/llvm-hs/test/LLVM/Test/Instructions.hs
+++ b/llvm-hs/test/LLVM/Test/Instructions.hs
@@ -1133,6 +1133,102 @@ tests = testGroup "Instructions" [
        \exit:                                             ; preds = %catch, %entry\n\
        \  ret void\n\
        \}\n"
+     ), ( -- This testcase is taken from test/Feature/exception.ll in LLVM
+       "catchret1",
+       Module {
+         moduleName = "<string>",
+         moduleSourceFileName = "<string>",
+         moduleDataLayout = Nothing,
+         moduleTargetTriple = Nothing,
+         moduleDefinitions = [
+           GlobalDefinition functionDefaults {
+             G.returnType = VoidType,
+             G.name = Name "_Z3quxv"
+           },
+           GlobalDefinition functionDefaults {
+             G.returnType = IntegerType {typeBits = 32},
+             G.name = Name "__gxx_personality_v0",
+             G.parameters = ([], True)
+           },
+           GlobalDefinition functionDefaults {
+             G.returnType = VoidType,
+             G.name = Name "catchret0",
+             G.basicBlocks = [
+               G.BasicBlock (Name "entry") [] (
+                 Do Invoke {
+                   callingConvention' = CC.C,
+                   returnAttributes' = [],
+                   function' = Right (
+                     ConstantOperand (
+                       C.GlobalReference PointerType {
+                         pointerReferent = FunctionType {resultType = VoidType, argumentTypes = [], isVarArg = False},
+                         pointerAddrSpace = AddrSpace 0
+                       } (Name "_Z3quxv")
+                     )
+                   ),
+                   arguments' = [],
+                   returnDest = Name "exit",
+                   exceptionDest = Name "pad",
+                   metadata' = [],
+                   functionAttributes' = []
+                 }
+               ),
+               G.BasicBlock (Name "catchret") [] (
+                 Do CatchRet {
+                    catchPad = LocalReference TokenType (Name "cp"),
+                    successor = Name "exit",
+                    metadata' = []
+                 }
+               ),
+               G.BasicBlock (Name "pad") [] (
+                 Name "cs1" := CatchSwitch {
+                   parentPad' = ConstantOperand C.TokenNone,
+                   catchHandlers = [Name "catch"],
+                   defaultUnwindDest = Nothing,
+                   metadata' = []
+                 }
+               ),
+               G.BasicBlock
+                 (Name "catch")
+                 [Name "cp" := CatchPad { catchSwitch = LocalReference TokenType (Name "cs1"), args = [ConstantOperand C.Int { C.integerBits = 7, C.integerValue = 4 }], metadata = [] }] (
+                 Do Br { dest = (Name "catchret"), metadata' = [] }
+               ),
+               G.BasicBlock (Name "exit") [] (Do Ret { returnOperand = Nothing, metadata' = [] })
+             ],
+             G.personalityFunction = Just (
+               C.GlobalReference PointerType {
+                 pointerReferent = FunctionType {resultType = IntegerType { typeBits = 32 }, argumentTypes = [], isVarArg = True},
+                 pointerAddrSpace = AddrSpace 0
+               } (Name "__gxx_personality_v0")
+             )
+           }
+         ]
+       },
+       "; ModuleID = '<string>'\n\
+       \source_filename = \"<string>\"\n\
+       \\n\
+       \declare void @_Z3quxv()\n\
+       \\n\
+       \declare i32 @__gxx_personality_v0(...)\n\
+       \\n\
+       \define void @catchret0() personality i32 (...)* @__gxx_personality_v0 {\n\
+       \entry:\n\
+       \  invoke void @_Z3quxv()\n\
+       \          to label %exit unwind label %pad\n\
+       \\n\
+       \catchret:                                         ; preds = %catch\n\
+       \  catchret from %cp to label %exit\n\
+       \\n\
+       \pad:                                              ; preds = %entry\n\
+       \  %cs1 = catchswitch within none [label %catch] unwind to caller\n\
+       \\n\
+       \catch:                                            ; preds = %pad\n\
+       \  %cp = catchpad within %cs1 [i7 4]\n\
+       \  br label %catchret\n\
+       \\n\
+       \exit:                                             ; preds = %catchret, %entry\n\
+       \  ret void\n\
+       \}\n"
      )
     ]
    ]

--- a/llvm-hs/test/LLVM/Test/Instructions.hs
+++ b/llvm-hs/test/LLVM/Test/Instructions.hs
@@ -8,6 +8,7 @@ import LLVM.Test.Support
 
 import Control.Monad
 import Data.Functor
+import Data.List.NonEmpty (NonEmpty((:|)))
 import Data.Maybe
 import Foreign.Ptr
 import Data.Word
@@ -1086,7 +1087,7 @@ tests = testGroup "Instructions" [
                G.BasicBlock (Name "pad") [] (
                  Name "cs1" := CatchSwitch {
                    parentPad' = ConstantOperand C.TokenNone,
-                   catchHandlers = [Name "catch"],
+                   catchHandlers = (Name "catch" :| []),
                    defaultUnwindDest = Nothing,
                    metadata' = []
                  }
@@ -1183,7 +1184,7 @@ tests = testGroup "Instructions" [
                G.BasicBlock (Name "pad") [] (
                  Name "cs1" := CatchSwitch {
                    parentPad' = ConstantOperand C.TokenNone,
-                   catchHandlers = [Name "catch"],
+                   catchHandlers = (Name "catch" :| []),
                    defaultUnwindDest = Nothing,
                    metadata' = []
                  }


### PR DESCRIPTION
I think with this PR we should now support all of the exception related instructions.

There are a few things that I’d like some input on:
* Do we want to depend on `semigroups` and use `Data.List.NonEmpty`? It makes sense to use this where LLVM requires nonempty lists (it’s only in `base >= 4.9`).
* Some of the FFI functions would have collided with other functions so I ended up prefixing all of the ones I added with the instruction they correspond to. While I like this naming scheme in general it introduces inconsistency unless we retrofit it on all functions. Personally I think the best solution is to just leave it as it is now and only prefix new functions since these functions are not exposed in the public API so inconsistencies are not that much of a problem.