### PR TITLE
Enable dynamic selection of OrcJIT layers on the Haskell side

### DIFF
--- a/llvm-hs/CHANGELOG.md
+++ b/llvm-hs/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Enable users to choose how they want to compose OrcJIT layers
+  instead of having to use the builtin variants.
+
 ## 4.1.0 (2017-05-17)
 
 * Switch most of the API from `String` to `ByteString`.

--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -130,6 +130,7 @@ library
     LLVM.Internal.Metadata
     LLVM.Internal.Module
     LLVM.Internal.OrcJIT
+    LLVM.Internal.OrcJIT.CompileLayer
     LLVM.Internal.OrcJIT.CompileOnDemandLayer
     LLVM.Internal.OrcJIT.IRCompileLayer
     LLVM.Internal.Operand
@@ -169,6 +170,7 @@ library
     LLVM.Internal.FFI.Metadata
     LLVM.Internal.FFI.Module
     LLVM.Internal.FFI.OrcJIT
+    LLVM.Internal.FFI.OrcJIT.CompileLayer
     LLVM.Internal.FFI.OrcJIT.CompileOnDemandLayer
     LLVM.Internal.FFI.OrcJIT.IRCompileLayer
     LLVM.Internal.FFI.PassManager

--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJIT.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJIT.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE MultiParamTypeClasses, ForeignFunctionInterface #-}
 
 module LLVM.Internal.FFI.OrcJIT where
 
@@ -9,10 +9,14 @@ import Foreign.Ptr
 
 import LLVM.Internal.FFI.DataLayout
 import LLVM.Internal.FFI.LLVMCTypes
+import LLVM.Internal.FFI.PtrHierarchy
 
 data JITSymbol
 data LambdaResolver
+
+data ObjectLayer
 data ObjectLinkingLayer
+instance ChildOf ObjectLayer ObjectLinkingLayer
 
 newtype TargetAddress = TargetAddress Word64
 
@@ -32,8 +36,8 @@ foreign import ccall safe "LLVM_Hs_createLambdaResolver" createLambdaResolver ::
 foreign import ccall safe "LLVM_Hs_createObjectLinkingLayer" createObjectLinkingLayer ::
   IO (Ptr ObjectLinkingLayer)
 
-foreign import ccall safe "LLVM_Hs_disposeObjectLinkingLayer" disposeObjectLinkingLayer ::
-  Ptr ObjectLinkingLayer -> IO ()
+foreign import ccall safe "LLVM_Hs_ObjectLayer_dispose" disposeObjectLayer ::
+  Ptr ObjectLayer -> IO ()
 
 foreign import ccall safe "LLVM_Hs_JITSymbol_getAddress" getAddress ::
   Ptr JITSymbol -> IO TargetAddress

--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJIT/CompileLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJIT/CompileLayer.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module LLVM.Internal.FFI.OrcJIT.CompileLayer where
+
+import LLVM.Prelude
+
+import LLVM.Internal.FFI.DataLayout
+import LLVM.Internal.FFI.LLVMCTypes
+import LLVM.Internal.FFI.Module
+import LLVM.Internal.FFI.OrcJIT
+
+import Foreign.C
+import Foreign.Ptr
+
+data CompileLayer
+
+newtype ModuleSetHandle = ModuleSetHandle Word
+
+foreign import ccall safe "LLVM_Hs_CompileLayer_dispose" disposeCompileLayer ::
+  Ptr CompileLayer -> IO ()
+
+foreign import ccall safe "LLVM_Hs_CompileLayer_addModuleSet" addModuleSet ::
+  Ptr CompileLayer ->
+  Ptr DataLayout ->
+  Ptr (Ptr Module) ->
+  CUInt ->
+  Ptr LambdaResolver ->
+  IO ModuleSetHandle
+
+foreign import ccall safe "LLVM_Hs_CompileLayer_removeModuleSet" removeModuleSet ::
+  Ptr CompileLayer -> ModuleSetHandle -> IO ()
+
+foreign import ccall safe "LLVM_Hs_CompileLayer_findSymbol" findSymbol ::
+  Ptr CompileLayer -> CString -> LLVMBool -> IO (Ptr JITSymbol)

