### PR TITLE
Default to -fshared-llvm=True

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_install:
  - export PATH=$HOME/bin:$PATH
  - export CC=/usr/bin/$GCC
  - export CXX=/usr/bin/$GXX
+ - export LD_LIBRARY_PATH=$HOME/llvm-build-${LLVM_VER}/lib:$LD_LIBRARY_PATH
 
 install:
  - curl https://cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.tar.gz | tar -xzf - -C $HOME

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
  - rsync -ac $HOME/llvm-${LLVM_VER}.src/ $HOME/llvm-src-${LLVM_VER}
  - cd $HOME/llvm-src-${LLVM_VER}
  - mkdir -p build && cd build
- - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$HOME/llvm-build-${LLVM_VER} -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD=X86 ..
+ - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$HOME/llvm-build-${LLVM_VER} -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_BUILD_LLVM_DYLIB=True -DLLVM_LINK_LLVM_DYLIB=True ..
  - make install -j3
  - cd $TRAVIS_BUILD_DIR
  - ln -s $HOME/llvm-build-${LLVM_VER}/bin/llvm-config $HOME/bin/llvm-config

--- a/README.md
+++ b/README.md
@@ -13,15 +13,19 @@ We love all kinds of contributions so feel free to open issues for
 missing LLVM features, report & fix bugs or report API
 inconveniences.
 
-## Building
+## Installing LLVM
 
-Example using Homebrew on Mac OS X:
+### Homebrew
+
+Example using Homebrew on macOS:
 
 ```bash
 $ brew update
 $ brew install libffi
 $ brew install homebrew/versions/llvm39 --all-targets
 ```
+
+### Debian/Ubuntu
 
 For Debian/Ubuntu based Linux distributions, the LLVM.org website provides
 binary distribution packages. Check [apt.llvm.org](apt.llvm.org) for
@@ -31,6 +35,48 @@ then:
 ```bash
 $ apt-get install llvm-4.0-dev
 ```
+
+### Building from source
+
+Example of building LLVM from source. Detailed build instructions are available
+on the LLVM.org website [here](http://llvm.org/docs/CMake.html). [CMake
+3.4.3](http://www.cmake.org/cmake/resources/software.html) and a recent C++
+compiler are required, at least Clang 3.1, GCC 4.8, or Visual Studio 2015
+(Update 3).
+
+  1. Download and unpack the [LLVM-4.0 source code](http://releases.llvm.org/4.0.0/llvm-4.0.0.src.tar.xz).
+     We'll refer to the path the source tree was unpacked to as `LLVM_SRC`.
+
+  2. Create a temporary build directory and `cd` to it, for example:
+     ```sh
+     mkdir /tmp/build
+     cd /tmp/build
+     ```
+
+  3. Execute the following to configure the build. Here, `INSTALL_PREFIX` is
+     where LLVM is to be installed, for example `/usr/local`:
+     ```sh
+     cmake $LLVM_SRC -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DLLVM_BUILD_LLVM_DYLIB=True -DLLVM_LINK_LLVM_DYLIB=True
+     ```
+     See [options and variables](http://llvm.org/docs/CMake.html#options-and-variables)
+     for a list of additional build parameters you can specify.
+
+  4. Build and install:
+     ```sh
+     cmake --build .
+     cmake --build . --target install
+     ```
+
+  5. For macOS only, some additional steps are useful to work around issues related
+     to [System Integrity Protection](https://en.wikipedia.org/wiki/System_Integrity_Protection):
+     ```sh
+     cd $INSTALL_PREFIX/lib
+     ln -s libLLVM.dylib libLLVM-4.0.dylib
+     install_name_tool -id $PWD/libLTO.dylib libLTO.dylib
+     install_name_tool -id $PWD/libLLVM.dylib libLLVM.dylib
+     install_name_tool -change '@rpath/libLLVM.dylib' $PWD/libLLVM.dylib libLTO.dylib
+     ```
+
 
 ## Versioning
 

--- a/llvm-hs/Setup.hs
+++ b/llvm-hs/Setup.hs
@@ -18,7 +18,7 @@ import Distribution.Version
 import System.Environment
 import Distribution.System
 
--- define these selectively in C files (where _not_ using HsFFI.h),
+-- define these selectively in C files (we are _not_ using HsFFI.h),
 -- rather than universally in the ccOptions, because HsFFI.h currently defines them
 -- without checking they're already defined and so causes warnings.
 uncheckedHsFFIDefines = ["__STDC_LIMIT_MACROS"]

--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -44,7 +44,7 @@ source-repository head
 
 flag shared-llvm
   description: link against llvm shared rather than static library
-  default: False
+  default: True
 
 flag debug
   description: compile C(++) shims with debug info for ease of troubleshooting


### PR DESCRIPTION
Build now defaults to linking against the shared library. Also added instructions for building LLVM from source so that (a) the appropriate dylibs will be built; and (b) some additional notes specific to macOS, to avoid the need to use `DYLD_LIBRARY_PATH`.

See discussion at #31.