### PR TITLE
Fix Haddocks in LLVM.AST.Type

### DIFF
--- a/llvm-hs-pure/src/LLVM/AST/Type.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Type.hs
@@ -37,8 +37,8 @@ data Type
   | NamedTypeReference Name
   -- | <http://llvm.org/docs/LangRef.html#metadata-type>
   | MetadataType -- only to be used as a parameter type for a few intrinsics
-  | TokenType
   -- | <http://llvm.org/docs/LangRef.html#token-type>
+  | TokenType
   deriving (Eq, Ord, Read, Show, Typeable, Data)
 
 -- | An abbreviation for 'VoidType'


### PR DESCRIPTION
Previously failed with the following message:

    src/LLVM/AST/Type.hs:42:3: error: parse error on input ‘deriving’