### PR TITLE
Add default case for GetTargetOptionFlag

### DIFF
--- a/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
@@ -156,6 +156,9 @@ unsigned LLVM_Hs_GetTargetOptionFlag(TargetOptions *to,
     return to->op;
     LLVM_HS_FOR_EACH_TARGET_OPTION_FLAG(ENUM_CASE)
 #undef ENUM_CASE
+  default:
+    assert(false && "Unknown target option flag");
+    return 0;
   }
 }
 


### PR DESCRIPTION
This fixes a warning because we don’t return anything otherwise from that function. I’m not quite sure what the best way to handle this error is. The problem with the assert is that it can be disabled and then we just return `0` but this is really a fatal error and should just kill the program. It is also an internal error so exposing it to the user does not make sense. Maybe a `fprintf` to `stderr` followed by `exit(1)` is better?