### PR TITLE
Throw an error when converting non-ASCII strings to `Name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 * The `FloatingPointType` constructor now takes a `FloatingPointType` argument
   instead of a width and a `FloatingPointFormat`, to more closely match the
   LLVM IR language reference.
+* The `IsString` instance of `Name` now throws an error on non-ASCII
+  strings instead of silently discarding the upper bytes. There is
+  also a new `mkName` function with the same behavior for easier
+  discoverability. Non-ASCII names need to be encoded using an arbitrary encoding to
+  to a `ShortByteString` which can then be used as a `Name`.
 
 ## 4.0.1
 

--- a/llvm-hs-pure/src/LLVM/AST/Name.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Name.hs
@@ -2,6 +2,8 @@
 module LLVM.AST.Name where
 
 import LLVM.Prelude
+import Data.Char
+import Data.Monoid
 import Data.String
 
 {- |
@@ -30,5 +32,15 @@ data Name
     | UnName Word -- ^ a number for a nameless thing
    deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
 
+-- | Using 'fromString` on non-ASCII strings will throw an error.
 instance IsString Name where
-  fromString = Name . fromString
+  fromString s
+    | all isAscii s = Name (fromString s)
+    | otherwise =
+      error ("Only ASCII strings are automatically converted to LLVM names. "
+          <> "Other strings need to be encoded to a `ShortByteString` using an arbitrary encoding.")
+
+-- | Create a 'Name' based on an ASCII 'String'.
+-- Non-ASCII strings will throw an error.
+mkName :: String -> Name
+mkName = fromString


### PR DESCRIPTION
See #88 for the discussion leading up to this.