### PR TITLE
Fix cabal warnings

### DIFF
--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -238,7 +238,7 @@ test-suite test
     HUnit >= 1.2.4.2,
     test-framework-quickcheck2 >= 0.3.0.1,
     QuickCheck >= 2.5.1.1,
-    llvm-hs == 4.0.0.0,
+    llvm-hs,
     llvm-hs-pure == 4.0.0.0,
     containers >= 0.4.2.1,
     mtl >= 2.1,


### PR DESCRIPTION
This includes two small fixes for cabal warnings.
1. include directories should be specified via extra-include-dirs and not via cflags. We were already passing the include-dirs in `extra-include-dirs` so this change just removes them from the c flags.
2. version bounds within the same package have no effect (according to a cabal warning) so remove the version bound from the test suite.