### PR TITLE
Remove test for function-local metadata

### DIFF
--- a/llvm-hs/test/LLVM/Test/Metadata.hs
+++ b/llvm-hs/test/LLVM/Test/Metadata.hs
@@ -16,46 +16,6 @@ import qualified LLVM.AST.Constant as C
 import LLVM.AST.Global as G
 
 tests = testGroup "Metadata" [
-  -- testCase "local" $ do
-  --   let ast = Module "<string>" Nothing Nothing [
-  --         GlobalDefinition $ globalVariableDefaults { G.name = UnName 0, G.type' = i32 },
-  --         GlobalDefinition $ functionDefaults {
-  --           G.returnType = i32,
-  --           G.name = Name "foo",
-  --           G.basicBlocks = [
-  --             BasicBlock (UnName 0) [
-  --                UnName 1 := Load {
-  --                           volatile = False,
-  --                           address = ConstantOperand (C.GlobalReference (ptr i32) (UnName 0)),
-  --                           maybeAtomicity = Nothing,
-  --                           A.alignment = 0,
-  --                           metadata = []
-  --                         }
-  --                ] (
-  --                Do $ Ret (Just (ConstantOperand (C.Int 32 0))) [
-  --                  (
-  --                    "my-metadatum", 
-  --                    MetadataNode [
-  --                     Just $ MDValue $ LocalReference i32 (UnName 1),
-  --                     Just $ MDString "super hyper",
-  --                     Nothing
-  --                    ]
-  --                  )
-  --                ]
-  --              )
-  --            ]
-  --          }
-  --        ]
-  --   let s = "; ModuleID = '<string>'\n\
-  --           \\n\
-  --           \@0 = external global i32\n\
-  --           \\n\
-  --           \define i32 @foo() {\n\
-  --           \  %1 = load i32, i32* @0\n\
-  --           \  ret i32 0, !my-metadatum !{i32 %1, !\"super hyper\", null}\n\
-  --           \}\n"
-  --   strCheck ast s,
-
   testCase "global" $ do
     let ast = Module "<string>" "<string>" Nothing Nothing [
           GlobalDefinition $ functionDefaults {


### PR DESCRIPTION
The release notes for [LLVM 3.6](http://releases.llvm.org/3.6.1/docs/ReleaseNotes.html#metadata-is-not-a-value) explicitely mention that this is no
longer supported.
fixes #6