### PR TITLE
Provide nix-shell and brief readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ then:
 $ apt-get install llvm-4.0-dev
 ```
 
+### Nix
+
+Nix users can use the following commands to build the library:
+
+```bash
+$ nix-shell
+$ cabal new-build llvm-hs
+```
+
 ### Building from source
 
 Example of building LLVM from source. Detailed build instructions are available

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ $ nix-shell
 $ cabal new-build llvm-hs
 ```
 
+The Nix shell uses a pinned version of nixpkgs by default.
+You can define the `nixpkgs` argument to use a different nixpkgs tree:
+
+```bash
+$ nix-shell --arg nixpkgs '<nixpkgs>'
+```
+
 ### Building from source
 
 Example of building LLVM from source. Detailed build instructions are available

--- a/llvm-hs-pure/default.nix
+++ b/llvm-hs-pure/default.nix
@@ -1,0 +1,21 @@
+{ mkDerivation, base, containers, HUnit, mtl, parsec, QuickCheck
+, stdenv, template-haskell, test-framework, test-framework-hunit
+, test-framework-quickcheck2, transformers, transformers-compat
+}:
+mkDerivation {
+  pname = "llvm-hs-pure";
+  version = "4.0.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    base containers mtl parsec template-haskell transformers
+    transformers-compat
+  ];
+  testHaskellDepends = [
+    base containers HUnit mtl QuickCheck test-framework
+    test-framework-hunit test-framework-quickcheck2 transformers
+    transformers-compat
+  ];
+  homepage = "http://github.com/llvm-hs/llvm-hs/";
+  description = "Pure Haskell LLVM functionality (no FFI)";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/llvm-hs/default.nix
+++ b/llvm-hs/default.nix
@@ -1,0 +1,26 @@
+{ mkDerivation, array, base, bytestring, Cabal, containers, HUnit
+, llvm-config, llvm-hs-pure, mtl, parsec, QuickCheck, stdenv
+, template-haskell, test-framework, test-framework-hunit
+, test-framework-quickcheck2, transformers, transformers-compat
+, utf8-string
+}:
+mkDerivation {
+  pname = "llvm-hs";
+  version = "4.0.0.0";
+  src = ./.;
+  configureFlags = [ "-fshared-llvm" ];
+  setupHaskellDepends = [ base Cabal containers ];
+  libraryHaskellDepends = [
+    array base bytestring containers llvm-hs-pure mtl parsec
+    template-haskell transformers transformers-compat utf8-string
+  ];
+  libraryToolDepends = [ llvm-config ];
+  testHaskellDepends = [
+    base containers HUnit llvm-hs-pure mtl QuickCheck test-framework
+    test-framework-hunit test-framework-quickcheck2 transformers
+    transformers-compat
+  ];
+  homepage = "http://github.com/llvm-hs/llvm-hs/";
+  description = "General purpose LLVM bindings";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,25 @@
+let
+  nixpkgs = (import <nixpkgs> {}).fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs";
+    rev = "68cc97d306d3187c142cfb2378852f28d47bc098";
+    sha256 = "07zxbk4g4d51hf7dhsj6h7jy5c2iccm2lwaashj36inkhh9lrqa3";
+  };
+
+  hsOverlay = self: super: {
+    haskellPackages = super.haskellPackages.override {
+      overrides = self': super': {
+        llvm-hs-pure = super'.callPackage ./llvm-hs-pure {};
+        llvm-hs = super'.callPackage ./llvm-hs {
+          llvm-config = self.llvm_4;
+        };
+      };
+    };
+  };
+
+  orig_pkgs = import nixpkgs {};
+  pkgs = import orig_pkgs.path { overlays = [ hsOverlay ]; };
+
+in
+
+pkgs.haskellPackages.llvm-hs.env

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,15 @@
 let
-  nixpkgs = (import <nixpkgs> {}).fetchFromGitHub {
+  default_nixpkgs = (import <nixpkgs> {}).fetchFromGitHub {
     owner = "NixOS";
     repo = "nixpkgs";
     rev = "68cc97d306d3187c142cfb2378852f28d47bc098";
     sha256 = "07zxbk4g4d51hf7dhsj6h7jy5c2iccm2lwaashj36inkhh9lrqa3";
   };
+in
+
+{ nixpkgs ? default_nixpkgs }:
+
+let
 
   hsOverlay = self: super: {
     haskellPackages = super.haskellPackages.override {


### PR DESCRIPTION
The nix-expressions for `llvm-hs-pure`, and `llvm-hs` are generated using `cabal2nix`.
The shell refers to a recent commit of the nixpkgs `release-17.03` branch, which contains llvm 4.
Nixpkgs 17.03 should be released soon.