### PR TITLE
Add better checks during deserialization

### DIFF
--- a/llvm-hs/CHANGELOG.md
+++ b/llvm-hs/CHANGELOG.md
@@ -1,3 +1,10 @@
+## unreleased
+
+* Throw 'EncodeException' when the type supplied in a
+  'GlobalReference' does not match the type of the expression.
+* Throw 'EncodeException' when the result of instructions returning
+  void is named using ':='.
+
 ## 4.2.0 (2017-06-20)
 
 * Revamp OrcJIT API

--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -275,6 +275,7 @@ test-suite test
     LLVM.Test.ObjectCode
     LLVM.Test.OrcJIT
     LLVM.Test.Optimization
+    LLVM.Test.Regression
     LLVM.Test.Support
     LLVM.Test.Target
     LLVM.Test.Tests

--- a/llvm-hs/src/LLVM/Internal/Value.hs
+++ b/llvm-hs/src/LLVM/Internal/Value.hs
@@ -15,7 +15,6 @@ import qualified LLVM.Internal.FFI.Value as FFI
 import LLVM.Internal.Coding
 import LLVM.Internal.DecodeAST
 import LLVM.Internal.Type () 
-import LLVM.Internal.Constant () 
 
 import qualified LLVM.AST.Type as A
 

--- a/llvm-hs/test/LLVM/Test/Instrumentation.hs
+++ b/llvm-hs/test/LLVM/Test/Instrumentation.hs
@@ -124,7 +124,13 @@ ast = do
           tailCallKind = Nothing,
           callingConvention = CC.C,
           returnAttributes = [],
-          function = Right (ConstantOperand (C.GlobalReference (FunctionType i32 [i32, ptr (ptr i8)] False) (Name "foo"))),
+          function = Right
+            (ConstantOperand
+              (C.GlobalReference
+                 (PointerType
+                    { pointerReferent = FunctionType i32 [i128] False
+                    , pointerAddrSpace = AddrSpace 0})
+                 (Name "foo"))),
           arguments = [
            (ConstantOperand (C.Int 128 9491828328), [])
           ],

--- a/llvm-hs/test/LLVM/Test/Optimization.hs
+++ b/llvm-hs/test/LLVM/Test/Optimization.hs
@@ -237,7 +237,7 @@ tests = testGroup "Optimization" [
                       (ConstantOperand (C.Int 64 0), UnName 0),
                       (LocalReference i64 (Name "indvars.iv.next"), Name ".lr.ph")
                      ] [],
-                    UnName 2 := GetElementPtr True (ConstantOperand (C.GlobalReference (A.T.ArrayType 2048 i32) (Name "a"))) [ 
+                    UnName 2 := GetElementPtr True (ConstantOperand (C.GlobalReference (PointerType (A.T.ArrayType 2048 i32) (AddrSpace 0)) (Name "a"))) [
                       ConstantOperand (C.Int 64 0),
                       (LocalReference i64 (Name "indvars.iv"))
                      ] [],

--- a/llvm-hs/test/LLVM/Test/Regression.hs
+++ b/llvm-hs/test/LLVM/Test/Regression.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE OverloadedStrings #-}
+module LLVM.Test.Regression
+  ( tests
+  ) where
+
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+import qualified LLVM.AST as AST
+import           LLVM.AST hiding (Module)
+import           LLVM.AST.Constant
+import           LLVM.AST.Global
+import           LLVM.AST.Type
+
+import           LLVM.Context
+import           LLVM.Exception
+import           LLVM.Module
+
+import           Control.Exception
+
+example1 :: AST.Module
+example1 =
+  defaultModule
+  { moduleDefinitions =
+      [ GlobalDefinition
+          functionDefaults
+          { name = "test"
+          , returnType = void
+          , basicBlocks =
+              [ BasicBlock
+                  "entry"
+                  [ UnName 0 := Alloca i32 Nothing 0 []
+                  , UnName 1 :=
+                    Store
+                      False
+                      (LocalReference (ptr i32) (UnName 0))
+                      (ConstantOperand (Int 32 42))
+                      Nothing
+                      0
+                      []
+                  ]
+                  (Do $ Ret Nothing [])
+              ]
+          }
+      ]
+  }
+
+example2 :: AST.Module
+example2 =
+  defaultModule
+  { moduleDefinitions =
+      [ GlobalDefinition
+          functionDefaults
+          { name = "test"
+          , returnType = void
+          , basicBlocks =
+              [ BasicBlock
+                  "entry"
+                  [ UnName 0 :=
+                    Alloca (ptr $ FunctionType void [] False) Nothing 0 []
+                  , Do $
+                    Store
+                      False
+                      (LocalReference
+                         (ptr $ ptr $ FunctionType void [] False)
+                         (UnName 0))
+                      (ConstantOperand $
+                       GlobalReference (FunctionType void [] False) "test")
+                      Nothing
+                      0
+                      []
+                  ]
+                  (Do $ Ret Nothing [])
+              ]
+          }
+      ]
+  }
+
+shouldThrowEncodeException :: AST.Module -> String -> IO ()
+shouldThrowEncodeException ast errMsg = do
+  result <- try $ withContext $ \context -> do
+    withModuleFromAST context ast (\_ -> return ())
+  case result of
+    Left (EncodeException actualErrMsg) -> actualErrMsg @?= errMsg
+    Right _ -> assertFailure ("Expected serialization to fail with: \"" ++ errMsg ++ "\"")
+
+tests :: TestTree
+tests =
+  testGroup
+    "Regression"
+    [ testCase
+        "no named voids"
+        (example1 `shouldThrowEncodeException`
+         "Instruction of type void must not have a name: UnName 1 := Store {volatile = False, address = LocalReference (PointerType {pointerReferent = IntegerType {typeBits = 32}, pointerAddrSpace = AddrSpace 0}) (UnName 0), value = ConstantOperand (Int {integerBits = 32, integerValue = 42}), maybeAtomicity = Nothing, alignment = 0, metadata = []}")
+    , testCase
+        "no implicit casts"
+        (example2 `shouldThrowEncodeException`
+         "The serialized GlobalReference has type PointerType {pointerReferent = FunctionType {resultType = VoidType, argumentTypes = [], isVarArg = False}, pointerAddrSpace = AddrSpace 0} but should have type FunctionType {resultType = VoidType, argumentTypes = [], isVarArg = False}")
+    ]

--- a/llvm-hs/test/LLVM/Test/Tests.hs
+++ b/llvm-hs/test/LLVM/Test/Tests.hs
@@ -19,6 +19,7 @@ import qualified LLVM.Test.ObjectCode as ObjectCode
 import qualified LLVM.Test.Optimization as Optimization
 import qualified LLVM.Test.OrcJIT as OrcJIT
 import qualified LLVM.Test.Target as Target
+import qualified LLVM.Test.Regression as Regression
 
 tests = testGroup "llvm-hs" [
     CallingConvention.tests,
@@ -37,5 +38,6 @@ tests = testGroup "llvm-hs" [
     Analysis.tests,
     Linking.tests,
     Instrumentation.tests,
-    ObjectCode.tests
+    ObjectCode.tests,
+    Regression.tests
   ]


### PR DESCRIPTION
This fixes the discrepancies between the checks performed by `llc` and by `llvm-hs` that @aherrmann discovered in https://github.com/llvm-hs/llvm-hs-pretty/issues/15. The only downside I can see is that there is a slight runtime cost associated with this but I doubt that anyone that accepts the overhead of `llvm-hs` over the C++-API cares about increasing this overhead slightly especially when it makes it easier to catch errors early. But if you disagree, please speak up!