### PR TITLE
Setup: Fix linker ordering by linking stdlib after LLVM

### DIFF
--- a/llvm-hs/Setup.hs
+++ b/llvm-hs/Setup.hs
@@ -164,7 +164,7 @@ main = do
                     libBuildInfo =
                       mempty {
                         ccOptions = llvmCxxFlags,
-                        extraLibs = stdLib : libs ++ systemLibs
+                        extraLibs = libs ++ stdLib : systemLibs
                       }
                   }
               }


### PR DESCRIPTION
This patch reorders the linking of libstdc++ to be after the linking of the LLVM libs, fixing undefined reference errors on some toolchains.