### PR TITLE
Create a more sensible FloatingPointType argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   of the pointer type itself. The address space is passed separately
   via the 'addrSpace' field. This makes 'GlobalAlias' consistent with
   'GlobalVariable'.
+* The `FloatingPointType` constructor now takes a `FloatingPointType` argument
+  instead of a width and a `FloatingPointFormat`, to more closely match the
+  LLVM IR language reference.
 
 ## 4.0.1
 

--- a/llvm-hs-pure/src/LLVM/AST.hs
+++ b/llvm-hs-pure/src/LLVM/AST.hs
@@ -21,7 +21,7 @@ module LLVM.AST (
 import LLVM.Prelude
 
 import LLVM.AST.Name
-import LLVM.AST.Type (Type(..), FloatingPointFormat(..))
+import LLVM.AST.Type (Type(..), FloatingPointType(..))
 import LLVM.AST.Global
 import LLVM.AST.Operand
 import LLVM.AST.Instruction

--- a/llvm-hs-pure/src/LLVM/AST/Type.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Type.hs
@@ -6,13 +6,14 @@ import LLVM.Prelude
 import LLVM.AST.AddrSpace
 import LLVM.AST.Name
 
--- | LLVM supports some special formats floating point format. This type is to distinguish those format.
--- I believe it's treated as a format for "a" float, as opposed to a vector of two floats, because
--- its intended usage is to represent a single number with a combined significand.
-data FloatingPointFormat
-  = IEEE
-  | DoubleExtended
-  | PairOfFloats
+-- | LLVM supports some special formats floating point format. This type is to distinguish those format. Also see  <http://llvm.org/docs/LangRef.html#floating-point-types>
+data FloatingPointType
+  = HalfFP      -- ^ 16-bit floating point value
+  | FloatFP     -- ^ 32-bit floating point value
+  | DoubleFP    -- ^ 64-bit floating point value
+  | FP128FP     -- ^ 128-bit floating point value (112-bit mantissa)
+  | X86_FP80FP  -- ^ 80-bit floating point value (X87)
+  | PPC_FP128FP -- ^ 128-bit floating point value (two 64-bits)
   deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
 
 -- | <http://llvm.org/docs/LangRef.html#type-system>
@@ -24,7 +25,7 @@ data Type
   -- | <http://llvm.org/docs/LangRef.html#pointer-type>
   | PointerType { pointerReferent :: Type, pointerAddrSpace :: AddrSpace }
   -- | <http://llvm.org/docs/LangRef.html#floating-point-types>
-  | FloatingPointType { typeBits :: Word32, floatingPointFormat :: FloatingPointFormat }
+  | FloatingPointType { floatingPointType :: FloatingPointType }
   -- | <http://llvm.org/docs/LangRef.html#function-type>
   | FunctionType { resultType :: Type, argumentTypes :: [Type], isVarArg :: Bool }
   -- | <http://llvm.org/docs/LangRef.html#vector-type>
@@ -73,27 +74,27 @@ i128 = IntegerType 128
 ptr :: Type -> Type
 ptr t = PointerType t (AddrSpace 0)
 
--- | An abbreviation for 'FloatingPointType' 16 'IEEE'
+-- | An abbreviation for 'FloatingPointType' 'HalfFP'
 half :: Type
-half = FloatingPointType 16 IEEE
+half = FloatingPointType HalfFP
 
--- | An abbreviation for 'FloatingPointType' 32 'IEEE'
+-- | An abbreviation for 'FloatingPointType' 'FloatFP'
 float :: Type
-float = FloatingPointType 32 IEEE
+float = FloatingPointType FloatFP
 
--- | An abbreviation for 'FloatingPointType' 64 'IEEE'
+-- | An abbreviation for 'FloatingPointType' 'DoubleFP'
 double :: Type
-double = FloatingPointType 64 IEEE
+double = FloatingPointType DoubleFP
 
--- | An abbreviation for 'FloatingPointType' 128 'IEEE'
+-- | An abbreviation for 'FloatingPointType' 'FP128FP'
 fp128 :: Type
-fp128 = FloatingPointType 128 IEEE
+fp128 = FloatingPointType FP128FP
 
--- | An abbreviation for 'FloatingPointType' 80 'DoubleExtended'
+-- | An abbreviation for 'FloatingPointType' 'X86_FP80FP'
 x86_fp80 :: Type
-x86_fp80 = FloatingPointType 80 DoubleExtended
+x86_fp80 = FloatingPointType X86_FP80FP
 
--- | An abbreviation for 'FloatingPointType' 128 'PairOfFloats'
+-- | An abbreviation for 'FloatingPointType' 'PPC_FP128FP'
 ppc_fp128 :: Type
-ppc_fp128 = FloatingPointType 128 PairOfFloats
+ppc_fp128 = FloatingPointType PPC_FP128FP
 

--- a/llvm-hs/src/LLVM/Internal/Type.hs
+++ b/llvm-hs/src/LLVM/Internal/Type.hs
@@ -82,13 +82,12 @@ instance EncodeM EncodeAST A.Type (Ptr FFI.Type) where
         a <- encodeM addressSpace
         liftIO $ FFI.pointerType e a
       A.VoidType -> liftIO $ FFI.voidTypeInContext context
-      A.FloatingPointType 16 A.IEEE -> liftIO $ FFI.halfTypeInContext context
-      A.FloatingPointType 32 A.IEEE -> liftIO $ FFI.floatTypeInContext context
-      A.FloatingPointType 64 A.IEEE -> liftIO $ FFI.doubleTypeInContext context
-      A.FloatingPointType 80 A.DoubleExtended -> liftIO $ FFI.x86FP80TypeInContext context
-      A.FloatingPointType 128 A.IEEE -> liftIO $ FFI.fP128TypeInContext context
-      A.FloatingPointType 128 A.PairOfFloats -> liftIO $ FFI.ppcFP128TypeInContext context
-      A.FloatingPointType _ _ -> throwM . EncodeException $ "unsupported floating point type: " ++ show f
+      A.FloatingPointType A.HalfFP      -> liftIO $ FFI.halfTypeInContext context
+      A.FloatingPointType A.FloatFP     -> liftIO $ FFI.floatTypeInContext context
+      A.FloatingPointType A.DoubleFP    -> liftIO $ FFI.doubleTypeInContext context
+      A.FloatingPointType A.X86_FP80FP  -> liftIO $ FFI.x86FP80TypeInContext context
+      A.FloatingPointType A.FP128FP     -> liftIO $ FFI.fP128TypeInContext context
+      A.FloatingPointType A.PPC_FP128FP -> liftIO $ FFI.ppcFP128TypeInContext context
       A.VectorType sz e -> do
         e <- encodeM e
         sz <- encodeM sz
@@ -125,12 +124,12 @@ instance DecodeM DecodeAST A.Type (Ptr FFI.Type) where
           return A.PointerType
              `ap` (decodeM =<< liftIO (FFI.getElementType t))
              `ap` (decodeM =<< liftIO (FFI.getPointerAddressSpace t))
-      [typeKindP|Half|] -> return $ A.FloatingPointType 16 A.IEEE
-      [typeKindP|Float|] -> return $ A.FloatingPointType 32 A.IEEE
-      [typeKindP|Double|] -> return $ A.FloatingPointType 64 A.IEEE
-      [typeKindP|FP128|] -> return $ A.FloatingPointType 128 A.IEEE
-      [typeKindP|X86_FP80|] -> return $ A.FloatingPointType 80 A.DoubleExtended
-      [typeKindP|PPC_FP128|] -> return $ A.FloatingPointType 128 A.PairOfFloats
+      [typeKindP|Half|]      -> return $ A.FloatingPointType A.HalfFP
+      [typeKindP|Float|]     -> return $ A.FloatingPointType A.FloatFP
+      [typeKindP|Double|]    -> return $ A.FloatingPointType A.DoubleFP
+      [typeKindP|FP128|]     -> return $ A.FloatingPointType A.FP128FP
+      [typeKindP|X86_FP80|]  -> return $ A.FloatingPointType A.X86_FP80FP
+      [typeKindP|PPC_FP128|] -> return $ A.FloatingPointType A.PPC_FP128FP
       [typeKindP|Vector|] ->
         return A.VectorType
          `ap` (decodeM =<< liftIO (FFI.getVectorSize t))


### PR DESCRIPTION
We now have

    data FloatingPointType
      = HalfFP      -- ^ 16-bit floating point value
      | FloatFP     -- ^ 32-bit floating point value
      | DoubleFP    -- ^ 64-bit floating point value
      | FP128FP     -- ^ 128-bit floating point value (112-bit mantissa)
      | X86_FP80FP  -- ^ 80-bit floating point value (X87)
      | PPC_FP128FP -- ^ 128-bit floating point value (two 64-bits)

which more closely matches the LLVM IR and the LLVM C++ interface.  Fixes: #93