### PR TITLE
Add missing target options (except MCOptions)

### DIFF
--- a/llvm-hs/src/LLVM/Internal/FFI/LLVMCTypes.hsc
+++ b/llvm-hs/src/LLVM/Internal/FFI/LLVMCTypes.hsc
@@ -220,6 +220,31 @@ newtype FPOpFusionMode = FPOpFusionMode CUInt
 #define FPOFM_Rec(n) { #n, LLVM_Hs_FPOpFusionMode_ ## n },
 #{inject FP_OP_FUSION_MODE, FPOpFusionMode, FPOpFusionMode, fpOpFusionMode, FPOFM_Rec}
 
+newtype ThreadModel = ThreadModel CUInt
+  deriving (Eq, Read, Show, Typeable, Data, Generic)
+#define TM_Rec(n) { #n, LLVM_Hs_ThreadModel_ ## n },
+#{inject THREAD_MODEL, ThreadModel, ThreadModel, threadModel, TM_Rec}
+
+newtype EABI = EABI CUInt
+  deriving (Eq, Read, Show, Typeable, Data, Generic)
+#define EABI_Rec(n) { #n, LLVM_Hs_EABI_ ## n },
+#{inject EABI, EABI, EABI, eabiVersion, EABI_Rec}
+
+newtype DebuggerKind = DebuggerKind CUInt
+  deriving (Eq, Read, Show, Typeable, Data, Generic)
+#define DBGK_Rec(n) { #n, LLVM_Hs_DebuggerKind_ ## n },
+#{inject DEBUGGER_KIND, DebuggerKind, DebuggerKind, debuggerKind, DBGK_Rec}
+
+newtype FPDenormalMode = FPDenormalMode CUInt
+  deriving (Eq, Read, Show, Typeable, Data, Generic)
+#define FPDM_Rec(n) { #n, LLVM_Hs_FPDenormalMode_ ## n },
+#{inject FP_DENORMAL_MODE, FPDenormalMode, FPDenormalMode, fpDenormalMode, FPDM_Rec}
+
+newtype ExceptionHandling = ExceptionHandling CUInt
+  deriving (Eq, Read, Show, Typeable, Data, Generic)
+#define EH_Rec(n) { #n, LLVM_Hs_ExceptionHandling_ ## n },
+#{inject EXCEPTION_HANDLING, ExceptionHandling, ExceptionHandling, exceptionHandling, EH_Rec}
+
 newtype TargetOptionFlag = TargetOptionFlag CUInt
   deriving (Eq, Read, Show, Typeable, Data, Generic)
 #define TOF_Rec(n) { #n, LLVM_Hs_TargetOptionFlag_ ## n },

--- a/llvm-hs/src/LLVM/Internal/FFI/Target.h
+++ b/llvm-hs/src/LLVM/Internal/FFI/Target.h
@@ -30,13 +30,22 @@
 	macro(UnsafeFPMath)																		\
 	macro(NoInfsFPMath)																		\
 	macro(NoNaNsFPMath)																		\
+	macro(NoTrappingFPMath)                               \
+	macro(NoSignedZerosFPMath)                            \
 	macro(HonorSignDependentRoundingFPMathOption)					\
 	macro(NoZerosInBSS)																		\
 	macro(GuaranteedTailCallOpt)													\
+	macro(StackSymbolOrdering)                            \
 	macro(EnableFastISel)																	\
 	macro(UseInitArray)																		\
 	macro(DisableIntegratedAS)														\