--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJIT/CompileOnDemandLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJIT/CompileOnDemandLayer.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ForeignFunctionInterface, MultiParamTypeClasses #-}
 module LLVM.Internal.FFI.OrcJIT.CompileOnDemandLayer where
 
 import LLVM.Prelude
@@ -10,14 +10,14 @@ import LLVM.Internal.FFI.DataLayout
 import LLVM.Internal.FFI.LLVMCTypes
 import LLVM.Internal.FFI.Module
 import LLVM.Internal.FFI.OrcJIT
-import LLVM.Internal.FFI.OrcJIT.IRCompileLayer (IRCompileLayer)
+import LLVM.Internal.FFI.OrcJIT.CompileLayer
 import LLVM.Internal.FFI.PtrHierarchy
 
 data IndirectStubsManagerBuilder
 data JITCompileCallbackManager
-data CompileOnDemandLayer
 data Set a
-data ModuleSetHandle
+data CompileOnDemandLayer
+instance ChildOf CompileLayer CompileOnDemandLayer
 
 type PartitioningFn = Ptr Function -> Ptr (Set (Ptr Function)) -> IO ()
 
@@ -43,32 +43,9 @@ foreign import ccall safe "LLVM_Hs_insertFun" insertFun ::
   Ptr (Set (Ptr Function)) -> Ptr Function -> IO ()
 
 foreign import ccall safe "LLVM_Hs_createCompileOnDemandLayer" createCompileOnDemandLayer ::
-  Ptr IRCompileLayer ->
+  Ptr CompileLayer ->
   FunPtr PartitioningFn ->
   Ptr JITCompileCallbackManager ->
   Ptr IndirectStubsManagerBuilder ->
   LLVMBool ->
   IO (Ptr CompileOnDemandLayer)
-
-foreign import ccall safe "LLVM_Hs_disposeCompileOnDemandLayer" disposeCompileOnDemandLayer ::
-  Ptr CompileOnDemandLayer ->
-  IO ()
-
-foreign import ccall safe "LLVM_Hs_CompileOnDemandLayer_addModuleSet" addModuleSet ::
-  Ptr CompileOnDemandLayer ->
-  Ptr DataLayout ->
-  Ptr (Ptr Module) ->
-  CUInt ->
-  Ptr LambdaResolver ->
-  IO (Ptr ModuleSetHandle)
-
-foreign import ccall safe "LLVM_Hs_CompileOnDemandLayer_removeModuleSet" removeModuleSet ::
-  Ptr CompileOnDemandLayer ->
-  Ptr ModuleSetHandle ->
-  IO ()
-
-foreign import ccall safe "LLVM_Hs_CompileOnDemandLayer_findSymbol" findSymbol ::
-  Ptr CompileOnDemandLayer ->
-  CString ->
-  LLVMBool ->
-  IO (Ptr JITSymbol)

