### PR TITLE
Switch AST to ByteString (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+
+* Switch AST to `ByteString`/`ShortByteString` reflecting LLVM’s use
+  of C-style strings
+
 ## 4.0.0 (initial release, changes in comparison to llvm-general)
 
 * Move modules from `LLVM.General*` to `LLVM.*`

--- a/llvm-hs-pure/llvm-hs-pure.cabal
+++ b/llvm-hs-pure/llvm-hs-pure.cabal
@@ -37,6 +37,7 @@ library
     build-depends:
       base >= 4.9 && < 5
   build-depends:
+    bytestring >= 0.10 && < 0.11,
     transformers >= 0.3 && < 0.6,
     transformers-compat >= 0.4,
     mtl >= 2.1,

--- a/llvm-hs-pure/src/LLVM/AST.hs
+++ b/llvm-hs-pure/src/LLVM/AST.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 -- | This module and descendants define AST data types to represent LLVM code.
 -- Note that these types are designed for fidelity rather than convenience - if the truth
 -- of what LLVM supports is less than pretty, so be it.
@@ -33,20 +34,20 @@ data Definition
   = GlobalDefinition Global
   | TypeDefinition Name (Maybe Type)
   | MetadataNodeDefinition MetadataNodeID [Maybe Metadata]
-  | NamedMetadataDefinition String [MetadataNodeID]
-  | ModuleInlineAssembly String
+  | NamedMetadataDefinition ShortByteString [MetadataNodeID]
+  | ModuleInlineAssembly ByteString
   | FunctionAttributes A.GroupID [A.FunctionAttribute]
-  | COMDAT String COMDAT.SelectionKind
+  | COMDAT ShortByteString COMDAT.SelectionKind
     deriving (Eq, Read, Show, Typeable, Data, Generic)
 
 -- | <http://llvm.org/docs/LangRef.html#module-structure>
 data Module =
   Module {
-    moduleName :: String,
-    moduleSourceFileName :: String,
+    moduleName :: ShortByteString,
+    moduleSourceFileName :: ShortByteString,
     -- | a 'DataLayout', if specified, must match that of the eventual code generator
     moduleDataLayout :: Maybe DataLayout,
-    moduleTargetTriple :: Maybe String,
+    moduleTargetTriple :: Maybe ShortByteString,
     moduleDefinitions :: [Definition]
   }
   deriving (Eq, Read, Show, Typeable, Data, Generic)

--- a/llvm-hs-pure/src/LLVM/AST/FunctionAttribute.hs
+++ b/llvm-hs-pure/src/LLVM/AST/FunctionAttribute.hs
@@ -35,8 +35,8 @@ data FunctionAttribute
     | SanitizeThread
     | SanitizeMemory
     | StringAttribute {
-        stringAttributeKind :: String,
-        stringAttributeValue :: String -- ^ Use "" for no value -- the two are conflated
+        stringAttributeKind :: ShortByteString,
+        stringAttributeValue :: ShortByteString -- ^ Use "" for no value -- the two are conflated
       }
     | AllocSize Word (Maybe Word)
     | WriteOnly

--- a/llvm-hs-pure/src/LLVM/AST/Global.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Global.hs
@@ -29,8 +29,8 @@ data Global
         isConstant :: Bool,
         type' :: Type,
         initializer :: Maybe Constant,
-        section :: Maybe String,
-        comdat :: Maybe String,
+        section :: Maybe ShortByteString,
+        comdat :: Maybe ShortByteString,
         alignment :: Word32
       }
     -- | <http://llvm.org/docs/LangRef.html#aliases>
@@ -55,10 +55,10 @@ data Global
         name :: Name,
         parameters :: ([Parameter],Bool), -- ^ snd indicates varargs
         functionAttributes :: [Either A.GroupID A.FunctionAttribute],
-        section :: Maybe String,
-        comdat :: Maybe String,
+        section :: Maybe ShortByteString,
+        comdat :: Maybe ShortByteString,
         alignment :: Word32,
-        garbageCollectorName :: Maybe String,
+        garbageCollectorName :: Maybe ShortByteString,
         prefix :: Maybe Constant,
         basicBlocks :: [BasicBlock],
         personalityFunction :: Maybe Constant

