### PR TITLE
Add bindings to IRTransformLayer

### DIFF
--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -133,6 +133,7 @@ library
     LLVM.Internal.OrcJIT.CompileLayer
     LLVM.Internal.OrcJIT.CompileOnDemandLayer
     LLVM.Internal.OrcJIT.IRCompileLayer
+    LLVM.Internal.OrcJIT.IRTransformLayer
     LLVM.Internal.Operand
     LLVM.Internal.PassManager
     LLVM.Internal.RawOStream
@@ -173,6 +174,7 @@ library
     LLVM.Internal.FFI.OrcJIT.CompileLayer
     LLVM.Internal.FFI.OrcJIT.CompileOnDemandLayer
     LLVM.Internal.FFI.OrcJIT.IRCompileLayer
+    LLVM.Internal.FFI.OrcJIT.IRTransformLayer
     LLVM.Internal.FFI.PassManager
     LLVM.Internal.FFI.PtrHierarchy
     LLVM.Internal.FFI.RawOStream
@@ -188,6 +190,7 @@ library
     LLVM.OrcJIT
     LLVM.OrcJIT.CompileOnDemandLayer
     LLVM.OrcJIT.IRCompileLayer
+    LLVM.OrcJIT.IRTransformLayer
     LLVM.PassManager
     LLVM.Relocation
     LLVM.Target

--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJIT/CompileOnDemandLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJIT/CompileOnDemandLayer.hs
@@ -6,9 +6,7 @@ import LLVM.Prelude
 import Foreign.C
 import Foreign.Ptr
 
-import LLVM.Internal.FFI.DataLayout
 import LLVM.Internal.FFI.LLVMCTypes
-import LLVM.Internal.FFI.Module
 import LLVM.Internal.FFI.OrcJIT
 import LLVM.Internal.FFI.OrcJIT.CompileLayer
 import LLVM.Internal.FFI.PtrHierarchy

--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJIT/IRTransformLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJIT/IRTransformLayer.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE ForeignFunctionInterface, MultiParamTypeClasses #-}
+module LLVM.Internal.FFI.OrcJIT.IRTransformLayer where
+
+import LLVM.Prelude
+
+import LLVM.Internal.FFI.OrcJIT.CompileLayer
+import LLVM.Internal.FFI.PtrHierarchy
+import LLVM.Internal.FFI.Module
+
+import Foreign.Ptr
+
+data IRTransformLayer
+instance ChildOf CompileLayer IRTransformLayer
+
+type ModuleTransform = Ptr Module -> IO (Ptr Module)
+
+foreign import ccall "wrapper" wrapModuleTransform ::
+  ModuleTransform -> IO (FunPtr ModuleTransform)
+
+foreign import ccall safe "LLVM_Hs_createIRTransformLayer" createIRTransformLayer ::
+  Ptr CompileLayer -> FunPtr ModuleTransform -> IO (Ptr IRTransformLayer)

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/CompileLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/CompileLayer.hs
@@ -44,6 +44,7 @@ addModuleSet compileLayer modules resolver = flip runAnyContT return $ do
   resolverAct <- encodeM resolver
   resolver' <- liftIO $ resolverAct (getCleanups compileLayer)
   modules' <- liftIO $ mapM readModule modules
+  liftIO $ mapM_ deleteModule modules
   (moduleCount, modules'') <-
     anyContToM $ \f -> withArrayLen modules' $ \n hs -> f (fromIntegral n, hs)
   liftIO $
@@ -58,6 +59,8 @@ removeModuleSet :: CompileLayer l => l -> FFI.ModuleSetHandle -> IO ()
 removeModuleSet compileLayer handle =
   FFI.removeModuleSet (getCompileLayer compileLayer) handle
 
+-- | 'withModuleSet' consumes the modules passed to it and they should
+-- not be used after calling this method.
 withModuleSet :: CompileLayer l => l -> [Module] -> SymbolResolver -> (FFI.ModuleSetHandle -> IO a) -> IO a
 withModuleSet compileLayer modules resolver =
   bracket

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/IRTransformLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/IRTransformLayer.hs
@@ -1,0 +1,56 @@
+module LLVM.Internal.OrcJIT.IRTransformLayer where
+
+import LLVM.Prelude
+
+import Control.Exception
+import Control.Monad.AnyCont
+import Control.Monad.IO.Class
+import Data.IORef
+import Foreign.Ptr
+
+import qualified LLVM.Internal.FFI.DataLayout as FFI
+import qualified LLVM.Internal.FFI.Module as FFI
+import qualified LLVM.Internal.FFI.OrcJIT.CompileLayer as FFI
+import qualified LLVM.Internal.FFI.OrcJIT.IRTransformLayer as FFI
+import qualified LLVM.Internal.FFI.PtrHierarchy as FFI
+import qualified LLVM.Internal.FFI.Target as FFI
+import LLVM.Internal.OrcJIT
+import LLVM.Internal.OrcJIT.CompileLayer
+import LLVM.Internal.Target
+
+data IRTransformLayer objectLayer =
+  IRTransformLayer {
+    compileLayer :: !(Ptr FFI.IRTransformLayer),
+    dataLayout :: !(Ptr FFI.DataLayout),
+    cleanupActions :: !(IORef [IO ()])
+  }
+  deriving Eq
+
+instance CompileLayer (IRTransformLayer l) where
+  getCompileLayer = FFI.upCast . compileLayer
+  getDataLayout = dataLayout
+  getCleanups = cleanupActions
+
+withIRTransformLayer
+  :: CompileLayer l
+  => l
+  -> TargetMachine
+  -> (Ptr FFI.Module -> IO (Ptr FFI.Module))
+  -> (IRTransformLayer l -> IO a)
+  -> IO a
+withIRTransformLayer compileLayer (TargetMachine tm) moduleTransform f =
+  flip runAnyContT return $ do
+    dl <-
+      anyContToM $ bracket (FFI.createTargetDataLayout tm) FFI.disposeDataLayout
+    moduleTransform' <-
+      anyContToM $
+      bracket (FFI.wrapModuleTransform moduleTransform) freeHaskellFunPtr
+    cl <-
+      anyContToM $
+      bracket
+        (FFI.createIRTransformLayer
+           (getCompileLayer compileLayer)
+           moduleTransform')
+        (FFI.disposeCompileLayer . FFI.upCast)
+    cleanup <- anyContToM $ bracket (newIORef []) (sequence <=< readIORef)
+    liftIO $ f (IRTransformLayer cl dl cleanup)

--- a/llvm-hs/src/LLVM/OrcJIT/IRTransformLayer.hs
+++ b/llvm-hs/src/LLVM/OrcJIT/IRTransformLayer.hs
@@ -1,0 +1,12 @@
+module LLVM.OrcJIT.IRTransformLayer (
+    IRTransformLayer,
+    ModuleSetHandle,
+    findSymbol,
+    mangleSymbol,
+    withIRTransformLayer,
+    withModuleSet
+  ) where
+
+import LLVM.Internal.OrcJIT.CompileLayer
+import LLVM.Internal.OrcJIT.IRTransformLayer
+import LLVM.Internal.FFI.OrcJIT.CompileLayer (ModuleSetHandle)


### PR DESCRIPTION
This is still missing high-level bindings but I’d first like to finish the raw bindings to the other layers and then cleanup the high-level API (before the next release). It is usable (albeit only using Internal modules) and there is a test for it, so we should be able to safely merge it now.