--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJIT/IRCompileLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJIT/IRCompileLayer.hs
@@ -1,36 +1,17 @@
-{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ForeignFunctionInterface, MultiParamTypeClasses #-}
 module LLVM.Internal.FFI.OrcJIT.IRCompileLayer where
 
 import LLVM.Prelude
 
-import LLVM.Internal.FFI.DataLayout
-import LLVM.Internal.FFI.LLVMCTypes
-import LLVM.Internal.FFI.Module
 import LLVM.Internal.FFI.OrcJIT
+import LLVM.Internal.FFI.OrcJIT.CompileLayer
+import LLVM.Internal.FFI.PtrHierarchy
 import LLVM.Internal.FFI.Target
 
 import Foreign.Ptr
-import Foreign.C
 
 data IRCompileLayer
-data ModuleSetHandle
+instance ChildOf CompileLayer IRCompileLayer
 
 foreign import ccall safe "LLVM_Hs_createIRCompileLayer" createIRCompileLayer ::
-  Ptr ObjectLinkingLayer -> Ptr TargetMachine -> IO (Ptr IRCompileLayer)
-
-foreign import ccall safe "LLVM_Hs_disposeIRCompileLayer" disposeIRCompileLayer ::
-  Ptr IRCompileLayer -> IO ()
-
-foreign import ccall safe "LLVM_Hs_IRCompileLayer_addModuleSet" addModuleSet ::
-  Ptr IRCompileLayer ->
-  Ptr DataLayout ->
-  Ptr (Ptr Module) ->
-  CUInt ->
-  Ptr LambdaResolver ->
-  IO (Ptr ModuleSetHandle)
-
-foreign import ccall safe "LLVM_Hs_IRCompileLayer_removeModuleSet" removeModuleSet ::
-  Ptr IRCompileLayer -> Ptr ModuleSetHandle -> IO ()
-
-foreign import ccall safe "LLVM_Hs_IRCompileLayer_findSymbol" findSymbol ::
-  Ptr IRCompileLayer -> CString -> LLVMBool -> IO (Ptr JITSymbol)
+  Ptr ObjectLayer -> Ptr TargetMachine -> IO (Ptr IRCompileLayer)

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/CompileLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/CompileLayer.hs
@@ -1,0 +1,65 @@
+module LLVM.Internal.OrcJIT.CompileLayer where
+
+import LLVM.Prelude
+
+import Control.Exception
+import Control.Monad.AnyCont
+import Control.Monad.IO.Class
+import Data.IORef
+import Foreign.Marshal.Array (withArrayLen)
+import Foreign.Ptr
+
+import LLVM.Internal.Coding
+import qualified LLVM.Internal.FFI.DataLayout as FFI
+import qualified LLVM.Internal.FFI.OrcJIT as FFI
+import qualified LLVM.Internal.FFI.OrcJIT.CompileLayer as FFI
+import LLVM.Internal.Module hiding (getDataLayout)
+import LLVM.Internal.OrcJIT
+
+
+class CompileLayer a where
+  getCompileLayer :: a -> Ptr FFI.CompileLayer
+  getDataLayout :: a -> Ptr FFI.DataLayout
+  getCleanups :: a -> IORef [IO ()]
+
+mangleSymbol :: CompileLayer l => l -> ShortByteString -> IO MangledSymbol
+mangleSymbol compileLayer symbol = flip runAnyContT return $ do
+  mangledSymbol <- alloca
+  symbol' <- encodeM symbol
+  anyContToM $ bracket
+    (FFI.getMangledSymbol mangledSymbol symbol' (getDataLayout compileLayer))
+    (\_ -> FFI.disposeMangledSymbol =<< peek mangledSymbol)
+  decodeM =<< peek mangledSymbol
+
+findSymbol :: CompileLayer l => l -> MangledSymbol -> Bool -> IO JITSymbol
+findSymbol compileLayer symbol exportedSymbolsOnly = flip runAnyContT return $ do
+  symbol' <- encodeM symbol
+  exportedSymbolsOnly' <- encodeM exportedSymbolsOnly
+  symbol <- anyContToM $ bracket
+    (FFI.findSymbol (getCompileLayer compileLayer) symbol' exportedSymbolsOnly') FFI.disposeSymbol
+  decodeM symbol
+
+addModuleSet :: CompileLayer l => l -> [Module] -> SymbolResolver -> IO FFI.ModuleSetHandle
+addModuleSet compileLayer modules resolver = flip runAnyContT return $ do
+  resolverAct <- encodeM resolver
+  resolver' <- liftIO $ resolverAct (getCleanups compileLayer)
+  modules' <- liftIO $ mapM readModule modules
+  (moduleCount, modules'') <-
+    anyContToM $ \f -> withArrayLen modules' $ \n hs -> f (fromIntegral n, hs)
+  liftIO $
+    FFI.addModuleSet
+      (getCompileLayer compileLayer)
+      (getDataLayout compileLayer)
+      modules''
+      moduleCount
+      resolver'
+
+removeModuleSet :: CompileLayer l => l -> FFI.ModuleSetHandle -> IO ()
+removeModuleSet compileLayer handle =
+  FFI.removeModuleSet (getCompileLayer compileLayer) handle
+
+withModuleSet :: CompileLayer l => l -> [Module] -> SymbolResolver -> (FFI.ModuleSetHandle -> IO a) -> IO a
+withModuleSet compileLayer modules resolver =
+  bracket
+    (addModuleSet compileLayer modules resolver)
+    (removeModuleSet compileLayer)

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/IRCompileLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/IRCompileLayer.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE MultiParamTypeClasses #-}
 module LLVM.Internal.OrcJIT.IRCompileLayer where
 
 import LLVM.Prelude
@@ -7,19 +6,18 @@ import Control.Exception
 import Control.Monad.AnyCont
 import Control.Monad.IO.Class
 import Data.IORef
-import Foreign.Marshal.Array (withArrayLen)
 import Foreign.Ptr
 
-import LLVM.Internal.Coding
 import qualified LLVM.Internal.FFI.DataLayout as FFI
-import qualified LLVM.Internal.FFI.OrcJIT as FFI
+import qualified LLVM.Internal.FFI.OrcJIT.CompileLayer as FFI
 import qualified LLVM.Internal.FFI.OrcJIT.IRCompileLayer as FFI
+import qualified LLVM.Internal.FFI.PtrHierarchy as FFI
 import qualified LLVM.Internal.FFI.Target as FFI
-import LLVM.Internal.Module
 import LLVM.Internal.OrcJIT
+import LLVM.Internal.OrcJIT.CompileLayer
 import LLVM.Internal.Target
 
-data IRCompileLayer =
+data IRCompileLayer objectLayer =
   IRCompileLayer {
     compileLayer :: !(Ptr FFI.IRCompileLayer),
     dataLayout :: !(Ptr FFI.DataLayout),
@@ -27,48 +25,14 @@ data IRCompileLayer =
   }
   deriving Eq
 
-newtype ModuleSet = ModuleSet (Ptr FFI.ModuleSetHandle)
+instance CompileLayer (IRCompileLayer l) where
+  getCompileLayer = FFI.upCast . compileLayer
+  getDataLayout = dataLayout
+  getCleanups = cleanupActions
 
-withIRCompileLayer :: ObjectLinkingLayer -> TargetMachine -> (IRCompileLayer -> IO a) -> IO a
-withIRCompileLayer (ObjectLinkingLayer oll) (TargetMachine tm) f = flip runAnyContT return $ do
+withIRCompileLayer :: ObjectLayer l => l -> TargetMachine -> (IRCompileLayer l -> IO a) -> IO a
+withIRCompileLayer objectLayer (TargetMachine tm) f = flip runAnyContT return $ do
   dl <- anyContToM $ bracket (FFI.createTargetDataLayout tm) FFI.disposeDataLayout
-  cl <- anyContToM $ bracket (FFI.createIRCompileLayer oll tm) FFI.disposeIRCompileLayer
+  cl <- anyContToM $ bracket (FFI.createIRCompileLayer (getObjectLayer objectLayer) tm) (FFI.disposeCompileLayer . FFI.upCast)
   cleanup <- anyContToM $ bracket (newIORef []) (sequence <=< readIORef)
   liftIO $ f (IRCompileLayer cl dl cleanup)
-
-mangleSymbol :: IRCompileLayer -> ShortByteString -> IO MangledSymbol
-mangleSymbol (IRCompileLayer _ dl _) symbol = flip runAnyContT return $ do
-  mangledSymbol <- alloca
-  symbol' <- encodeM symbol
-  anyContToM $ bracket
-    (FFI.getMangledSymbol mangledSymbol symbol' dl)
-    (\_ -> FFI.disposeMangledSymbol =<< peek mangledSymbol)
-  decodeM =<< peek mangledSymbol
-
-findSymbol :: IRCompileLayer -> MangledSymbol -> Bool -> IO JITSymbol
-findSymbol (IRCompileLayer cl _ _) symbol exportedSymbolsOnly = flip runAnyContT return $ do
-  symbol' <- encodeM symbol
-  exportedSymbolsOnly' <- encodeM exportedSymbolsOnly
-  symbol <- anyContToM $ bracket
-    (FFI.findSymbol cl symbol' exportedSymbolsOnly') FFI.disposeSymbol
-  decodeM symbol
-
-addModuleSet :: IRCompileLayer -> [Module] -> SymbolResolver -> IO ModuleSet
-addModuleSet (IRCompileLayer cl dl cleanups) modules resolver = flip runAnyContT return $ do
-  resolverAct <- encodeM resolver
-  resolver' <- liftIO $ resolverAct cleanups
-  modules' <- liftIO $ mapM readModule modules
-  (moduleCount, modules'') <-
-    anyContToM $ \f -> withArrayLen modules' $ \n hs -> f (fromIntegral n, hs)
-  moduleSet <- liftIO $ FFI.addModuleSet cl dl modules'' moduleCount resolver'
-  pure (ModuleSet moduleSet)
-
-removeModuleSet :: IRCompileLayer -> ModuleSet -> IO ()
-removeModuleSet (IRCompileLayer cl _ _) (ModuleSet handle) =
-  FFI.removeModuleSet cl handle
-
-withModuleSet :: IRCompileLayer -> [Module] -> SymbolResolver -> (ModuleSet -> IO a) -> IO a
-withModuleSet compileLayer modules resolver =
-  bracket
-    (addModuleSet compileLayer modules resolver)
-    (removeModuleSet compileLayer)

--- a/llvm-hs/src/LLVM/OrcJIT/CompileOnDemandLayer.hs
+++ b/llvm-hs/src/LLVM/OrcJIT/CompileOnDemandLayer.hs
@@ -12,3 +12,4 @@ module LLVM.OrcJIT.CompileOnDemandLayer (
   ) where
 
 import LLVM.Internal.OrcJIT.CompileOnDemandLayer
+import LLVM.Internal.OrcJIT.CompileLayer

--- a/llvm-hs/src/LLVM/OrcJIT/IRCompileLayer.hs
+++ b/llvm-hs/src/LLVM/OrcJIT/IRCompileLayer.hs
@@ -1,10 +1,12 @@
 module LLVM.OrcJIT.IRCompileLayer (
     IRCompileLayer,
-    ModuleSet,
+    ModuleSetHandle,
     findSymbol,
     mangleSymbol,
     withIRCompileLayer,
     withModuleSet
   ) where
 
-import           LLVM.Internal.OrcJIT.IRCompileLayer
+import LLVM.Internal.OrcJIT.CompileLayer
+import LLVM.Internal.OrcJIT.IRCompileLayer
+import LLVM.Internal.FFI.OrcJIT.CompileLayer (ModuleSetHandle)


### PR DESCRIPTION
Let me give a bit of background on OrcJIT that explains the reasoning for this change:

The C++ OrcJIT API is composed of different layers, e.g. `IRCompileLayer` and `CompileOnDemandLayer`. Users choose which layers they need and how they want to compose them. However, while these layers all provide the same API, the layers are statically selected using C++-templates. For this reason, it is currently impossible to choose custom compositions of layers in Haskell code since the order is fixed on the C++-side. While this is not that big of a problem since we only support two compile layers atm, I intend to expand the set of layers available in `llvm-hs` and then it becomes important that users can choose how they want to use them.

This PR turns the static polymorphism via C++-templates into dynamic polymorphism and thereby moves the selection of compile layers to the Haskell side. This involves a fair amount of boilerplate but that boilerplate is independent of the number of layers we expose and is very simple so I don’t expect it to cause a lot of maintenance effort.