### PR TITLE
Use fatal errors instead of assert(false)

### DIFF
--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -24,6 +24,7 @@ extra-source-files:
   src/LLVM/Internal/FFI/BinaryOperator.h
   src/LLVM/Internal/FFI/CallingConvention.h
   src/LLVM/Internal/FFI/Constant.h
+  src/LLVM/Internal/FFI/ErrorHandling.hpp
   src/LLVM/Internal/FFI/GlobalValue.h
   src/LLVM/Internal/FFI/InlineAssembly.h
   src/LLVM/Internal/FFI/Instruction.h
@@ -209,6 +210,7 @@ library
     src/LLVM/Internal/FFI/CallingConventionC.cpp
     src/LLVM/Internal/FFI/ConstantC.cpp
     src/LLVM/Internal/FFI/CommandLineC.cpp
+    src/LLVM/Internal/FFI/ErrorHandling.cpp
     src/LLVM/Internal/FFI/ExecutionEngineC.cpp
     src/LLVM/Internal/FFI/FunctionC.cpp
     src/LLVM/Internal/FFI/GlobalAliasC.cpp

--- a/llvm-hs/src/LLVM/Internal/FFI/BuilderC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/BuilderC.cpp
@@ -4,8 +4,9 @@
 
 #include "llvm-c/Core.h"
 
-#include "LLVM/Internal/FFI/Instruction.h"
 #include "LLVM/Internal/FFI/BinaryOperator.h"
+#include "LLVM/Internal/FFI/ErrorHandling.hpp"
+#include "LLVM/Internal/FFI/Instruction.h"
 
 using namespace llvm;
 
@@ -24,7 +25,7 @@ static SyncScope::ID unwrap(LLVMSynchronizationScope l) {
 #define ENUM_CASE(x) case LLVM ## x ## SynchronizationScope: return SyncScope::x;
 LLVM_HS_FOR_EACH_SYNCRONIZATION_SCOPE(ENUM_CASE)
 #undef ENUM_CASE
-	default: assert(false && "Unknown synchronization scope");
+	default: reportFatalError("Unknown synchronization scope");
 	}
 }
 

--- a/llvm-hs/src/LLVM/Internal/FFI/ErrorHandling.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/ErrorHandling.cpp
@@ -1,0 +1,8 @@
+#include "LLVM/Internal/FFI/ErrorHandling.hpp"
+#include <iostream>
+
+void reportFatalError(const std::string &errorMsg) {
+    std::cerr << "LLVM-HS ERROR at " << __FILE__ << ":" << __LINE__ << ": "
+              << errorMsg << "\n ";
+    exit(1);
+}

--- a/llvm-hs/src/LLVM/Internal/FFI/ErrorHandling.hpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/ErrorHandling.hpp
@@ -1,0 +1,7 @@
+#ifndef __LLVM_INTERNAL_FFI__ANALYSIS__H__
+#define __LLVM_INTERNAL_FFI__ANALYSIS__H__
+#include <string>
+
+[[noreturn]] void reportFatalError(const std::string &errorMsg);
+
+#endif

--- a/llvm-hs/src/LLVM/Internal/FFI/InstructionC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/InstructionC.cpp
@@ -11,6 +11,7 @@
 #include "llvm-c/Core.h"
 
 #include "LLVM/Internal/FFI/AttributeC.hpp"
+#include "LLVM/Internal/FFI/ErrorHandling.hpp"
 #include "LLVM/Internal/FFI/Instruction.h"
 
 using namespace llvm;
@@ -31,7 +32,7 @@ static LLVMSynchronizationScope wrap(SyncScope::ID l) {
 #define ENUM_CASE(x) case SyncScope::x: return LLVM ## x ## SynchronizationScope;
 LLVM_HS_FOR_EACH_SYNCRONIZATION_SCOPE(ENUM_CASE)
 #undef ENUM_CASE
-	default: assert(false && "Unknown synchronization scope");
+    default: reportFatalError("Unknown synchronization scope");
 	}
 }
 


### PR DESCRIPTION
Assertions are disabled when compiling in release mode which results
in a warning and potentially unexpected runtime behavior.