### PR TITLE
Fix argument order in LLVM_Hs_CreateTargetMachine

### DIFF
--- a/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
@@ -470,8 +470,8 @@ void LLVM_Hs_InitializeAllTargets() {
 LLVMTargetMachineRef
 LLVM_Hs_CreateTargetMachine(LLVMTargetRef T, const char *Triple,
                             const char *CPU, const char *Features,
-                            TargetOptions *TO, LLVMCodeGenOptLevel Level,
-                            LLVMRelocMode Reloc, LLVMCodeModel CodeModel) {
+                            TargetOptions *TO, LLVMRelocMode Reloc,
+                            LLVMCodeModel CodeModel, LLVMCodeGenOptLevel Level) {
     Optional<Reloc::Model> RM;
     switch (Reloc) {
     case LLVMRelocStatic:

--- a/llvm-hs/test/LLVM/Test/Module.hs
+++ b/llvm-hs/test/LLVM/Test/Module.hs
@@ -302,8 +302,6 @@ tests = testGroup "Module" [
             \main:\n\
             \\t.cfi_startproc\n\
             \\txorl\t%eax, %eax\n\
-            \\tmovl\t%edi, -4(%rsp)\n\
-            \\tmovq\t%rsi, -16(%rsp)\n\
             \\tretq\n\
             \.Lfunc_end0:\n\
             \\t.size\tmain, .Lfunc_end0-main\n\


### PR DESCRIPTION
@barrucadu It would be great if you could confirm that this fixes things for you.