### PR TITLE
Add support for MCOption flags of target options

### DIFF
--- a/llvm-hs/src/LLVM/Internal/FFI/LLVMCTypes.hsc
+++ b/llvm-hs/src/LLVM/Internal/FFI/LLVMCTypes.hsc
@@ -250,6 +250,11 @@ newtype TargetOptionFlag = TargetOptionFlag CUInt
 #define TOF_Rec(n) { #n, LLVM_Hs_TargetOptionFlag_ ## n },
 #{inject TARGET_OPTION_FLAG, TargetOptionFlag, TargetOptionFlag, targetOptionFlag, TOF_Rec}
 
+newtype MCTargetOptionFlag = MCTargetOptionFlag CUInt
+  deriving (Eq, Read, Show, Typeable, Data, Generic)
+#define MCTOF_Rec(n) { #n, LLVM_Hs_MCTargetOptionFlag_ ## n },
+#{inject MC_TARGET_OPTION_FLAG, MCTargetOptionFlag, MCTargetOptionFlag, mcTargetOptionFlag, MCTOF_Rec}
+
 newtype DebugCompressionType = DebugCompressionType CUInt
   deriving (Eq, Read, Show, Typeable, Data, Generic)
 #define DCT_Rec(n) { #n, LLVM_Hs_DebugCompressionType_ ## n },

--- a/llvm-hs/src/LLVM/Internal/FFI/Target.h
+++ b/llvm-hs/src/LLVM/Internal/FFI/Target.h
@@ -53,6 +53,28 @@ typedef enum {
 #undef ENUM_CASE
 } LLVM_Hs_TargetOptionFlag;
 
+#define LLVM_HS_FOR_EACH_MC_TARGET_OPTION_FLAG(macro)  \
+  macro(SanitizeAddress)                                \
+  macro(MCRelaxAll)                                     \
+  macro(MCNoExecStack)                                  \
+  macro(MCFatalWarnings)                                \
+  macro(MCNoWarn)                                       \
+  macro(MCNoDeprecatedWarn)                             \
+  macro(MCSaveTempLabels)                               \
+  macro(MCUseDwarfDirectory)                            \
+  macro(MCIncrementalLinkerCompatible)                  \
+  macro(MCPIECopyRelocations)                           \
+  macro(ShowMCEncoding)                                 \
+  macro(ShowMCInst)                                     \
+  macro(AsmVerbose)                                     \
+  macro(PreserveAsmComments)
+
+typedef enum {
+#define ENUM_CASE(n) LLVM_Hs_MCTargetOptionFlag_ ## n,
+  LLVM_HS_FOR_EACH_MC_TARGET_OPTION_FLAG(ENUM_CASE)
+#undef ENUM_CASE
+} LLVM_Hs_MCTargetOptionFlag;
+
 #define LLVM_HS_FOR_EACH_DEBUG_COMPRESSION_TYPE(macro) \
     macro(None) \
     macro(GNU) \

--- a/llvm-hs/src/LLVM/Internal/FFI/Target.h
+++ b/llvm-hs/src/LLVM/Internal/FFI/Target.h
@@ -1,55 +1,55 @@
 #ifndef __LLVM_INTERNAL_FFI__TARGET__H__
 #define __LLVM_INTERNAL_FFI__TARGET__H__
 
-#define LLVM_HS_FOR_EACH_RELOC_MODEL(macro)	\
-	macro(Default, Default)													\
-	macro(Static, Static)														\
-	macro(PIC, PIC_)																\
-	macro(DynamicNoPic, DynamicNoPIC)
+#define LLVM_HS_FOR_EACH_RELOC_MODEL(macro) \
+  macro(Default, Default)                         \
+  macro(Static, Static)                           \
+  macro(PIC, PIC_)                                \
+  macro(DynamicNoPic, DynamicNoPIC)
 
 #define LLVM_HS_FOR_EACH_CODE_MODEL(macro) \
-	macro(Default)																\
-	macro(JITDefault)															\
-	macro(Small)																	\
-	macro(Kernel)																	\
-	macro(Medium)																	\
-	macro(Large)
+  macro(Default)                                \
+  macro(JITDefault)                             \
+  macro(Small)                                  \
+  macro(Kernel)                                 \
+  macro(Medium)                                 \
+  macro(Large)
 
 #define LLVM_HS_FOR_EACH_CODE_GEN_OPT_LEVEL(macro) \