-	macro(TrapUnreachable)
+	macro(RelaxELFRelocations)                            \
+	macro(FunctionSections)                               \
+	macro(DataSections)                                   \
+	macro(UniqueSectionNames)                             \
+	macro(TrapUnreachable)                                \
+	macro(EmulatedTLS)                                    \
+	macro(EnableIPRA)
 
 typedef enum {
 #define ENUM_CASE(n) LLVM_Hs_TargetOptionFlag_ ## n,
@@ -76,5 +85,64 @@ typedef enum {
 	LLVM_HS_FOR_EACH_FP_OP_FUSION_MODE(ENUM_CASE)
 #undef ENUM_CASE
 } LLVM_Hs_FPOpFusionMode;
+
+#define LLVM_HS_FOR_EACH_THREAD_MODEL(macro) \
+	macro(POSIX) \
+	macro(Single)
+
+typedef enum {
+#define ENUM_CASE(n) LLVM_Hs_ThreadModel_ ## n,
+	LLVM_HS_FOR_EACH_THREAD_MODEL(ENUM_CASE)
+#undef ENUM_CASE
+} LLVM_Hs_ThreadModel;
+
+#define LLVM_HS_FOR_EACH_EABI(macro) \
+	macro(Unknown)																				\
+	macro(Default)																				\
+	macro(EABI4)																					\
+	macro(EABI5)																					\
+	macro(GNU)
+
+typedef enum {
+#define ENUM_CASE(n) LLVM_Hs_EABI_ ## n,
+	LLVM_HS_FOR_EACH_EABI(ENUM_CASE)
+#undef ENUM_CASE
+} LLVM_Hs_EABI;
+
+#define LLVM_HS_FOR_EACH_DEBUGGER_KIND(macro) \
+	macro(Default)																				\
+	macro(GDB)																						\
+	macro(LLDB)																						\
+	macro(SCE)
+
+typedef enum {
+#define ENUM_CASE(n) LLVM_Hs_DebuggerKind_ ## n,
+	LLVM_HS_FOR_EACH_DEBUGGER_KIND(ENUM_CASE)
+#undef ENUM_CASE
+} LLVM_Hs_DebuggerKind;
+
+#define LLVM_HS_FOR_EACH_FP_DENORMAL_MODE(macro) \
+	macro(IEEE)																						\
+	macro(PreserveSign)																		\
+	macro(PositiveZero)
+
+typedef enum {
+#define ENUM_CASE(n) LLVM_Hs_FPDenormalMode_ ## n,
+	LLVM_HS_FOR_EACH_FP_DENORMAL_MODE(ENUM_CASE)
+#undef ENUM_CASE
+} LLVM_Hs_FPDenormalMode;
+
+#define LLVM_HS_FOR_EACH_EXCEPTION_HANDLING(macro) \
+	macro(None)																						\
+	macro(DwarfCFI)																				\
+	macro(SjLj)																						\
+	macro(ARM)																						\
+	macro(WinEH)
+
+typedef enum {
+#define ENUM_CASE(n) LLVM_Hs_ExceptionHandling_ ## n,
+	LLVM_HS_FOR_EACH_EXCEPTION_HANDLING(ENUM_CASE)
+#undef ENUM_CASE
+} LLVM_Hs_ExceptionHandling;
 
 #endif

--- a/llvm-hs/src/LLVM/Internal/FFI/Target.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Target.hs
@@ -58,6 +58,36 @@ foreign import ccall unsafe "LLVM_Hs_SetAllowFPOpFusion" setAllowFPOpFusion ::
 foreign import ccall unsafe "LLVM_Hs_GetAllowFPOpFusion" getAllowFPOpFusion ::
   Ptr TargetOptions -> IO FPOpFusionMode
 
+foreign import ccall unsafe "LLVM_Hs_SetThreadModel" setThreadModel ::
+  Ptr TargetOptions -> ThreadModel -> IO ()
+
+foreign import ccall unsafe "LLVM_Hs_GetThreadModel" getThreadModel ::
+  Ptr TargetOptions -> IO ThreadModel
+
+foreign import ccall unsafe "LLVM_Hs_SetEABIVersion" setEABIVersion ::
+  Ptr TargetOptions -> EABI -> IO ()
+
+foreign import ccall unsafe "LLVM_Hs_GetEABIVersion" getEABIVersion ::
+  Ptr TargetOptions -> IO EABI
+
+foreign import ccall unsafe "LLVM_Hs_SetDebuggerTuning" setDebuggerTuning ::
+  Ptr TargetOptions -> DebuggerKind -> IO ()
+
+foreign import ccall unsafe "LLVM_Hs_GetDebuggerTuning" getDebuggerTuning ::
+  Ptr TargetOptions -> IO DebuggerKind
+
+foreign import ccall unsafe "LLVM_Hs_SetFPDenormalMode" setFPDenormalMode ::
+  Ptr TargetOptions -> FPDenormalMode -> IO ()
+
+foreign import ccall unsafe "LLVM_Hs_GetFPDenormalMode" getFPDenormalMode ::
+  Ptr TargetOptions -> IO FPDenormalMode
+
+foreign import ccall unsafe "LLVM_Hs_SetExceptionModel" setExceptionModel ::
+  Ptr TargetOptions -> ExceptionHandling -> IO ()
+
+foreign import ccall unsafe "LLVM_Hs_GetExceptionModel" getExceptionModel ::
+  Ptr TargetOptions -> IO ExceptionHandling
+
 foreign import ccall unsafe "LLVM_Hs_DisposeTargetOptions" disposeTargetOptions ::
   Ptr TargetOptions -> IO ()
 

--- a/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
@@ -110,6 +110,125 @@ static LLVM_Hs_FPOpFusionMode wrap(FPOpFusion::FPOpFusionMode x) {
         return LLVM_Hs_FPOpFusionMode(0);
     }
 }
