### PR TITLE
remove transformers-compat

### DIFF
--- a/llvm-hs-pure/llvm-hs-pure.cabal
+++ b/llvm-hs-pure/llvm-hs-pure.cabal
@@ -38,7 +38,6 @@ library
       base >= 4.9 && < 5
   build-depends:
     transformers >= 0.3 && < 0.6,
-    transformers-compat >= 0.4,
     mtl >= 2.1,
     template-haskell >= 2.5.0.0,
     containers >= 0.4.2.1,
@@ -95,7 +94,6 @@ test-suite test
     tasty-hunit >= 0.9,
     llvm-hs-pure,
     transformers >= 0.3,
-    transformers-compat >= 0.4,
     containers >= 0.4.2.1,
     mtl >= 2.1
   hs-source-dirs: test

--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -73,7 +73,6 @@ library
     utf8-string >= 0.3.7,
     bytestring >= 0.9.1.10,
     transformers >= 0.3 && < 0.6,
-    transformers-compat >= 0.4,
     mtl >= 2.1.3,
     template-haskell >= 2.5.0.0,
     containers >= 0.4.2.1,
@@ -243,7 +242,6 @@ test-suite test
     containers >= 0.4.2.1,
     mtl >= 2.1,
     transformers >= 0.3.0.0,
-    transformers-compat,
     temporary >= 1.2 && < 1.3,
     pretty-show >= 1.6 && < 1.7
   hs-source-dirs: test


### PR DESCRIPTION
It seems that transfromers-compat is not necessary anymore for >= 7.8 according to my travis build