-	macro(None)																						\
-	macro(Less)																						\
-	macro(Default)																				\
-	macro(Aggressive)
+  macro(None)                                           \
+  macro(Less)                                           \
+  macro(Default)                                        \
+  macro(Aggressive)
 
-#define LLVM_HS_FOR_EACH_CODE_GEN_FILE_TYPE(macro)	\
-	macro(Assembly)                                       \
-	macro(Object)
+#define LLVM_HS_FOR_EACH_CODE_GEN_FILE_TYPE(macro)  \
+  macro(Assembly)                                       \
+  macro(Object)
 
-#define LLVM_HS_FOR_EACH_TARGET_OPTION_FLAG(macro)	\
-	macro(PrintMachineCode)																\
-	macro(UnsafeFPMath)																		\
-	macro(NoInfsFPMath)																		\
-	macro(NoNaNsFPMath)																		\
-	macro(NoTrappingFPMath)                               \
-	macro(NoSignedZerosFPMath)                            \
-	macro(HonorSignDependentRoundingFPMathOption)					\
-	macro(NoZerosInBSS)																		\
-	macro(GuaranteedTailCallOpt)													\
-	macro(StackSymbolOrdering)                            \
-	macro(EnableFastISel)																	\
-	macro(UseInitArray)																		\
-	macro(DisableIntegratedAS)														\
-	macro(RelaxELFRelocations)                            \
-	macro(FunctionSections)                               \
-	macro(DataSections)                                   \
-	macro(UniqueSectionNames)                             \
-	macro(TrapUnreachable)                                \
-	macro(EmulatedTLS)                                    \
-	macro(EnableIPRA)
+#define LLVM_HS_FOR_EACH_TARGET_OPTION_FLAG(macro)  \
+  macro(PrintMachineCode)                               \
+  macro(UnsafeFPMath)                                   \
+  macro(NoInfsFPMath)                                   \
+  macro(NoNaNsFPMath)                                   \
+  macro(NoTrappingFPMath)                               \
+  macro(NoSignedZerosFPMath)                            \
+  macro(HonorSignDependentRoundingFPMathOption)         \
+  macro(NoZerosInBSS)                                   \
+  macro(GuaranteedTailCallOpt)                          \
+  macro(StackSymbolOrdering)                            \
+  macro(EnableFastISel)                                 \
+  macro(UseInitArray)                                   \
+  macro(DisableIntegratedAS)                            \
+  macro(RelaxELFRelocations)                            \
+  macro(FunctionSections)                               \
+  macro(DataSections)                                   \
+  macro(UniqueSectionNames)                             \
+  macro(TrapUnreachable)                                \
+  macro(EmulatedTLS)                                    \
+  macro(EnableIPRA)
 
 typedef enum {
 #define ENUM_CASE(n) LLVM_Hs_TargetOptionFlag_ ## n,
-	LLVM_HS_FOR_EACH_TARGET_OPTION_FLAG(ENUM_CASE)
+  LLVM_HS_FOR_EACH_TARGET_OPTION_FLAG(ENUM_CASE)
 #undef ENUM_CASE
 } LLVM_Hs_TargetOptionFlag;
 
@@ -64,84 +64,84 @@ typedef enum {
 #undef ENUM_CASE
 } LLVM_Hs_DebugCompressionType;
 
-#define LLVM_HS_FOR_EACH_FLOAT_ABI(macro)	\
-	macro(Default)																\
-	macro(Soft)																		\
-	macro(Hard)
+#define LLVM_HS_FOR_EACH_FLOAT_ABI(macro) \
+  macro(Default)                                \
+  macro(Soft)                                   \
+  macro(Hard)
 
 typedef enum {
 #define ENUM_CASE(n) LLVM_Hs_FloatABI_ ## n,
-	LLVM_HS_FOR_EACH_FLOAT_ABI(ENUM_CASE)
+  LLVM_HS_FOR_EACH_FLOAT_ABI(ENUM_CASE)
 #undef ENUM_CASE
 } LLVM_Hs_FloatABI;
 
-#define LLVM_HS_FOR_EACH_FP_OP_FUSION_MODE(macro)	\
-	macro(Fast)																						\
-	macro(Standard)																				\
-	macro(Strict)
+#define LLVM_HS_FOR_EACH_FP_OP_FUSION_MODE(macro) \
+  macro(Fast)                                           \
+  macro(Standard)                                       \
+  macro(Strict)
 
 typedef enum {
 #define ENUM_CASE(n) LLVM_Hs_FPOpFusionMode_ ## n,
-	LLVM_HS_FOR_EACH_FP_OP_FUSION_MODE(ENUM_CASE)
+  LLVM_HS_FOR_EACH_FP_OP_FUSION_MODE(ENUM_CASE)
 #undef ENUM_CASE
 } LLVM_Hs_FPOpFusionMode;
 
 #define LLVM_HS_FOR_EACH_THREAD_MODEL(macro) \
