### PR TITLE
Default to -fshared-llvm=True in Setup.hs

### DIFF
--- a/llvm-hs/Setup.hs
+++ b/llvm-hs/Setup.hs
@@ -139,7 +139,7 @@ main = do
       let getLibs = liftM (map (fromJust . stripPrefix "-l") . words) . llvmConfig
           flags    = configConfigurationsFlags configFlags
           linkFlag = case lookup (FlagName "shared-llvm") flags of
-                       Nothing     -> "--link-static"
+                       Nothing     -> "--link-shared"
                        Just shared -> if shared then "--link-shared" else "--link-static"
       libs       <- getLibs ["--libs", linkFlag]
       systemLibs <- getLibs ["--system-libs", linkFlag]


### PR DESCRIPTION
We have shared-llvm=True set as the default in the .cabal file, but if a user installs via `runhaskell Setup.hs` that won't be picked up. This appears to be the case for installs via stack as well. This fixes the problem.

 - https://github.com/AccelerateHS/accelerate/issues/369#issuecomment-291627522
 - https://github.com/AccelerateHS/accelerate/issues/366