### PR TITLE
Switch the rest of the API from String to ByteString

### DIFF
--- a/llvm-hs/src/LLVM/Internal/CommandLine.hs
+++ b/llvm-hs/src/LLVM/Internal/CommandLine.hs
@@ -16,7 +16,7 @@ import LLVM.Internal.String ()
 -- Sadly, there is occasionally some configuration one would like to control
 -- in LLVM which are accessible only as command line flags setting global state,
 -- as if the command line tools were the only use of LLVM. Very sad.
-parseCommandLineOptions :: [String] -> Maybe String -> IO ()
+parseCommandLineOptions :: [ShortByteString] -> Maybe ShortByteString -> IO ()
 parseCommandLineOptions args overview = flip runAnyContT return $ do
   args <- encodeM args
   overview <- maybe (return nullPtr) encodeM overview

--- a/llvm-hs/src/LLVM/Internal/Module.hs
+++ b/llvm-hs/src/LLVM/Internal/Module.hs
@@ -210,9 +210,9 @@ emitToByteString fileType tm m = flip runAnyContT return $ do
 writeTargetAssemblyToFile :: TargetMachine -> File -> Module -> IO ()
 writeTargetAssemblyToFile = emitToFile FFI.codeGenFileTypeAssembly
 
--- | produce target-specific assembly as a 'String'
-moduleTargetAssembly :: TargetMachine -> Module -> IO String
-moduleTargetAssembly tm m = decodeM . UTF8ByteString =<< emitToByteString FFI.codeGenFileTypeAssembly tm m
+-- | produce target-specific assembly as a 'ByteString'
+moduleTargetAssembly :: TargetMachine -> Module -> IO ByteString
+moduleTargetAssembly tm m = emitToByteString FFI.codeGenFileTypeAssembly tm m
 
 -- | produce target-specific object code as a 'ByteString'
 moduleObject :: TargetMachine -> Module -> IO BS.ByteString

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/CompileOnDemandLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/CompileOnDemandLayer.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE MultiParamTypeClasses, OverloadedStrings #-}
 module LLVM.Internal.OrcJIT.CompileOnDemandLayer where
 
 import LLVM.Prelude
@@ -56,7 +56,7 @@ instance (MonadIO m, MonadAnyCont IO m) =>
     return . FFI.TargetAddress . fromIntegral . ptrToWordPtr . castFunPtrToPtr $ f'
 
 withIndirectStubsManagerBuilder ::
-  String {- ^ triple -} ->
+  ShortByteString {- ^ triple -} ->
   (IndirectStubsManagerBuilder -> IO a) ->
   IO a
 withIndirectStubsManagerBuilder triple f = flip runAnyContT return $ do
@@ -67,7 +67,7 @@ withIndirectStubsManagerBuilder triple f = flip runAnyContT return $ do
   liftIO $ f (StubsMgr stubsMgr)
 
 withJITCompileCallbackManager ::
-  String {- ^ triple -} ->
+  ShortByteString {- ^ triple -} ->
   Maybe (IO ()) ->
   (JITCompileCallbackManager -> IO a) ->
   IO a
@@ -109,7 +109,7 @@ withCompileOnDemandLayer
          FFI.disposeCompileOnDemandLayer
  liftIO $ f (CompileOnDemandLayer cl baseLayer cleanup)
 
-mangleSymbol :: CompileOnDemandLayer -> String -> IO MangledSymbol
+mangleSymbol :: CompileOnDemandLayer -> ShortByteString -> IO MangledSymbol
 mangleSymbol (CompileOnDemandLayer _ bl _) symbol =
   IRCompileLayer.mangleSymbol bl symbol
 

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/IRCompileLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/IRCompileLayer.hs
@@ -36,7 +36,7 @@ withIRCompileLayer (ObjectLinkingLayer oll) (TargetMachine tm) f = flip runAnyCo
   cleanup <- anyContToM $ bracket (newIORef []) (sequence <=< readIORef)
   liftIO $ f (IRCompileLayer cl dl cleanup)
 