--- a/llvm-hs-pure/src/LLVM/AST/InlineAssembly.hs
+++ b/llvm-hs-pure/src/LLVM/AST/InlineAssembly.hs
@@ -18,8 +18,8 @@ data Dialect
 data InlineAssembly
   = InlineAssembly {
       type' :: Type,
-      assembly :: String,
-      constraints :: String,
+      assembly :: ByteString,
+      constraints :: ShortByteString,
       hasSideEffects :: Bool,
       alignStack :: Bool,
       dialect :: Dialect

--- a/llvm-hs-pure/src/LLVM/AST/Instruction.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Instruction.hs
@@ -19,7 +19,7 @@ import Data.List.NonEmpty
 
 -- | <http://llvm.org/docs/LangRef.html#metadata-nodes-and-metadata-strings>
 -- Metadata can be attached to an instruction
-type InstructionMetadata = [(String, MetadataNode)]
+type InstructionMetadata = [(ShortByteString, MetadataNode)]
 
 -- | <http://llvm.org/docs/LangRef.html#terminators>
 data Terminator 

--- a/llvm-hs-pure/src/LLVM/AST/Name.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Name.hs
@@ -26,10 +26,9 @@ unnamed node numbers should be thought of as having any scope limited to the 'LL
 which they are used.
 -}
 data Name
-    = Name String -- ^ a string name
+    = Name ShortByteString -- ^ a string name
     | UnName Word -- ^ a number for a nameless thing
    deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
 
 instance IsString Name where
-  fromString = Name
-
+  fromString = Name . fromString

--- a/llvm-hs-pure/src/LLVM/AST/Operand.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Operand.hs
@@ -22,7 +22,7 @@ data MetadataNode
 
 -- | <http://llvm.org/docs/LangRef.html#metadata>
 data Metadata
-  = MDString String -- ^ <http://llvm.org/docs/doxygen/html/classllvm_1_1MDNode.html>
+  = MDString ShortByteString -- ^ <http://llvm.org/docs/doxygen/html/classllvm_1_1MDNode.html>
   | MDNode MetadataNode -- ^ <http://llvm.org/docs/doxygen/html/classllvm_1_1MDNode.html>
   | MDValue Operand -- ^ <http://llvm.org/docs/doxygen/html/classllvm_1_1ValueAsMetadata.html>
   deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)