-	macro(POSIX) \
-	macro(Single)
+  macro(POSIX) \
+  macro(Single)
 
 typedef enum {
 #define ENUM_CASE(n) LLVM_Hs_ThreadModel_ ## n,
-	LLVM_HS_FOR_EACH_THREAD_MODEL(ENUM_CASE)
+  LLVM_HS_FOR_EACH_THREAD_MODEL(ENUM_CASE)
 #undef ENUM_CASE
 } LLVM_Hs_ThreadModel;
 
 #define LLVM_HS_FOR_EACH_EABI(macro) \
-	macro(Unknown)																				\
-	macro(Default)																				\
-	macro(EABI4)																					\
-	macro(EABI5)																					\
-	macro(GNU)
+  macro(Unknown)                                        \
+  macro(Default)                                        \
+  macro(EABI4)                                          \
+  macro(EABI5)                                          \
+  macro(GNU)
 
 typedef enum {
 #define ENUM_CASE(n) LLVM_Hs_EABI_ ## n,
-	LLVM_HS_FOR_EACH_EABI(ENUM_CASE)
+  LLVM_HS_FOR_EACH_EABI(ENUM_CASE)
 #undef ENUM_CASE
 } LLVM_Hs_EABI;
 
 #define LLVM_HS_FOR_EACH_DEBUGGER_KIND(macro) \
-	macro(Default)																				\
-	macro(GDB)																						\
-	macro(LLDB)																						\
-	macro(SCE)
+  macro(Default)                                        \
+  macro(GDB)                                            \
+  macro(LLDB)                                           \
+  macro(SCE)
 
 typedef enum {
 #define ENUM_CASE(n) LLVM_Hs_DebuggerKind_ ## n,
-	LLVM_HS_FOR_EACH_DEBUGGER_KIND(ENUM_CASE)
+  LLVM_HS_FOR_EACH_DEBUGGER_KIND(ENUM_CASE)
 #undef ENUM_CASE
 } LLVM_Hs_DebuggerKind;
 
 #define LLVM_HS_FOR_EACH_FP_DENORMAL_MODE(macro) \
-	macro(IEEE)																						\
-	macro(PreserveSign)																		\
-	macro(PositiveZero)
+  macro(IEEE)                                           \
+  macro(PreserveSign)                                   \
+  macro(PositiveZero)
 
 typedef enum {
 #define ENUM_CASE(n) LLVM_Hs_FPDenormalMode_ ## n,
-	LLVM_HS_FOR_EACH_FP_DENORMAL_MODE(ENUM_CASE)
+  LLVM_HS_FOR_EACH_FP_DENORMAL_MODE(ENUM_CASE)
 #undef ENUM_CASE
 } LLVM_Hs_FPDenormalMode;
 
 #define LLVM_HS_FOR_EACH_EXCEPTION_HANDLING(macro) \
-	macro(None)																						\
-	macro(DwarfCFI)																				\
-	macro(SjLj)																						\
-	macro(ARM)																						\
-	macro(WinEH)
+  macro(None)                                           \
+  macro(DwarfCFI)                                       \
+  macro(SjLj)                                           \
+  macro(ARM)                                            \
+  macro(WinEH)
 
 typedef enum {
 #define ENUM_CASE(n) LLVM_Hs_ExceptionHandling_ ## n,
-	LLVM_HS_FOR_EACH_EXCEPTION_HANDLING(ENUM_CASE)
+  LLVM_HS_FOR_EACH_EXCEPTION_HANDLING(ENUM_CASE)
 #undef ENUM_CASE
 } LLVM_Hs_ExceptionHandling;
 

--- a/llvm-hs/src/LLVM/Internal/FFI/Target.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Target.hs
@@ -24,6 +24,7 @@ foreign import ccall unsafe "LLVM_Hs_LookupTarget" lookupTarget ::
     CString -> CString -> Ptr (OwnerTransfered CString) -> Ptr (OwnerTransfered CString) -> IO (Ptr Target)
 
 data TargetOptions
+data MCTargetOptions
 
 foreign import ccall unsafe "LLVM_Hs_CreateTargetOptions" createTargetOptions ::
   IO (Ptr TargetOptions)