-mangleSymbol :: IRCompileLayer -> String -> IO MangledSymbol
+mangleSymbol :: IRCompileLayer -> ShortByteString -> IO MangledSymbol
 mangleSymbol (IRCompileLayer _ dl _) symbol = flip runAnyContT return $ do
   mangledSymbol <- alloca
   symbol' <- encodeM symbol

--- a/llvm-hs/src/LLVM/Internal/Target.hs
+++ b/llvm-hs/src/LLVM/Internal/Target.hs
@@ -240,7 +240,7 @@ initializeNativeTarget = do
   when failure $ fail "native target initialization failed"
 
 -- | the target triple corresponding to the target machine
-getTargetMachineTriple :: TargetMachine -> IO String
+getTargetMachineTriple :: TargetMachine -> IO ShortByteString
 getTargetMachineTriple (TargetMachine m) = decodeM =<< FFI.getTargetMachineTriple m
 
 -- | the default target triple that LLVM has been configured to produce code for
@@ -286,7 +286,7 @@ withHostTargetMachine f = do
 newtype TargetLibraryInfo = TargetLibraryInfo (Ptr FFI.TargetLibraryInfo)
 
 -- | Look up a 'LibraryFunction' by its standard name
-getLibraryFunction :: TargetLibraryInfo -> String -> IO (Maybe LibraryFunction)
+getLibraryFunction :: TargetLibraryInfo -> ShortByteString -> IO (Maybe LibraryFunction)
 getLibraryFunction (TargetLibraryInfo f) name = flip runAnyContT return $ do
   libFuncP <- alloca :: AnyContT IO (Ptr FFI.LibFunc)
   name <- (encodeM name :: AnyContT IO CString)
@@ -294,7 +294,7 @@ getLibraryFunction (TargetLibraryInfo f) name = flip runAnyContT return $ do
   forM (if r then Just libFuncP else Nothing) $ decodeM <=< peek
 
 -- | Get a the current name to be emitted for a 'LibraryFunction'
-getLibraryFunctionName :: TargetLibraryInfo -> LibraryFunction -> IO String
+getLibraryFunctionName :: TargetLibraryInfo -> LibraryFunction -> IO ShortByteString
 getLibraryFunctionName (TargetLibraryInfo f) l = flip runAnyContT return $ do
   l <- encodeM l
   decodeM $ FFI.libFuncGetName f l
@@ -303,7 +303,7 @@ getLibraryFunctionName (TargetLibraryInfo f) l = flip runAnyContT return $ do
 setLibraryFunctionAvailableWithName ::
   TargetLibraryInfo
   -> LibraryFunction
-  -> String -- ^ The function name to be emitted
+  -> ShortByteString -- ^ The function name to be emitted
   -> IO ()
 setLibraryFunctionAvailableWithName (TargetLibraryInfo f) libraryFunction name = flip runAnyContT return $ do
   name <- encodeM name

--- a/llvm-hs/src/LLVM/Transforms.hs
+++ b/llvm-hs/src/LLVM/Transforms.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 -- | This module provides an enumeration of the various transformation (e.g. optimization) passes
 -- provided by LLVM. They can be used to create a 'LLVM.PassManager.PassManager' to, in turn,
 -- run the passes on 'LLVM.Module.Module's. If you don't know what passes you want, consider
@@ -164,7 +165,7 @@ defaultVectorizeBasicBlocks = BasicBlockVectorize {
   }
 
 -- | See <http://gcc.gnu.org/viewcvs/gcc/trunk/gcc/gcov-io.h?view=markup>.
-newtype GCOVVersion = GCOVVersion String
+newtype GCOVVersion = GCOVVersion ShortByteString
   deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
 
 -- | Defaults for 'GCOVProfiler'.

--- a/llvm-hs/test/LLVM/Test/Target.hs
+++ b/llvm-hs/test/LLVM/Test/Target.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE
+  OverloadedStrings,
   RecordWildCards,
   ScopedTypeVariables
   #-}

--- a/llvm-hs/test/Test.hs
+++ b/llvm-hs/test/Test.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 import Test.Tasty
 import qualified LLVM.Test.Tests as LLVM
 import LLVM.CommandLine


### PR DESCRIPTION
fixes #60

I tried grepping through the codebase for reference to String so I’m reasonabley confident that this is everything that needs changing but ofc I might have missed something.