+
+static ThreadModel::Model unwrap(LLVM_Hs_ThreadModel x) {
+    switch (x) {
+#define ENUM_CASE(x)                                                           \
+    case LLVM_Hs_ThreadModel_##x:                                              \
+        return ThreadModel::x;
+        LLVM_HS_FOR_EACH_THREAD_MODEL(ENUM_CASE)
+#undef ENUM_CASE
+    default:
+        return ThreadModel::Model(0);
+    }
+}
+
+static LLVM_Hs_ThreadModel wrap(ThreadModel::Model x) {
+    switch (x) {
+#define ENUM_CASE(x)                                                           \
+    case ThreadModel::x:                                                       \
+        return LLVM_Hs_ThreadModel_##x;
+        LLVM_HS_FOR_EACH_THREAD_MODEL(ENUM_CASE)
+#undef ENUM_CASE
+    default:
+        return LLVM_Hs_ThreadModel(0);
+    }
+}
+static EABI unwrap(LLVM_Hs_EABI x) {
+    switch (x) {
+#define ENUM_CASE(x)                                                           \
+    case LLVM_Hs_EABI_##x:                                                     \
+        return EABI::x;
+        LLVM_HS_FOR_EACH_EABI(ENUM_CASE)
+#undef ENUM_CASE
+    default:
+        return EABI(0);
+    }
+}
+
+static LLVM_Hs_EABI wrap(EABI x) {
+    switch (x) {
+#define ENUM_CASE(x)                                                           \
+    case EABI::x:                                                              \
+        return LLVM_Hs_EABI_##x;
+        LLVM_HS_FOR_EACH_EABI(ENUM_CASE)
+#undef ENUM_CASE
+    default:
+        return LLVM_Hs_EABI(0);
+    }
+}
+
+static DebuggerKind unwrap(LLVM_Hs_DebuggerKind x) {
+    switch (x) {
+#define ENUM_CASE(x)                                                           \
+    case LLVM_Hs_DebuggerKind_##x:                                             \
+      return DebuggerKind::x;
+      LLVM_HS_FOR_EACH_DEBUGGER_KIND(ENUM_CASE)
+#undef ENUM_CASE
+    default:
+      return DebuggerKind(0);
+    }
+}
+
+static LLVM_Hs_DebuggerKind wrap(DebuggerKind x) {
+    switch (x) {
+#define ENUM_CASE(x)                                                           \
+    case DebuggerKind::x:                                                      \
+        return LLVM_Hs_DebuggerKind_##x;
+        LLVM_HS_FOR_EACH_DEBUGGER_KIND(ENUM_CASE)
+#undef ENUM_CASE
+    default:
+        return LLVM_Hs_DebuggerKind(0);
+    }
+}
+
+static FPDenormal::DenormalMode unwrap(LLVM_Hs_FPDenormalMode x) {
+    switch (x) {
+#define ENUM_CASE(x)                                                           \
+    case LLVM_Hs_FPDenormalMode_##x:                                           \
+        return FPDenormal::x;
+        LLVM_HS_FOR_EACH_FP_DENORMAL_MODE(ENUM_CASE)
+#undef ENUM_CASE
+    default:
+        return FPDenormal::DenormalMode(0);
+    }
+}
+
+static LLVM_Hs_FPDenormalMode wrap(FPDenormal::DenormalMode x) {
+    switch (x) {
+#define ENUM_CASE(x)                                                           \
+    case FPDenormal::x:                                                        \
+        return LLVM_Hs_FPDenormalMode_##x;
+        LLVM_HS_FOR_EACH_FP_DENORMAL_MODE(ENUM_CASE)
+#undef ENUM_CASE
+    default:
+        return LLVM_Hs_FPDenormalMode(0);
+    }
+}
+static ExceptionHandling unwrap(LLVM_Hs_ExceptionHandling x) {
+    switch (x) {
+#define ENUM_CASE(x)                                                           \
+    case LLVM_Hs_ExceptionHandling_##x:                                        \
+        return ExceptionHandling::x;
+        LLVM_HS_FOR_EACH_EXCEPTION_HANDLING(ENUM_CASE)
+#undef ENUM_CASE
+    default:
+        return ExceptionHandling(0);
+    }
+}
+
+static LLVM_Hs_ExceptionHandling wrap(ExceptionHandling x) {
+    switch (x) {
+#define ENUM_CASE(x)                                                           \
+    case ExceptionHandling::x:                                                 \
+        return LLVM_Hs_ExceptionHandling_##x;
+        LLVM_HS_FOR_EACH_EXCEPTION_HANDLING(ENUM_CASE)
+#undef ENUM_CASE
+    default:
+        return LLVM_Hs_ExceptionHandling(0);
+    }
+}
+
 } // namespace llvm
 
 extern "C" {
@@ -225,6 +344,46 @@ void LLVM_Hs_SetAllowFPOpFusion(TargetOptions *to, LLVM_Hs_FPOpFusionMode v) {
 
 LLVM_Hs_FPOpFusionMode LLVM_Hs_GetAllowFPOpFusion(TargetOptions *to) {
     return wrap(to->AllowFPOpFusion);
+}
+
+void LLVM_Hs_SetThreadModel(TargetOptions *to, LLVM_Hs_ThreadModel v) {
+    to->ThreadModel = unwrap(v);
+}
+
+LLVM_Hs_ThreadModel LLVM_Hs_GetThreadModel(TargetOptions *to) {
+    return wrap(to->ThreadModel);
+}
+
+void LLVM_Hs_SetEABIVersion(TargetOptions *to, LLVM_Hs_EABI v) {
+    to->EABIVersion = unwrap(v);
+}
+
+LLVM_Hs_EABI LLVM_Hs_GetEABIVersion(TargetOptions *to) {
+    return wrap(to->EABIVersion);
+}
+
+void LLVM_Hs_SetDebuggerTuning(TargetOptions *to, LLVM_Hs_DebuggerKind v) {
+    to->DebuggerTuning = unwrap(v);
+}
+
+LLVM_Hs_DebuggerKind LLVM_Hs_GetDebuggerTuning(TargetOptions *to) {
+    return wrap(to->DebuggerTuning);
+}
+
+void LLVM_Hs_SetFPDenormalMode(TargetOptions *to, LLVM_Hs_FPDenormalMode v) {
+    to->FPDenormalMode = unwrap(v);
+}
+
+LLVM_Hs_FPDenormalMode LLVM_Hs_GetFPDenormalMode(TargetOptions *to) {
+    return wrap(to->FPDenormalMode);
+}
+
+void LLVM_Hs_SetExceptionModel(TargetOptions *to, LLVM_Hs_ExceptionHandling v) {
+    to->ExceptionModel = unwrap(v);
+}
+
+LLVM_Hs_ExceptionHandling LLVM_Hs_GetExceptionModel(TargetOptions *to) {
+    return wrap(to->ExceptionModel);
 }
 
 void LLVM_Hs_DisposeTargetOptions(TargetOptions *t) { delete t; }

--- a/llvm-hs/src/LLVM/Target/Options.hs
+++ b/llvm-hs/src/LLVM/Target/Options.hs
@@ -24,6 +24,45 @@ data DebugCompressionType
   | CompressZ -- ^ zlib style compression
   deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data, Generic)
 
+-- | <http://llvm.org/doxygen/namespacellvm_1_1ThreadModel.html#a299c775d35e28348ecfbe03c38c17fe1>
+data ThreadModel
+  = ThreadModelPOSIX
+  | ThreadModelSingle
+  deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data, Generic)
+
+-- | <http://llvm.org/doxygen/namespacellvm.html#adc04b17f40513e658e600a26842b1ed6>
+data DebuggerKind
+  = DebuggerDefault
+  | DebuggerGDB
+  | DebuggerLLDB
+  | DebuggerSCE
+  deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data, Generic)
+
+-- | <http://llvm.org/doxygen/namespacellvm.html#ada924e855250645672a493841803ff91>
+data EABIVersion
+  = EABIVersionUnknown
+  | EABIVersionDefault
+  | EABIVersion4
+  | EABIVersion5
+  | EABIVersionGNU
+  deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data, Generic)
+
+-- | <http://llvm.org/doxygen/namespacellvm_1_1FPDenormal.html#aa0e896c04e0537cf6d0926f3c8db6d6c>
+data FloatingPointDenormalMode
+  = FloatingPointDenormalIEEE -- ^ IEEE 754 denormal numbers
+  | FloatingPointDenormalPreserveSign -- ^ The sign of a flushed-to-zero number is preserved in the sign of 0
+  | FloatingPointDenormalPositiveZero -- ^ Denormals are flushed to positive zero
+  deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data, Generic)
+
+-- | <http://llvm.org/doxygen/namespacellvm.html#a2ca3855108426698ff21517a7c884c84>
+data ExceptionHandling
+  = ExceptionHandlingNone -- ^ No exception support
+  | ExceptionHandlingDwarfCFI -- ^ DWARF-like instruction based exceptions
+  | ExceptionHandlingSjLj -- ^ setjmp/longjmp based exceptions
+  | ExceptionHandlingARM -- ^ ARM EHABI
+  | ExceptionHandlingWinEH -- ^ Windows Exception Handling
+  deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data, Generic)
+
 -- | The options of a 'LLVM.Target.TargetOptions'
 -- <http://llvm.org/doxygen/classllvm_1_1TargetOptions.html>
 data Options = Options {
@@ -31,17 +70,30 @@ data Options = Options {
   unsafeFloatingPointMath :: Bool,
   noInfinitiesFloatingPointMath :: Bool,
   noNaNsFloatingPointMath :: Bool,
+  noTrappingFloatingPointMath :: Bool,
+  noSignedZeroesFloatingPointMath :: Bool,
   honorSignDependentRoundingFloatingPointMathOption :: Bool,
   noZerosInBSS :: Bool,
   guaranteedTailCallOptimization :: Bool,
+  stackSymbolOrdering :: Bool,
   enableFastInstructionSelection :: Bool,
   useInitArray :: Bool,
   disableIntegratedAssembler :: Bool,
   compressDebugSections :: DebugCompressionType,
+  relaxELFRelocations :: Bool,
+  functionSections :: Bool,
+  dataSections :: Bool,
+  uniqueSectionNames :: Bool,
   trapUnreachable :: Bool,
+  emulatedThreadLocalStorage :: Bool,
+  enableInterProceduralRegisterAllocation :: Bool,
   stackAlignmentOverride :: Word32,
   floatABIType :: FloatABI,
-  allowFloatingPointOperationFusion :: FloatingPointOperationFusionMode
+  allowFloatingPointOperationFusion :: FloatingPointOperationFusionMode,
+  threadModel :: ThreadModel,
+  eabiVersion :: EABIVersion,
+  debuggerTuning :: DebuggerKind,
+  floatingPointDenormalMode :: FloatingPointDenormalMode,
+  exceptionModel :: ExceptionHandling
   }
   deriving (Eq, Ord, Read, Show)
-

--- a/llvm-hs/test/LLVM/Test/Target.hs
+++ b/llvm-hs/test/LLVM/Test/Target.hs
@@ -37,23 +37,52 @@ instance Arbitrary FloatABI where
 instance Arbitrary FloatingPointOperationFusionMode where
   arbitrary = elements [minBound .. maxBound]
 
+instance Arbitrary ThreadModel where
+  arbitrary = elements [minBound .. maxBound]
+
+instance Arbitrary EABIVersion where
+  arbitrary = elements [minBound .. maxBound]
+
+instance Arbitrary DebuggerKind where
+  arbitrary = elements [minBound .. maxBound]
+
+instance Arbitrary FloatingPointDenormalMode where
+  arbitrary = elements [minBound .. maxBound]
+
+instance Arbitrary ExceptionHandling where
+  arbitrary = elements [minBound .. maxBound]
+
 instance Arbitrary Options where
   arbitrary = do
     printMachineCode <- arbitrary
     unsafeFloatingPointMath <- arbitrary
     noInfinitiesFloatingPointMath <- arbitrary
     noNaNsFloatingPointMath <- arbitrary
+    noTrappingFloatingPointMath <- arbitrary
+    noSignedZeroesFloatingPointMath <- arbitrary
     honorSignDependentRoundingFloatingPointMathOption <- arbitrary
     noZerosInBSS <- arbitrary
     guaranteedTailCallOptimization <- arbitrary
+    stackSymbolOrdering <- arbitrary
     enableFastInstructionSelection <- arbitrary
     useInitArray <- arbitrary
     disableIntegratedAssembler <- arbitrary
     compressDebugSections <- arbitrary
+    relaxELFRelocations <- arbitrary
+    functionSections <- arbitrary
+    dataSections <- arbitrary
+    uniqueSectionNames <- arbitrary
     trapUnreachable <- arbitrary
+    emulatedThreadLocalStorage <- arbitrary
+    enableInterProceduralRegisterAllocation <- arbitrary
     stackAlignmentOverride <- arbitrary
     floatABIType <- arbitrary
     allowFloatingPointOperationFusion <- arbitrary
+    threadModel <- arbitrary
+    eabiVersion <- arbitrary
+    debuggerTuning <- arbitrary
+    floatingPointDenormalMode <- arbitrary
+    exceptionModel <- arbitrary
     return Options { .. }
 
 instance Arbitrary DebugCompressionType where


### PR DESCRIPTION
This patch adds all missing simple fields of TargetOptions structure as of LLVM 5. The only remaining one is MCOptions that is a separate structure and needs more work.