### PR TITLE
Set target options in `withTargetMachine`

### DIFF
--- a/llvm-hs/CHANGELOG.md
+++ b/llvm-hs/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Bugfixes
+  * Set target options in `withTargetMachine`. Previously the options
+    passed there were simply ignored.
+
 ## 5.0.0 (2017-09-07)
 
 * Support for LLVM 5.0

--- a/llvm-hs/src/LLVM/Internal/FFI/Target.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Target.hs
@@ -63,7 +63,7 @@ foreign import ccall unsafe "LLVM_Hs_DisposeTargetOptions" disposeTargetOptions 
 
 data TargetMachine
 
-foreign import ccall unsafe "LLVMCreateTargetMachine" createTargetMachine ::
+foreign import ccall unsafe "LLVM_Hs_CreateTargetMachine" createTargetMachine ::
   Ptr Target
   -> CString
   -> CString
@@ -76,6 +76,9 @@ foreign import ccall unsafe "LLVMCreateTargetMachine" createTargetMachine ::
 
 foreign import ccall unsafe "LLVMDisposeTargetMachine" disposeTargetMachine ::
   Ptr TargetMachine -> IO ()
+
+foreign import ccall unsafe "LLVM_Hs_TargetMachineOptions" targetMachineOptions ::
+  Ptr TargetMachine -> IO (Ptr TargetOptions)
 
 foreign import ccall unsafe "LLVM_Hs_TargetMachineEmit" targetMachineEmit ::
   Ptr TargetMachine

--- a/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
@@ -1,9 +1,9 @@
 #define __STDC_LIMIT_MACROS
-#include "llvm-c/Target.h"
 #include "LLVM/Internal/FFI/LibFunc.h"
 #include "LLVM/Internal/FFI/Target.h"
 #include "LLVM/Internal/FFI/Target.hpp"
 #include "llvm-c/Core.h"
+#include "llvm-c/Target.h"
 #include "llvm-c/TargetMachine.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
