### PR TITLE
Remove instructions on how to load llvm-hs in stack ghci

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,6 @@ then:
 $ apt-get install llvm-3.9-dev
 ```
 
-### Loading llvm-hs in stack ghci
-
-If you are seeing linker errors when running `stack ghci`, you need to
-add the following lines to your `stack.yaml`. The exact options needed
-might vary between systems.
-
-```
-ghc-options:
-  llvm-hs: -pgml g++ -optl-Wl,-lLLVM
-```
-
 ## Versioning
 
 Trying to represent the version of LLVM in the version number but also


### PR DESCRIPTION
These do not seem to work properly, in particular, they cause linker
errors on a clean build.