--- a/llvm-hs-pure/src/LLVM/Prelude.hs
+++ b/llvm-hs-pure/src/LLVM/Prelude.hs
@@ -11,7 +11,10 @@ module LLVM.Prelude (
     module Data.Foldable,
     module Data.Traversable,
     module Control.Applicative,
-    module Control.Monad
+    module Control.Monad,
+    ByteString,
+    ShortByteString,
+    fromMaybe
     ) where
 
 import Prelude hiding (
@@ -26,6 +29,7 @@ import Prelude hiding (
 import Data.Data (Data, Typeable)
 import GHC.Generics (Generic)
 import Data.Int
+import Data.Maybe (fromMaybe)
 import Data.Word
 import Data.Functor
 import Data.Foldable
@@ -37,3 +41,6 @@ import Control.Monad hiding (
     sequence, sequence_,
     msum
   )
+
+import Data.ByteString (ByteString)
+import Data.ByteString.Short (ShortByteString)

--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -172,6 +172,7 @@ library
     LLVM.Internal.FFI.PassManager
     LLVM.Internal.FFI.PtrHierarchy
     LLVM.Internal.FFI.RawOStream
+    LLVM.Internal.FFI.ShortByteString
     LLVM.Internal.FFI.SMDiagnostic
     LLVM.Internal.FFI.Target
     LLVM.Internal.FFI.Threading

--- a/llvm-hs/src/LLVM/Internal/DecodeAST.hs
+++ b/llvm-hs/src/LLVM/Internal/DecodeAST.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE
   GeneralizedNewtypeDeriving,
   MultiParamTypeClasses,
-  UndecidableInstances
+  UndecidableInstances,
+  OverloadedStrings
   #-}
 module LLVM.Internal.DecodeAST where
 
@@ -44,10 +45,10 @@ data DecodeState = DecodeState {
     typesToDefine :: Seq (Ptr FFI.Type),
     metadataNodesToDefine :: Seq (A.MetadataNodeID, Ptr FFI.MDNode),
     metadataNodes :: Map (Ptr FFI.MDNode) A.MetadataNodeID,
-    metadataKinds :: Array Word String,
+    metadataKinds :: Array Word ShortByteString,
     parameterAttributeSets :: Map FFI.ParameterAttributeSet [A.A.ParameterAttribute],
     functionAttributeSetIDs :: Map FFI.FunctionAttributeSet A.A.GroupID,
-    comdats :: Map (Ptr FFI.COMDAT) (String, A.COMDAT.SelectionKind)
+    comdats :: Map (Ptr FFI.COMDAT) (ShortByteString, A.COMDAT.SelectionKind)
   }
 initialDecode = DecodeState {
     globalVarNum = Map.empty,

--- a/llvm-hs/src/LLVM/Internal/ExecutionEngine.hs
+++ b/llvm-hs/src/LLVM/Internal/ExecutionEngine.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE
   MultiParamTypeClasses,
   FunctionalDependencies,
+  OverloadedStrings,
   RankNTypes
   #-}
 module LLVM.Internal.ExecutionEngine where

--- a/llvm-hs/src/LLVM/Internal/FFI/ShortByteString.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/ShortByteString.hs
@@ -1,0 +1,44 @@
+module LLVM.Internal.FFI.ShortByteString
+  ( packCString
+  , packCStringLen
+  , useAsCString
+  , useAsCStringLen
+  ) where
+
+import LLVM.Prelude
+
+import Data.ByteString.Internal (c_strlen)
+import Data.ByteString.Short.Internal
+import qualified Data.ByteString.Short as ByteString
+import Foreign.C.String
+import Foreign.Marshal.Alloc
+import Foreign.Storable
+
+{-# INLINABLE packCString #-}
+packCString :: CString -> IO ShortByteString
+packCString cstr = do
+    len <- c_strlen cstr
+    packCStringLen (cstr, fromIntegral len)
+
+{-# INLINABLE packCStringLen #-}
+packCStringLen :: CStringLen -> IO ShortByteString
+packCStringLen (cstr, len) | len >= 0 = createFromPtr cstr len
+packCStringLen (_, len) =
+    error ("negative length: " ++ show len)
+
+{-# INLINABLE useAsCString #-}
+useAsCString :: ShortByteString -> (CString -> IO a) -> IO a
+useAsCString bs action =
+ allocaBytes (l+1) $ \buf -> do
+     copyToPtr bs 0 buf (fromIntegral l)
+     pokeByteOff buf l (0::Word8)
+     action buf
+ where l = ByteString.length bs
+
+{-# INLINABLE useAsCStringLen #-}
+useAsCStringLen :: ShortByteString -> (CStringLen -> IO a) -> IO a
+useAsCStringLen bs action =
+ allocaBytes l $ \buf -> do
+     copyToPtr bs 0 buf (fromIntegral l)
+     action (buf, l)
+ where l = ByteString.length bs

--- a/llvm-hs/src/LLVM/Internal/Function.hs
+++ b/llvm-hs/src/LLVM/Internal/Function.hs
@@ -43,10 +43,10 @@ getParameters f attrs = scopeAnyCont $ do
        `ap` getLocalName param
        `ap` (return $ Map.findWithDefault [] i attrs)
   
-getGC :: Ptr FFI.Function -> DecodeAST (Maybe String)
+getGC :: Ptr FFI.Function -> DecodeAST (Maybe ShortByteString)
 getGC f = scopeAnyCont $ decodeM =<< liftIO (FFI.getGC f)
 
-setGC :: Ptr FFI.Function -> Maybe String -> EncodeAST ()
+setGC :: Ptr FFI.Function -> Maybe ShortByteString -> EncodeAST ()
 setGC f gc = scopeAnyCont $ liftIO . FFI.setGC f =<< encodeM gc 
 
 getPrefixData :: Ptr FFI.Function -> DecodeAST (Maybe A.Constant)

--- a/llvm-hs/src/LLVM/Internal/InlineAssembly.hs
+++ b/llvm-hs/src/LLVM/Internal/InlineAssembly.hs
@@ -1,12 +1,15 @@
 {-# LANGUAGE
   TemplateHaskell,
-  MultiParamTypeClasses
+  MultiParamTypeClasses,
+  OverloadedStrings
   #-}
 module LLVM.Internal.InlineAssembly where
  
 import LLVM.Prelude
 
 import Control.Monad.IO.Class
+
+import qualified Data.ByteString.Char8 as ByteString
 
 import Foreign.C
 import Foreign.Ptr
@@ -59,10 +62,5 @@ instance DecodeM DecodeAST A.InlineAssembly (Ptr FFI.InlineAsm) where
 
 instance DecodeM DecodeAST [A.Definition] (FFI.ModuleAsm CString) where
   decodeM (FFI.ModuleAsm s) = do
-    s <- decodeM s
-    let takeModIA "" = []
-        takeModIA s =
-          let (a,r) = break (== '\n') s
-          in A.ModuleInlineAssembly a : takeModIA (dropWhile (== '\n') r)
-    return $ takeModIA s
-    
+    s' <- decodeM s
+    return . map A.ModuleInlineAssembly $ ByteString.lines s'

--- a/llvm-hs/src/LLVM/Internal/Metadata.hs
+++ b/llvm-hs/src/LLVM/Internal/Metadata.hs
@@ -23,7 +23,7 @@ import LLVM.Internal.EncodeAST
 import LLVM.Internal.DecodeAST
 import LLVM.Internal.Value ()
 
-instance EncodeM EncodeAST String FFI.MDKindID where
+instance EncodeM EncodeAST ShortByteString FFI.MDKindID where
   encodeM s = do
     Context c <- gets encodeStateContext
     s <- encodeM s
@@ -45,10 +45,10 @@ getMetadataKindNames (Context c) = scopeAnyCont $ do
   strs <- g 16
   modify $ \s -> s { metadataKinds = Array.listArray (0, fromIntegral (length strs) - 1) strs }
 
-instance DecodeM DecodeAST String FFI.MDKindID where
+instance DecodeM DecodeAST ShortByteString FFI.MDKindID where
   decodeM (FFI.MDKindID k) = gets $ (Array.! (fromIntegral k)) . metadataKinds
 
-instance DecodeM DecodeAST String (Ptr FFI.MDString) where
+instance DecodeM DecodeAST ShortByteString (Ptr FFI.MDString) where
   decodeM p = do
     np <- alloca
     s <- liftIO $ FFI.getMDString p np

--- a/llvm-hs/src/LLVM/Internal/String.hs
+++ b/llvm-hs/src/LLVM/Internal/String.hs
@@ -21,6 +21,7 @@ import LLVM.Internal.FFI.LLVMCTypes
 import LLVM.Internal.Coding
 
 import qualified Data.ByteString as BS
+import qualified LLVM.Internal.FFI.ShortByteString as SBS
 import qualified Data.ByteString.Unsafe as BS
 import qualified Data.ByteString.UTF8 as BSUTF8
 
@@ -35,16 +36,41 @@ instance (Monad d) => DecodeM d String UTF8ByteString where
 instance (MonadAnyCont IO e) => EncodeM e String CString where
   encodeM s = anyContToM (BS.unsafeUseAsCString . utf8Bytes =<< encodeM (s ++ "\0"))
 
+instance (MonadAnyCont IO e) => EncodeM e ByteString CString where
+  encodeM s = anyContToM (BS.useAsCString s)
+
+instance (MonadAnyCont IO e) => EncodeM e ShortByteString CString where
+  encodeM s = anyContToM (SBS.useAsCString s)
+
 instance (Integral i, MonadAnyCont IO e) => EncodeM e String (Ptr CChar, i) where
   encodeM s = anyContToM ((. (. second fromIntegral)) $ BS.useAsCStringLen . utf8Bytes =<< encodeM s)
+
+instance (Integral i, MonadAnyCont IO e) => EncodeM e ByteString (Ptr CChar, i) where
+  encodeM s =
+    anyContToM (\cont -> BS.useAsCStringLen s (\(ptr, len) -> cont (ptr, fromIntegral len)))
+
+instance (Integral i, MonadAnyCont IO e) => EncodeM e ShortByteString (Ptr CChar, i) where
+  encodeM s =
+    anyContToM (\cont -> SBS.useAsCStringLen s (\(ptr, len) -> cont (ptr, fromIntegral len)))
 
 instance (MonadIO d) => DecodeM d String CString where
   decodeM = decodeM . UTF8ByteString <=< liftIO . BS.packCString
 
+instance (MonadIO d) => DecodeM d ByteString CString where
+  decodeM = liftIO . BS.packCString
+
+instance (MonadIO d) => DecodeM d ShortByteString CString where
+  decodeM = liftIO . SBS.packCString
+
 instance (MonadIO d) => DecodeM d String (OwnerTransfered CString) where
   decodeM (OwnerTransfered s) = liftIO $ finally (decodeM s) (free s)
 
-instance (MonadIO d) => DecodeM d String (Ptr (OwnerTransfered CString)) where
+instance (MonadIO d) => DecodeM d ByteString (OwnerTransfered CString) where
+  decodeM (OwnerTransfered s) = liftIO $ finally (decodeM s) (free s)
+
+instance (MonadIO d) => DecodeM d ShortByteString (OwnerTransfered CString) where
+  decodeM (OwnerTransfered s) = liftIO $ finally (decodeM s) (free s)
+instance (MonadIO d, DecodeM IO s (OwnerTransfered CString)) =>DecodeM d s (Ptr (OwnerTransfered CString)) where
   decodeM = liftIO . decodeM <=< peek
 
 instance (Integral i, MonadIO d) => DecodeM d String (Ptr CChar, i) where
@@ -53,7 +79,10 @@ instance (Integral i, MonadIO d) => DecodeM d String (Ptr CChar, i) where
 instance (Integral i, MonadIO d) => DecodeM d BS.ByteString (Ptr CChar, i) where
   decodeM = liftIO . BS.packCStringLen . second fromIntegral
 
-instance (Integral i, Storable i, MonadIO d) => DecodeM d String (Ptr i -> IO (Ptr CChar)) where
+instance (Integral i, MonadIO d) => DecodeM d ShortByteString (Ptr CChar, i) where
+  decodeM = liftIO . SBS.packCStringLen . second fromIntegral
+
+instance (Integral i, Storable i, MonadIO d, DecodeM d s (CString, i)) => DecodeM d s (Ptr i -> IO CString) where
   decodeM f = decodeM =<< (liftIO $ F.M.alloca $ \p -> (,) `liftM` f p `ap` peek p)
 
 instance (Monad e, EncodeM e String c) => EncodeM e (Maybe String) (NothingAsEmptyString c) where

--- a/llvm-hs/test/LLVM/Test/Analysis.hs
+++ b/llvm-hs/test/LLVM/Test/Analysis.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module LLVM.Test.Analysis where
 
 import Test.Tasty

--- a/llvm-hs/test/LLVM/Test/CallingConvention.hs
+++ b/llvm-hs/test/LLVM/Test/CallingConvention.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module LLVM.Test.CallingConvention where
 
 import Test.Tasty
@@ -6,6 +7,7 @@ import Test.Tasty.HUnit
 import LLVM.Test.Support
 
 import Data.Maybe
+import Data.Monoid
 import qualified Data.Set as Set
 import qualified Data.Map as Map
 
@@ -15,6 +17,8 @@ import LLVM.AST
 import LLVM.AST.Type as T
 import qualified LLVM.AST.CallingConvention as CC
 import qualified LLVM.AST.Global as G
+
+import qualified Data.ByteString.Char8 as ByteString
 
 tests = testGroup "CallingConvention" [
   testCase name $ strCheck (defaultModule {
@@ -28,7 +32,7 @@ tests = testGroup "CallingConvention" [
    }) ("; ModuleID = '<string>'\n\
        \source_filename = \"<string>\"\n\
        \\n\
-       \declare" ++ (if name == "" then "" else (" " ++ name)) ++ " i32 @foo()\n")
+       \declare" <> (if name == "" then "" else (" " <> ByteString.pack name)) <> " i32 @foo()\n")
    | (name, cc) <- [
    ("", CC.C),
    ("fastcc", CC.Fast),

--- a/llvm-hs/test/LLVM/Test/Constants.hs
+++ b/llvm-hs/test/LLVM/Test/Constants.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module LLVM.Test.Constants where
 
 import Test.Tasty
@@ -8,6 +9,7 @@ import LLVM.Test.Support
 import Control.Monad
 import Data.Functor
 import Data.Maybe
+import Data.Monoid
 import Foreign.Ptr
 import Data.Word
 
@@ -178,7 +180,7 @@ tests = testGroup "Constants" [
                G.name = UnName 2, G.type' = i32, G.initializer = Nothing 
              }
            ]
-       mStr = "; ModuleID = '<string>'\nsource_filename = \"<string>\"\n\n@0 = " ++ str ++ "\n\
+       mStr = "; ModuleID = '<string>'\nsource_filename = \"<string>\"\n\n@0 = " <> str <> "\n\
               \@1 = external global i32\n\
               \@2 = external global i32\n"
  ]

--- a/llvm-hs/test/LLVM/Test/DataLayout.hs
+++ b/llvm-hs/test/LLVM/Test/DataLayout.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module LLVM.Test.DataLayout where
 
 import Test.Tasty
@@ -6,6 +7,7 @@ import Test.Tasty.HUnit
 import LLVM.Test.Support
 
 import Data.Maybe
+import Data.Monoid
 import qualified Data.Set as Set
 import qualified Data.Map as Map
 
@@ -16,8 +18,8 @@ import LLVM.AST.DataLayout
 import LLVM.AST.AddrSpace
 import qualified LLVM.AST.Global as G
 
-m s = "; ModuleID = '<string>'\nsource_filename = \"<string>\"\n" ++ s
-t s = "target datalayout = \"" ++ s ++ "\"\n"
+m s = "; ModuleID = '<string>'\nsource_filename = \"<string>\"\n" <> s
+t s = "target datalayout = \"" <> s <> "\"\n"
 ddl = defaultDataLayout BigEndian
 
 tests = testGroup "DataLayout" [

--- a/llvm-hs/test/LLVM/Test/ExecutionEngine.hs
+++ b/llvm-hs/test/LLVM/Test/ExecutionEngine.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE
-  ForeignFunctionInterface
+  ForeignFunctionInterface,
+  OverloadedStrings
   #-}
 module LLVM.Test.ExecutionEngine where
 

--- a/llvm-hs/test/LLVM/Test/Global.hs
+++ b/llvm-hs/test/LLVM/Test/Global.hs
@@ -1,7 +1,12 @@
+{-# LANGUAGE OverloadedStrings #-}
 module LLVM.Test.Global where
 
 import Test.Tasty
 import Test.Tasty.HUnit
+
+import Data.Monoid
+import qualified Data.ByteString.Char8 as ByteString
+import Data.ByteString.Short (fromShort)
 
 import LLVM.Test.Support
 
@@ -37,6 +42,6 @@ tests = testGroup "Global" [
       let
           gn (G.Function {}) = "function"
           gn (G.GlobalVariable {}) = "variable"
-          name = gn g ++ ", align " ++ show a ++ (maybe "" ("  section " ++ ) s)
+          name = gn g <> ", align " <> show a <> (maybe "" (("  section " <>) . ByteString.unpack . fromShort) s)
    ]
  ]

--- a/llvm-hs/test/LLVM/Test/InlineAssembly.hs
+++ b/llvm-hs/test/LLVM/Test/InlineAssembly.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module LLVM.Test.InlineAssembly where
 
 import Test.Tasty

--- a/llvm-hs/test/LLVM/Test/Instrumentation.hs
+++ b/llvm-hs/test/LLVM/Test/Instrumentation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module LLVM.Test.Instrumentation where
 
 import Test.Tasty

--- a/llvm-hs/test/LLVM/Test/Linking.hs
+++ b/llvm-hs/test/LLVM/Test/Linking.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module LLVM.Test.Linking where
 
 import Test.Tasty

--- a/llvm-hs/test/LLVM/Test/Metadata.hs
+++ b/llvm-hs/test/LLVM/Test/Metadata.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module LLVM.Test.Metadata where
 
 import Test.Tasty

--- a/llvm-hs/test/LLVM/Test/Module.hs
+++ b/llvm-hs/test/LLVM/Test/Module.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module LLVM.Test.Module where
 
 import Test.Tasty

--- a/llvm-hs/test/LLVM/Test/Optimization.hs
+++ b/llvm-hs/test/LLVM/Test/Optimization.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module LLVM.Test.Optimization where
 
 import Test.Tasty
@@ -6,6 +7,7 @@ import Test.Tasty.HUnit
 import LLVM.Test.Support
 
 import Data.Functor
+import Data.Monoid
 import qualified Data.Set as Set
 import qualified Data.Map as Map
 
@@ -179,12 +181,12 @@ tests = testGroup "Optimization" [
            G.returnType = double,
             G.name = Name "foo",
             G.parameters = ([
-              Parameter double (Name (l ++ n)) []
+              Parameter double (Name (l <> n)) []
                 | l <- [ "a", "b" ], n <- ["1", "2"]
              ], False),
             G.basicBlocks = [
               BasicBlock (UnName 0) ([
-                Name (l ++ n) := op NoFastMathFlags (LocalReference double (Name (o1 ++ n))) (LocalReference double (Name (o2 ++ n))) []
+                Name (l <> n) := op NoFastMathFlags (LocalReference double (Name (o1 <> n))) (LocalReference double (Name (o2 <> n))) []
                 | (l, op, o1, o2) <- [
                    ("x", FSub, "a", "b"),
                    ("y", FMul, "x", "a"),

--- a/llvm-hs/test/LLVM/Test/OrcJIT.hs
+++ b/llvm-hs/test/LLVM/Test/OrcJIT.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ForeignFunctionInterface, OverloadedStrings #-}
 module LLVM.Test.OrcJIT where
 
 import Test.Tasty
@@ -6,6 +6,7 @@ import Test.Tasty.HUnit
 
 import LLVM.Test.Support
 
+import Data.ByteString (ByteString)
 import Data.Foldable
 import Data.IORef
 import Data.Word
@@ -20,7 +21,7 @@ import LLVM.OrcJIT.CompileOnDemandLayer (CompileOnDemandLayer, withIndirectStubs
 import qualified LLVM.OrcJIT.CompileOnDemandLayer as CODLayer
 import LLVM.Target
 
-testModule :: String
+testModule :: ByteString
 testModule =
   "; ModuleID = '<string>'\n\
   \source_filename = \"<string>\"\n\

--- a/llvm-hs/test/LLVM/Test/Support.hs
+++ b/llvm-hs/test/LLVM/Test/Support.hs
@@ -3,6 +3,7 @@ module LLVM.Test.Support where
 import Test.Tasty
 import Test.Tasty.HUnit
 
+import Data.ByteString (ByteString)
 import Data.Functor
 import Control.Monad
 import Control.Monad.Trans.Except
@@ -24,6 +25,7 @@ instance FailInIO String where
 instance FailInIO (Either String Diagnostic) where
   errorToString = either id diagnosticDisplay
 
+withModuleFromLLVMAssembly' :: Context -> ByteString -> (Module -> IO a) -> IO a
 withModuleFromLLVMAssembly' c s f  = failInIO $ withModuleFromLLVMAssembly c s f
 withModuleFromAST' c a f = failInIO $ withModuleFromAST c a f
 withModuleFromBitcode' c a f = failInIO $ withModuleFromBitcode c ("<string>", a) f


### PR DESCRIPTION
This is the first step in moving to `ByteString`. I switched all of the AST over so the API should be at least in a somewhat consistent state.

This is still WIP so I’m mainly opening the PR now to avoid duplicating work. Apart from cleaning up, the main issue is that we probably don’t want pinned bytestrings at least not for `Name` so we should use `ShortByteString` there.