### PR TITLE
Use linkFlag when running llvm-config --system-libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Switch from ExceptT to using exceptions.
   See `LLVM.Exception` for an overview of the exceptions potentially thrown.
 
+## 4.0.1
+
+* Fix linking of system libraries
+
 ## 4.0.0 (initial release, changes in comparison to llvm-general)
 
 * Move modules from `LLVM.General*` to `LLVM.*`

--- a/llvm-hs/Setup.hs
+++ b/llvm-hs/Setup.hs
@@ -142,7 +142,7 @@ main = do
                        Nothing     -> "--link-static"
                        Just shared -> if shared then "--link-shared" else "--link-static"
       libs       <- getLibs ["--libs", linkFlag]
-      systemLibs <- getLibs ["--system-libs"]
+      systemLibs <- getLibs ["--system-libs", linkFlag]
 
       let genericPackageDescription' = genericPackageDescription {
             condLibrary = do


### PR DESCRIPTION
This is necessary since https://reviews.llvm.org/D27805

fixes #52