@@ -33,6 +34,12 @@ foreign import ccall unsafe "LLVM_Hs_SetTargetOptionFlag" setTargetOptionFlag ::
 
 foreign import ccall unsafe "LLVM_Hs_GetTargetOptionFlag" getTargetOptionsFlag ::
   Ptr TargetOptions -> TargetOptionFlag -> IO LLVMBool
+
+foreign import ccall unsafe "LLVM_Hs_SetMCTargetOptionFlag" setMCTargetOptionFlag ::
+  Ptr MCTargetOptions -> MCTargetOptionFlag -> LLVMBool -> IO ()
+
+foreign import ccall unsafe "LLVM_Hs_GetMCTargetOptionFlag" getMCTargetOptionsFlag ::
+  Ptr MCTargetOptions -> MCTargetOptionFlag -> IO LLVMBool
 
 foreign import ccall unsafe "LLVM_Hs_GetCompressDebugSections" getCompressDebugSections ::
   Ptr TargetOptions -> IO DebugCompressionType
@@ -109,6 +116,9 @@ foreign import ccall unsafe "LLVMDisposeTargetMachine" disposeTargetMachine ::
 
 foreign import ccall unsafe "LLVM_Hs_TargetMachineOptions" targetMachineOptions ::
   Ptr TargetMachine -> IO (Ptr TargetOptions)
+
+foreign import ccall unsafe "LLVM_Hs_MCTargetOptions" machineCodeOptions ::
+  Ptr TargetOptions -> IO (Ptr MCTargetOptions)
 
 foreign import ccall unsafe "LLVM_Hs_TargetMachineEmit" targetMachineEmit ::
   Ptr TargetMachine

--- a/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
@@ -269,6 +269,18 @@ void LLVM_Hs_SetTargetOptionFlag(TargetOptions *to, LLVM_Hs_TargetOptionFlag f,
     }
 }
 
+void LLVM_Hs_SetMCTargetOptionFlag(MCTargetOptions *to, LLVM_Hs_MCTargetOptionFlag f,
+                                   unsigned v) {
+    switch (f) {
+#define ENUM_CASE(op)                                                          \
+    case LLVM_Hs_MCTargetOptionFlag_##op:                                      \
+        to->op = v ? 1 : 0;                                                    \
+        break;
+        LLVM_HS_FOR_EACH_MC_TARGET_OPTION_FLAG(ENUM_CASE)
+#undef ENUM_CASE
+    }
+}
+
 static llvm::DebugCompressionType
 unwrap(LLVM_Hs_DebugCompressionType compressionType) {
     switch (compressionType) {
@@ -318,6 +330,20 @@ unsigned LLVM_Hs_GetTargetOptionFlag(TargetOptions *to,
 #undef ENUM_CASE
     default:
         assert(false && "Unknown target option flag");
+        return 0;
+    }
+}
+
+unsigned LLVM_Hs_GetMCTargetOptionFlag(MCTargetOptions *to,
+                                       LLVM_Hs_MCTargetOptionFlag f) {
+    switch (f) {
+#define ENUM_CASE(op)                                                          \
+    case LLVM_Hs_MCTargetOptionFlag_##op:                                      \
+        return to->op;
+        LLVM_HS_FOR_EACH_MC_TARGET_OPTION_FLAG(ENUM_CASE)
+#undef ENUM_CASE
+    default:
+        assert(false && "Unknown machine code target option flag");
         return 0;
     }
 }
@@ -511,6 +537,10 @@ LLVM_Hs_CreateTargetMachine(LLVMTargetRef T, const char *Triple,
 
 TargetOptions *LLVM_Hs_TargetMachineOptions(LLVMTargetMachineRef TM) {
     return &unwrap(TM)->Options;
+}
+
+MCTargetOptions *LLVM_Hs_MCTargetOptions(TargetOptions *to) {
+    return &to->MCOptions;
 }
 
 // This is identical to LLVMTargetMachineEmit but LLVM doesn’t expose this

--- a/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
@@ -1,4 +1,5 @@
 #define __STDC_LIMIT_MACROS
+#include "LLVM/Internal/FFI/ErrorHandling.hpp"
 #include "LLVM/Internal/FFI/LibFunc.h"
 #include "LLVM/Internal/FFI/Target.h"
 #include "LLVM/Internal/FFI/Target.hpp"
@@ -290,7 +291,7 @@ unwrap(LLVM_Hs_DebugCompressionType compressionType) {
         LLVM_HS_FOR_EACH_DEBUG_COMPRESSION_TYPE(ENUM_CASE)
 #undef ENUM_CASE
     default:
-        assert(false && "Unknown debug compression type");
+        reportFatalError("Unknown debug compression type");
         return llvm::DebugCompressionType::None;
     }
 }
@@ -304,7 +305,7 @@ wrap(llvm::DebugCompressionType compressionType) {
         LLVM_HS_FOR_EACH_DEBUG_COMPRESSION_TYPE(ENUM_CASE)
 #undef ENUM_CASE
     default: {
-        assert(false && "Unknown debug compression type");
+        reportFatalError("Unknown debug compression type");
         return LLVM_Hs_DebugCompressionType_None;
     }
     }
@@ -329,7 +330,7 @@ unsigned LLVM_Hs_GetTargetOptionFlag(TargetOptions *to,
         LLVM_HS_FOR_EACH_TARGET_OPTION_FLAG(ENUM_CASE)
 #undef ENUM_CASE
     default:
-        assert(false && "Unknown target option flag");
+        reportFatalError("Unknown target option flag");
         return 0;
     }
 }
