### PR TITLE
Fix build with GHC 8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ matrix:
     - env: CABALVER=1.24 GHCVER=8.0.2
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,gcc-5,g++-5,happy-1.19.5], sources: [hvr-ghc,llvm-toolchain-precise,ubuntu-toolchain-r-test]}}
+    - env: CABALVER=1.24 GHCVER=8.2.1
+      compiler: ": #GHC 8.2.1"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.2.1,gcc-5,g++-5,happy-1.19.5], sources: [hvr-ghc,llvm-toolchain-precise,ubuntu-toolchain-r-test]}}
 
 before_install:
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/1.19.5/bin:$PATH


### PR DESCRIPTION
This is sufficient on our side, but we need a new release of `async` until we can build without `--allow-newer`. I’m not going to merge this until that is done and I can enable Travis for 8.2 but I’m opening this PR now to avoid duplicated work.