### PR TITLE
Add a Str constant constructor

### DIFF
--- a/llvm-hs-pure/src/LLVM/AST/Constant.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Constant.hs
@@ -29,6 +29,7 @@ data Constant
     | Array { memberType :: Type, memberValues :: [ Constant ] }
     | Vector { memberValues :: [ Constant ] }
     | Undef { constantType :: Type }
+    | Str { innerString :: String }
     | BlockAddress { blockAddressFunction :: Name, blockAddressBlock :: Name }
     | GlobalReference Type Name
     | TokenNone
@@ -212,7 +213,6 @@ data Constant
         indices' :: [Word32]
       }
     deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
-
 
 -- | Since LLVM types don't include signedness, there's ambiguity in interpreting
 -- an constant as an Integer. The LLVM assembly printer prints integers as signed, but

--- a/llvm-hs/src/LLVM/Internal/Coding.hs
+++ b/llvm-hs/src/LLVM/Internal/Coding.hs
@@ -138,3 +138,9 @@ instance Monad m => EncodeM m Word64 Word64 where
 
 instance Monad m => DecodeM m Word64 Word64 where
   decodeM = return
+
+instance Monad m => EncodeM m String (IO CString) where
+  encodeM = return . newCString
+
+instance Monad m => DecodeM m (IO String) CString where
+  decodeM = return . peekCString

--- a/llvm-hs/src/LLVM/Internal/FFI/Constant.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Constant.hs
@@ -147,3 +147,6 @@ foreign import ccall unsafe "LLVM_Hs_GetBlockAddressBlock" getBlockAddressBlock 
 
 foreign import ccall unsafe "LLVM_Hs_GetConstTokenNone" getConstTokenNone ::
   Ptr Context -> IO (Ptr Constant)
+
+foreign import ccall unsafe "LLVMConstStringInContext" constStringInContext ::
+  Ptr Context -> CString -> CUInt -> LLVMBool -> IO (Ptr Constant)

--- a/llvm-hs/test/LLVM/Test/Constants.hs
+++ b/llvm-hs/test/LLVM/Test/Constants.hs
@@ -94,7 +94,14 @@ tests = testGroup "Constants" [
       StructureType False (replicate 2 i32),
       C.Struct Nothing False (replicate 2 (C.Int 32 1)),
       "global { i32, i32 } { i32 1, i32 1 }"
-    ), (
+    ),
+{-( -- thinks c"string" and i8 array are not the same
+      "string",
+      ArrayType 5 i8,
+      C.Str "test",
+      [r|global [5 x i8] c"test\00"|]
+),-}
+    (
       "dataarray",
       ArrayType 3 i32,
       C.Array i32 [C.Int 32 i | i <- [1,2,1]],
@@ -137,7 +144,7 @@ tests = testGroup "Constants" [
     ), (
       "selectvalue",
       i32,
-      C.Select (C.PtrToInt (C.GlobalReference (ptr i32) (UnName 1)) i1) 
+      C.Select (C.PtrToInt (C.GlobalReference (ptr i32) (UnName 1)) i1)
          (C.Int 32 1)
          (C.Int 32 2),
       "global i32 select (i1 ptrtoint (i32* @1 to i1), i32 1, i32 2)"
@@ -161,7 +168,7 @@ tests = testGroup "Constants" [
       "extractvalue",
       i8,
       C.ExtractValue
-        (C.Select (C.PtrToInt (C.GlobalReference (p i32) (UnName 1)) i1) 
+        (C.Select (C.PtrToInt (C.GlobalReference (p i32) (UnName 1)) i1)
          (C.Array i8 [C.Int 8 0])
          (C.Array i8 [C.Int 8 1]))
         [0],
@@ -171,13 +178,13 @@ tests = testGroup "Constants" [
    ],
    let mAST = Module "<string>" "<string>" Nothing Nothing [
              GlobalDefinition $ globalVariableDefaults {
-               G.name = UnName 0, G.type' = type', G.initializer = Just value 
+               G.name = UnName 0, G.type' = type', G.initializer = Just value
              },
              GlobalDefinition $ globalVariableDefaults {
-               G.name = UnName 1, G.type' = i32, G.initializer = Nothing 
+               G.name = UnName 1, G.type' = i32, G.initializer = Nothing
              },
              GlobalDefinition $ globalVariableDefaults {
-               G.name = UnName 2, G.type' = i32, G.initializer = Nothing 
+               G.name = UnName 2, G.type' = i32, G.initializer = Nothing
              }
            ]
        mStr = "; ModuleID = '<string>'\nsource_filename = \"<string>\"\n\n@0 = " <> str <> "\n\


### PR DESCRIPTION
This commit adds a Str constructor for the Constant type,
this constructor leverages LLVMConstStringInContext to
create LLVM IR strings from Haskell strings. However,
this change also has some problems, for which i do not see an obvious solution:
1. llvm-hs thinks constant string and array of i8 are different, but those are the same thing
2. newCString allocates the string on the heap and we need to free it manually, but how do we do this?