@@ -11,6 +11,7 @@
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/CodeGenCWrappers.h"
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Support/TargetRegistry.h"
@@ -24,154 +25,157 @@ namespace llvm {
 // These functions need to be marked as static to avoid undefined behavior
 // due to multiple definitions
 static LLVMTargetRef wrap(const Target *P) {
-  return reinterpret_cast<LLVMTargetRef>(const_cast<Target *>(P));
+    return reinterpret_cast<LLVMTargetRef>(const_cast<Target *>(P));
 }
 
+static Target *unwrap(LLVMTargetRef P) { return reinterpret_cast<Target *>(P); }
+
 static inline TargetLibraryInfoImpl *unwrap(LLVMTargetLibraryInfoRef P) {
-  return reinterpret_cast<TargetLibraryInfoImpl*>(P);
+    return reinterpret_cast<TargetLibraryInfoImpl *>(P);
 }
 
 static inline LLVMTargetLibraryInfoRef wrap(const TargetLibraryInfoImpl *P) {
-  TargetLibraryInfoImpl *X = const_cast<TargetLibraryInfoImpl*>(P);
-  return reinterpret_cast<LLVMTargetLibraryInfoRef>(X);
+    TargetLibraryInfoImpl *X = const_cast<TargetLibraryInfoImpl *>(P);
+    return reinterpret_cast<LLVMTargetLibraryInfoRef>(X);
 }
 
 static FloatABI::ABIType unwrap(LLVM_Hs_FloatABI x) {
-  switch (x) {
+    switch (x) {
 #define ENUM_CASE(x)                                                           \
-  case LLVM_Hs_FloatABI_##x:                                              \
-    return FloatABI::x;
-    LLVM_HS_FOR_EACH_FLOAT_ABI(ENUM_CASE)
+    case LLVM_Hs_FloatABI_##x:                                                 \
+        return FloatABI::x;
+        LLVM_HS_FOR_EACH_FLOAT_ABI(ENUM_CASE)
 #undef ENUM_CASE
-  default:
-    return FloatABI::ABIType(0);
-  }
+    default:
+        return FloatABI::ABIType(0);
+    }
 }
 
 static LibFunc unwrap(LLVMLibFunc x) {
-  switch (x) {
+    switch (x) {
 #define ENUM_CASE(x)                                                           \
-  case LLVMLibFunc__##x:                                                       \
-    return LibFunc_ ## x;
-    LLVM_HS_FOR_EACH_LIB_FUNC(ENUM_CASE)
+    case LLVMLibFunc__##x:                                                     \
+        return LibFunc_##x;
+        LLVM_HS_FOR_EACH_LIB_FUNC(ENUM_CASE)
 #undef ENUM_CASE
-  default:
-    return LibFunc(0);
-  }
+    default:
+        return LibFunc(0);
+    }
 }
 
 static LLVMLibFunc wrap(LibFunc x) {
-  switch (x) {
+    switch (x) {
 #define ENUM_CASE(x)                                                           \
-  case LibFunc_ ## x:                                                             \
-    return LLVMLibFunc__##x;
-    LLVM_HS_FOR_EACH_LIB_FUNC(ENUM_CASE)
+    case LibFunc_##x:                                                          \
+        return LLVMLibFunc__##x;
+        LLVM_HS_FOR_EACH_LIB_FUNC(ENUM_CASE)
 #undef ENUM_CASE
-  default:
-    return LLVMLibFunc(0);
-  }
+    default:
+        return LLVMLibFunc(0);
+    }
 }
 
 static LLVM_Hs_FloatABI wrap(FloatABI::ABIType x) {
-  switch (x) {
+    switch (x) {
 #define ENUM_CASE(x)                                                           \
-  case FloatABI::x:                                                            \
-    return LLVM_Hs_FloatABI_##x;
-    LLVM_HS_FOR_EACH_FLOAT_ABI(ENUM_CASE)
+    case FloatABI::x:                                                          \
+        return LLVM_Hs_FloatABI_##x;
+        LLVM_HS_FOR_EACH_FLOAT_ABI(ENUM_CASE)
 #undef ENUM_CASE
-  default:
-    return LLVM_Hs_FloatABI(0);
-  }
+    default:
+        return LLVM_Hs_FloatABI(0);
+    }
 }
 
 static FPOpFusion::FPOpFusionMode unwrap(LLVM_Hs_FPOpFusionMode x) {
-  switch (x) {
+    switch (x) {
 #define ENUM_CASE(x)                                                           \
-  case LLVM_Hs_FPOpFusionMode_##x:                                        \
-    return FPOpFusion::x;
-    LLVM_HS_FOR_EACH_FP_OP_FUSION_MODE(ENUM_CASE)
+    case LLVM_Hs_FPOpFusionMode_##x:                                           \
+        return FPOpFusion::x;
+        LLVM_HS_FOR_EACH_FP_OP_FUSION_MODE(ENUM_CASE)
 #undef ENUM_CASE
-  default:
-    return FPOpFusion::FPOpFusionMode(0);
-  }
+    default:
+        return FPOpFusion::FPOpFusionMode(0);
+    }
 }
 
 static LLVM_Hs_FPOpFusionMode wrap(FPOpFusion::FPOpFusionMode x) {
-  switch (x) {
+    switch (x) {
 #define ENUM_CASE(x)                                                           \
-  case FPOpFusion::x:                                                          \
-    return LLVM_Hs_FPOpFusionMode_##x;
-    LLVM_HS_FOR_EACH_FP_OP_FUSION_MODE(ENUM_CASE)
+    case FPOpFusion::x:                                                        \
+        return LLVM_Hs_FPOpFusionMode_##x;
+        LLVM_HS_FOR_EACH_FP_OP_FUSION_MODE(ENUM_CASE)
 #undef ENUM_CASE
-  default:
-    return LLVM_Hs_FPOpFusionMode(0);
-  }
+    default:
+        return LLVM_Hs_FPOpFusionMode(0);
+    }
 }
-}
+} // namespace llvm
 
 extern "C" {
 
 LLVMBool LLVM_Hs_InitializeNativeTarget() {
-  return LLVMInitializeNativeTarget() || InitializeNativeTargetAsmPrinter() ||
-         InitializeNativeTargetAsmParser();
+    return LLVMInitializeNativeTarget() || InitializeNativeTargetAsmPrinter() ||
+           InitializeNativeTargetAsmParser();
 }
 
 LLVMTargetRef LLVM_Hs_LookupTarget(const char *arch, const char *ctriple,
-                                        const char **tripleOut,
-                                        const char **cerror) {
-  std::string error;
-  Triple triple(ctriple);
-  if (const Target *result =
-          TargetRegistry::lookupTarget(arch, triple, error)) {
-    *tripleOut = strdup(triple.getTriple().c_str());
-    return wrap(result);
-  }
-  *cerror = strdup(error.c_str());
-  return 0;
+                                   const char **tripleOut,
+                                   const char **cerror) {
+    std::string error;
+    Triple triple(ctriple);
+    if (const Target *result =
+            TargetRegistry::lookupTarget(arch, triple, error)) {
+        *tripleOut = strdup(triple.getTriple().c_str());
+        return wrap(result);
+    }
+    *cerror = strdup(error.c_str());
+    return 0;
 }
 
 TargetOptions *LLVM_Hs_CreateTargetOptions() {
-  TargetOptions *to = new TargetOptions();
-  return to;
+    TargetOptions *to = new TargetOptions();
+    return to;
 }
 
-void LLVM_Hs_SetTargetOptionFlag(TargetOptions *to,
-                                      LLVM_Hs_TargetOptionFlag f,
-                                      unsigned v) {
-  switch (f) {
+void LLVM_Hs_SetTargetOptionFlag(TargetOptions *to, LLVM_Hs_TargetOptionFlag f,
+                                 unsigned v) {
+    switch (f) {
 #define ENUM_CASE(op)                                                          \
-  case LLVM_Hs_TargetOptionFlag_##op:                                     \
-    to->op = v ? 1 : 0;                                                        \
-    break;
-    LLVM_HS_FOR_EACH_TARGET_OPTION_FLAG(ENUM_CASE)
+    case LLVM_Hs_TargetOptionFlag_##op:                                        \
+        to->op = v ? 1 : 0;                                                    \
+        break;
+        LLVM_HS_FOR_EACH_TARGET_OPTION_FLAG(ENUM_CASE)
 #undef ENUM_CASE
-  }
+    }
 }
 
-static llvm::DebugCompressionType unwrap(LLVM_Hs_DebugCompressionType compressionType) {
-    switch(compressionType) {
-#define ENUM_CASE(op)                                \
-        case LLVM_Hs_DebugCompressionType_ ## op:    \
-            return llvm::DebugCompressionType::op;
+static llvm::DebugCompressionType
+unwrap(LLVM_Hs_DebugCompressionType compressionType) {
+    switch (compressionType) {
+#define ENUM_CASE(op)                                                          \
+    case LLVM_Hs_DebugCompressionType_##op:                                    \
+        return llvm::DebugCompressionType::op;
         LLVM_HS_FOR_EACH_DEBUG_COMPRESSION_TYPE(ENUM_CASE)
 #undef ENUM_CASE
     default:
-            assert(false && "Unknown debug compression type");
+        assert(false && "Unknown debug compression type");
         return llvm::DebugCompressionType::None;
     }
 }
 
-static LLVM_Hs_DebugCompressionType wrap(llvm::DebugCompressionType compressionType) {
-    switch(compressionType) {
-#define ENUM_CASE(op)                                   \
-        case llvm::DebugCompressionType::op:            \
-            return LLVM_Hs_DebugCompressionType_ ## op;
+static LLVM_Hs_DebugCompressionType
+wrap(llvm::DebugCompressionType compressionType) {
+    switch (compressionType) {
+#define ENUM_CASE(op)                                                          \
+    case llvm::DebugCompressionType::op:                                       \
+        return LLVM_Hs_DebugCompressionType_##op;
         LLVM_HS_FOR_EACH_DEBUG_COMPRESSION_TYPE(ENUM_CASE)
 #undef ENUM_CASE
     default: {
-            assert(false && "Unknown debug compression type");
-            return LLVM_Hs_DebugCompressionType_None;
-        }
+        assert(false && "Unknown debug compression type");
+        return LLVM_Hs_DebugCompressionType_None;
+    }
     }
 }
 
@@ -180,47 +184,47 @@ void LLVM_Hs_SetCompressDebugSections(TargetOptions *to,
     to->CompressDebugSections = unwrap(compress);
 }
 
-LLVM_Hs_DebugCompressionType LLVM_Hs_GetCompressDebugSections(TargetOptions* to) {
+LLVM_Hs_DebugCompressionType
+LLVM_Hs_GetCompressDebugSections(TargetOptions *to) {
     return wrap(to->CompressDebugSections);
 }
 
 unsigned LLVM_Hs_GetTargetOptionFlag(TargetOptions *to,
-                                          LLVM_Hs_TargetOptionFlag f) {
-  switch (f) {
+                                     LLVM_Hs_TargetOptionFlag f) {
+    switch (f) {
 #define ENUM_CASE(op)                                                          \
-  case LLVM_Hs_TargetOptionFlag_##op:                                     \
-    return to->op;
-    LLVM_HS_FOR_EACH_TARGET_OPTION_FLAG(ENUM_CASE)
+    case LLVM_Hs_TargetOptionFlag_##op:                                        \
+        return to->op;
+        LLVM_HS_FOR_EACH_TARGET_OPTION_FLAG(ENUM_CASE)
 #undef ENUM_CASE
-  default:
-    assert(false && "Unknown target option flag");
-    return 0;
-  }
+    default:
+        assert(false && "Unknown target option flag");
+        return 0;
+    }
 }
 
 void LLVM_Hs_SetStackAlignmentOverride(TargetOptions *to, unsigned v) {
-  to->StackAlignmentOverride = v;
+    to->StackAlignmentOverride = v;
 }
 
 unsigned LLVM_Hs_GetStackAlignmentOverride(TargetOptions *to) {
-  return to->StackAlignmentOverride;
+    return to->StackAlignmentOverride;
 }
 
 void LLVM_Hs_SetFloatABIType(TargetOptions *to, LLVM_Hs_FloatABI v) {
-  to->FloatABIType = unwrap(v);
+    to->FloatABIType = unwrap(v);
 }
 
 LLVM_Hs_FloatABI LLVM_Hs_GetFloatABIType(TargetOptions *to) {
-  return wrap(to->FloatABIType);
+    return wrap(to->FloatABIType);
 }
 
-void LLVM_Hs_SetAllowFPOpFusion(TargetOptions *to,
-                                     LLVM_Hs_FPOpFusionMode v) {
-  to->AllowFPOpFusion = unwrap(v);
+void LLVM_Hs_SetAllowFPOpFusion(TargetOptions *to, LLVM_Hs_FPOpFusionMode v) {
+    to->AllowFPOpFusion = unwrap(v);
 }
 
 LLVM_Hs_FPOpFusionMode LLVM_Hs_GetAllowFPOpFusion(TargetOptions *to) {
-  return wrap(to->AllowFPOpFusion);
+    return wrap(to->AllowFPOpFusion);
 }
 
 void LLVM_Hs_DisposeTargetOptions(TargetOptions *t) { delete t; }
@@ -231,125 +235,158 @@ void LLVM_Hs_DisposeTargetOptions(TargetOptions *t) { delete t; }
 // }
 
 char *LLVM_Hs_GetDefaultTargetTriple() {
-  return strdup(sys::getDefaultTargetTriple().c_str());
+    return strdup(sys::getDefaultTargetTriple().c_str());
 }
 
 char *LLVM_Hs_GetProcessTargetTriple() {
-  return strdup(sys::getProcessTriple().c_str());
+    return strdup(sys::getProcessTriple().c_str());
 }
 
 const char *LLVM_Hs_GetHostCPUName(size_t &len) {
-  StringRef r = sys::getHostCPUName();
-  len = r.size();
-  return r.data();
+    StringRef r = sys::getHostCPUName();
+    len = r.size();
+    return r.data();
 }
 
 char *LLVM_Hs_GetHostCPUFeatures() {
-  StringMap<bool> featureMap;
-  std::string features;
-  if (sys::getHostCPUFeatures(featureMap)) {
-    bool first = true;
-    for (llvm::StringMap<bool>::const_iterator it = featureMap.begin();
-         it != featureMap.end(); ++it) {
-      if (!first) {
-        features += ",";
-      }
-      first = false;
-      features += (it->second ? "+" : "-") + it->first().str();
+    StringMap<bool> featureMap;
+    std::string features;
+    if (sys::getHostCPUFeatures(featureMap)) {
+        bool first = true;
+        for (llvm::StringMap<bool>::const_iterator it = featureMap.begin();
+             it != featureMap.end(); ++it) {
+            if (!first) {
+                features += ",";
+            }
+            first = false;
+            features += (it->second ? "+" : "-") + it->first().str();
+        }
     }
-  }
-  return strdup(features.c_str());
+    return strdup(features.c_str());
 }
 
 char *LLVM_Hs_GetTargetMachineDataLayout(LLVMTargetMachineRef t) {
-  return strdup(
-      unwrap(t)->createDataLayout().getStringRepresentation().c_str());
+    return strdup(
+        unwrap(t)->createDataLayout().getStringRepresentation().c_str());
 }
 
-LLVMTargetLibraryInfoRef
-LLVM_Hs_CreateTargetLibraryInfo(const char *triple) {
-    const TargetLibraryInfoImpl* p = new TargetLibraryInfoImpl(Triple(triple));
+LLVMTargetLibraryInfoRef LLVM_Hs_CreateTargetLibraryInfo(const char *triple) {
+    const TargetLibraryInfoImpl *p = new TargetLibraryInfoImpl(Triple(triple));
     return wrap(p);
 }
 
-LLVMBool LLVM_Hs_GetLibFunc(
-	LLVMTargetLibraryInfoRef l,
-	const char *funcName,
-	LLVMLibFunc *f
-) {
-	LibFunc func;
-	LLVMBool result = unwrap(l)->getLibFunc(funcName, func);
-	*f = wrap(func);
-	return result;
+LLVMBool LLVM_Hs_GetLibFunc(LLVMTargetLibraryInfoRef l, const char *funcName,
+                            LLVMLibFunc *f) {
+    LibFunc func;
+    LLVMBool result = unwrap(l)->getLibFunc(funcName, func);
+    *f = wrap(func);
+    return result;
 }
 
-const char *LLVM_Hs_LibFuncGetName(
-	LLVMTargetLibraryInfoRef l,
-	LLVMLibFunc f,
-	size_t *nameSize
-) {
-	TargetLibraryInfo impl(*unwrap(l));
+const char *LLVM_Hs_LibFuncGetName(LLVMTargetLibraryInfoRef l, LLVMLibFunc f,
+                                   size_t *nameSize) {
+    TargetLibraryInfo impl(*unwrap(l));
     StringRef s = impl.getName(unwrap(f));
-	*nameSize = s.size();
-	return s.data();
+    *nameSize = s.size();
+    return s.data();
 }
 
-void LLVM_Hs_LibFuncSetAvailableWithName(
-	LLVMTargetLibraryInfoRef l,
-	LLVMLibFunc f,
-	const char *name
-) {
-	unwrap(l)->setAvailableWithName(unwrap(f), name);
+void LLVM_Hs_LibFuncSetAvailableWithName(LLVMTargetLibraryInfoRef l,
+                                         LLVMLibFunc f, const char *name) {
+    unwrap(l)->setAvailableWithName(unwrap(f), name);
 }
 
 void LLVM_Hs_DisposeTargetLibraryInfo(LLVMTargetLibraryInfoRef l) {
-	delete unwrap(l);
+    delete unwrap(l);
 }
 
 void LLVM_Hs_InitializeAllTargets() {
-  InitializeAllTargetInfos();
-  InitializeAllTargets();
-  InitializeAllTargetMCs();
-  InitializeAllAsmPrinters();
-  // None of the other components are bound yet
+    InitializeAllTargetInfos();
+    InitializeAllTargets();
+    InitializeAllTargetMCs();
+    InitializeAllAsmPrinters();
+    // None of the other components are bound yet
 }
 
-// This is identical to LLVMTargetMachineEmit but LLVM doesn’t expose this function so we copy it here.
-LLVMBool LLVM_Hs_TargetMachineEmit(
-    LLVMTargetMachineRef T,
-    LLVMModuleRef M,
-    raw_pwrite_stream *OS,
-    LLVMCodeGenFileType codegen,
-    char **ErrorMessage
-) {
-  TargetMachine* TM = unwrap(T);
-  Module* Mod = unwrap(M);
-
-  legacy::PassManager pass;
-
-  std::string error;
-
-  Mod->setDataLayout(TM->createDataLayout());
-
-  TargetMachine::CodeGenFileType ft;
-  switch (codegen) {
-    case LLVMAssemblyFile:
-      ft = TargetMachine::CGFT_AssemblyFile;
-      break;
+LLVMTargetMachineRef
+LLVM_Hs_CreateTargetMachine(LLVMTargetRef T, const char *Triple,
+                            const char *CPU, const char *Features,
+                            TargetOptions *TO, LLVMCodeGenOptLevel Level,
+                            LLVMRelocMode Reloc, LLVMCodeModel CodeModel) {
+    Optional<Reloc::Model> RM;
+    switch (Reloc) {
+    case LLVMRelocStatic:
+        RM = Reloc::Static;
+        break;
+    case LLVMRelocPIC:
+        RM = Reloc::PIC_;
+        break;
+    case LLVMRelocDynamicNoPic:
+        RM = Reloc::DynamicNoPIC;
+        break;
     default:
-      ft = TargetMachine::CGFT_ObjectFile;
-      break;
-  }
-  if (TM->addPassesToEmitFile(pass, *OS, ft)) {
-    error = "TargetMachine can't emit a file of this type";
-    *ErrorMessage = strdup(error.c_str());
-    return true;
-  }
+        break;
+    }
 
-  pass.run(*Mod);
+    CodeModel::Model CM = unwrap(CodeModel);
 
-  OS->flush();
-  return false;
+    CodeGenOpt::Level OL;
+    switch (Level) {
+    case LLVMCodeGenLevelNone:
+        OL = CodeGenOpt::None;
+        break;
+    case LLVMCodeGenLevelLess:
+        OL = CodeGenOpt::Less;
+        break;
+    case LLVMCodeGenLevelAggressive:
+        OL = CodeGenOpt::Aggressive;
+        break;
+    default:
+        OL = CodeGenOpt::Default;
+        break;
+    }
+
+    return wrap(
+        unwrap(T)->createTargetMachine(Triple, CPU, Features, *TO, RM, CM, OL));
 }
 
+TargetOptions *LLVM_Hs_TargetMachineOptions(LLVMTargetMachineRef TM) {
+    return &unwrap(TM)->Options;
+}
+
+// This is identical to LLVMTargetMachineEmit but LLVM doesn’t expose this
+// function so we copy it here.
+LLVMBool LLVM_Hs_TargetMachineEmit(LLVMTargetMachineRef T, LLVMModuleRef M,
+                                   raw_pwrite_stream *OS,
+                                   LLVMCodeGenFileType codegen,
+                                   char **ErrorMessage) {
+    TargetMachine *TM = unwrap(T);
+    Module *Mod = unwrap(M);
+
+    legacy::PassManager pass;
+
+    std::string error;
+
+    Mod->setDataLayout(TM->createDataLayout());
+
+    TargetMachine::CodeGenFileType ft;
+    switch (codegen) {
+    case LLVMAssemblyFile:
+        ft = TargetMachine::CGFT_AssemblyFile;
+        break;
+    default:
+        ft = TargetMachine::CGFT_ObjectFile;
+        break;
+    }
+    if (TM->addPassesToEmitFile(pass, *OS, ft)) {
+        error = "TargetMachine can't emit a file of this type";
+        *ErrorMessage = strdup(error.c_str());
+        return true;
+    }
+
+    pass.run(*Mod);
+
+    OS->flush();
+    return false;
+}
 }

--- a/llvm-hs/src/LLVM/Internal/Target.hs
+++ b/llvm-hs/src/LLVM/Internal/Target.hs
@@ -225,6 +225,9 @@ withTargetMachine
       FFI.disposeTargetMachine
       . (. TargetMachine)
 
+targetMachineOptions :: TargetMachine -> IO TargetOptions
+targetMachineOptions (TargetMachine tm) = TargetOptions <$> FFI.targetMachineOptions tm
+
 -- | <http://llvm.org/doxygen/classllvm_1_1TargetLowering.html>
 newtype TargetLowering = TargetLowering (Ptr FFI.TargetLowering)
 

--- a/llvm-hs/src/LLVM/Target.hs
+++ b/llvm-hs/src/LLVM/Target.hs
@@ -7,7 +7,7 @@ module LLVM.Target (
    Target, TargetMachine, TargetLowering,
    CPUFeature(..),
    withTargetOptions, peekTargetOptions, pokeTargetOptions,
-   withTargetMachine, withHostTargetMachine,
+   withTargetMachine, withHostTargetMachine, targetMachineOptions,
    getTargetLowering,
    getTargetMachineTriple, getDefaultTargetTriple, getProcessTargetTriple, getHostCPUName, getHostCPUFeatures,
    getTargetMachineDataLayout, initializeNativeTarget, initializeAllTargets,

--- a/llvm-hs/test/LLVM/Test/Module.hs
+++ b/llvm-hs/test/LLVM/Test/Module.hs
@@ -274,6 +274,8 @@ tests = testGroup "Module" [
             \main:\n\
             \\t.cfi_startproc\n\
             \\txorl\t%eax, %eax\n\
+            \\tmovl\t%edi, -4(%rsp)\n\
+            \\tmovq\t%rsi, -16(%rsp)\n\
             \\tretq\n\
             \.Lfunc_end0:\n\
             \\t.size\tmain, .Lfunc_end0-main\n\


### PR DESCRIPTION
fixes #141 

Turns out `withTargetMachine` simply ignored `TargetOptions`. I’m a bit scared that this went unnoticed for so long :/