### PR TITLE
Update Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ inconveniences.
 Example using Homebrew on macOS:
 
 ```bash
-$ brew update
-$ brew install libffi
-$ brew install homebrew/versions/llvm39 --all-targets
+$ brew install llvm-hs/homebrew-llvm/llvm-4.0
 ```
 
 ### Debian/Ubuntu


### PR DESCRIPTION
Points to the homebrew configuration files hosted by llvm-hs.

Fixes: llvm-hs/llvm-hs#46.