### PR TITLE
Explicitely cast LLVMBool to bool

### DIFF
--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp
@@ -196,7 +196,8 @@ CompileLayer *LLVM_Hs_createCompileOnDemandLayer(
             partitioningFtor(&f, &result);
             return result;
         },
-        *callbackManager, *stubsManager, cloneStubsIntoPartitions);
+        *callbackManager, *stubsManager,
+        static_cast<bool>(cloneStubsIntoPartitions));
 }
 
 CompileLayer *LLVM_Hs_createIRTransformLayer(CompileLayer *compileLayer,


### PR DESCRIPTION
fixes #131 

@tmcdonell Can you confirm that this fixes the build error? I’m sadly unable to figure out how to get `ghc` and `cabal` to use `clang` instead of `gcc` (`gcc` on macOS refers to `clang`) so I can’t confirm that this fixes the bug myself.