### PR TITLE
Change GlobalAlias to expect element type instead of pointer type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   recover the old behavior set it to the same value as abiAlignment.
 * Switch from ExceptT to using exceptions.
   See `LLVM.Exception` for an overview of the exceptions potentially thrown.
+* 'GlobalAlias' now expects the element type of a pointer type instead
+  of the pointer type itself. The address space is passed separately
+  via the 'addrSpace' field. This makes 'GlobalAlias' consistent with
+  'GlobalVariable'.
 
 ## 4.0.1
 

--- a/llvm-hs-pure/src/LLVM/AST/Global.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Global.hs
@@ -24,10 +24,10 @@ data Global
         visibility :: V.Visibility,
         dllStorageClass :: Maybe DLL.StorageClass,
         threadLocalMode :: Maybe TLS.Model,
-        addrSpace :: AddrSpace,
         unnamedAddr :: Maybe UnnamedAddr,
         isConstant :: Bool,
         type' :: Type,
+        addrSpace :: AddrSpace,
         initializer :: Maybe Constant,
         section :: Maybe ShortByteString,
         comdat :: Maybe ShortByteString,
@@ -42,6 +42,7 @@ data Global
         threadLocalMode :: Maybe TLS.Model,
         unnamedAddr :: Maybe UnnamedAddr,
         type' :: Type,
+        addrSpace :: AddrSpace,
         aliasee :: Constant
       }
     -- | <http://llvm.org/docs/LangRef.html#functions>
@@ -108,6 +109,7 @@ globalAliasDefaults =
     threadLocalMode = Nothing,
     unnamedAddr = Nothing,
     type' = error "global alias type not defined",
+    addrSpace = AddrSpace 0,
     aliasee = error "global alias aliasee not defined"
   }
 

--- a/llvm-hs/test/LLVM/Test/Module.hs
+++ b/llvm-hs/test/LLVM/Test/Module.hs
@@ -135,18 +135,20 @@ handAST = Module "<string>" "<string>" Nothing Nothing [
       GlobalDefinition $ globalAliasDefaults {
          G.name = Name "three",
          G.linkage = L.Private,
-         G.type' = PointerType i32 (AddrSpace 3),
+         G.type' = i32,
+         G.addrSpace = AddrSpace 3,
          G.aliasee = C.GlobalReference (PointerType i32 (AddrSpace 3)) (UnName 1)
       },
       GlobalDefinition $ globalAliasDefaults {
         G.name = Name "two",
         G.unnamedAddr = Just GlobalAddr,
-        G.type' = PointerType i32 (AddrSpace 3),
+        G.type' = i32,
+        G.addrSpace = AddrSpace 3,
         G.aliasee = C.GlobalReference (PointerType i32 (AddrSpace 3)) (Name "three")
       },
       GlobalDefinition $ globalAliasDefaults {
         G.name = Name "one",
-        G.type' = ptr i32,
+        G.type' = i32,
         G.aliasee = C.GlobalReference (ptr i32) (UnName 5),
         G.threadLocalMode = Just TLS.InitialExec
       },


### PR DESCRIPTION
fixes #79 

So I’ve thought about the possible solutions to #79 and I see three options
1. Use what this PR implements, i.e., separate fields for type and address space and type represents the element type not the pointer type
2. Use a tuple of type and address space.
3. Accept an arbitrary type but expect a pointer type and crash at runtime if that’s not the case.

3 has the obvious problem of runtime crashes which outweigh the potential aesthetic benefits. That leaves us with 1 and 2. 2 seems tempting since it makes it clear that the type and the address space belong together. However, it breaks defaulting the address space via `globalAliasDefault`. I therefore think the solution in this PR works best.