@@ -343,7 +344,7 @@ unsigned LLVM_Hs_GetMCTargetOptionFlag(MCTargetOptions *to,
         LLVM_HS_FOR_EACH_MC_TARGET_OPTION_FLAG(ENUM_CASE)
 #undef ENUM_CASE
     default:
-        assert(false && "Unknown machine code target option flag");
+        reportFatalError("Unknown machine code target option flag");
         return 0;
     }
 }

--- a/llvm-hs/src/LLVM/Target/Options.hs
+++ b/llvm-hs/src/LLVM/Target/Options.hs
@@ -94,6 +94,26 @@ data Options = Options {
   eabiVersion :: EABIVersion,
   debuggerTuning :: DebuggerKind,
   floatingPointDenormalMode :: FloatingPointDenormalMode,
-  exceptionModel :: ExceptionHandling
+  exceptionModel :: ExceptionHandling,
+  machineCodeOptions :: MachineCodeOptions
+  }
+  deriving (Eq, Ord, Read, Show)
+
+-- | <http://llvm.org/doxygen/classllvm_1_1MCTargetOptions.html>
+data MachineCodeOptions = MachineCodeOptions {
+  sanitizeAddresses :: Bool,
+  relaxAll :: Bool,
+  noExecutableStack :: Bool,
+  fatalWarnings :: Bool,
+  noWarnings :: Bool,
+  noDeprecatedWarning :: Bool,
+  saveTemporaryLabels :: Bool,
+  useDwarfDirectory :: Bool,
+  incrementalLinkerCompatible :: Bool,
+  pieCopyRelocations :: Bool,
+  showMachineCodeEncoding :: Bool,
+  showMachineCodeInstructions :: Bool,
+  verboseAssembly :: Bool,
+  preserveComentsInAssembly :: Bool
   }
   deriving (Eq, Ord, Read, Show)

--- a/llvm-hs/test/LLVM/Test/Target.hs
+++ b/llvm-hs/test/LLVM/Test/Target.hs
@@ -83,7 +83,26 @@ instance Arbitrary Options where
     debuggerTuning <- arbitrary
     floatingPointDenormalMode <- arbitrary
     exceptionModel <- arbitrary
+    machineCodeOptions <- arbitrary
     return Options { .. }
+
+instance Arbitrary MachineCodeOptions where
+  arbitrary = do
+    sanitizeAddresses <- arbitrary
+    relaxAll <- arbitrary
+    noExecutableStack <- arbitrary
+    fatalWarnings <- arbitrary
+    noWarnings <- arbitrary
+    noDeprecatedWarning <- arbitrary
+    saveTemporaryLabels <- arbitrary
+    useDwarfDirectory <- arbitrary
+    incrementalLinkerCompatible <- arbitrary
+    pieCopyRelocations <- arbitrary
+    showMachineCodeEncoding <- arbitrary
+    showMachineCodeInstructions <- arbitrary
+    verboseAssembly <- arbitrary
+    preserveComentsInAssembly <- arbitrary
+    return MachineCodeOptions { .. }
 
 instance Arbitrary DebugCompressionType where
   arbitrary = elements [CompressNone, CompressGNU, CompressZ]


### PR DESCRIPTION
This patch adds machineTargetOptions member to LLVM.Target.Options with all flag options of LLVM's MCTargetOptions.

Additionally FFI/Target.h was reindented to make editing easier.