### PR TITLE
add bindings to loadLibraryPermanently and getSymbolAddressInProcess

### DIFF
--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -156,6 +156,7 @@ library
     LLVM.Internal.FFI.Constant
     LLVM.Internal.FFI.Context
     LLVM.Internal.FFI.DataLayout
+    LLVM.Internal.FFI.DynamicLibrary
     LLVM.Internal.FFI.ExecutionEngine
     LLVM.Internal.FFI.Function
     LLVM.Internal.FFI.GlobalAlias
@@ -177,6 +178,7 @@ library
     LLVM.Internal.FFI.PassManager
     LLVM.Internal.FFI.PtrHierarchy
     LLVM.Internal.FFI.RawOStream
+    LLVM.Internal.FFI.RTDyldMemoryManager
     LLVM.Internal.FFI.ShortByteString
     LLVM.Internal.FFI.SMDiagnostic
     LLVM.Internal.FFI.Target
@@ -185,6 +187,8 @@ library
     LLVM.Internal.FFI.Type
     LLVM.Internal.FFI.User
     LLVM.Internal.FFI.Value
+    LLVM.Internal.Linking
+    LLVM.Linking
     LLVM.Module
     LLVM.OrcJIT
     LLVM.PassManager
@@ -221,6 +225,7 @@ library
     src/LLVM/Internal/FFI/OrcJITC.cpp
     src/LLVM/Internal/FFI/RawOStreamC.cpp
     src/LLVM/Internal/FFI/PassManagerC.cpp
+    src/LLVM/Internal/FFI/RTDyldMemoryManager.cpp
     src/LLVM/Internal/FFI/SMDiagnosticC.cpp
     src/LLVM/Internal/FFI/TargetC.cpp
     src/LLVM/Internal/FFI/TypeC.cpp

--- a/llvm-hs/src/LLVM/Internal/FFI/DynamicLibrary.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/DynamicLibrary.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+-- | FFI functions for handling the DynamicLibrary class
+module LLVM.Internal.FFI.DynamicLibrary where
+
+import LLVM.Prelude
+
+import Foreign.C
+
+import LLVM.Internal.FFI.LLVMCTypes
+
+-- | <https://llvm.org/doxygen/Support_8h.html#a6fc1331c1a6d2cc6f0fda94f4a4636f9>
+foreign import ccall safe "LLVMLoadLibraryPermanently" loadLibraryPermanently ::
+  CString -> IO LLVMBool

--- a/llvm-hs/src/LLVM/Internal/FFI/RTDyldMemoryManager.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/RTDyldMemoryManager.cpp
@@ -1,0 +1,14 @@
+#define __STDC_LIMIT_MACROS
+
+#include "llvm/ExecutionEngine/RTDyldMemoryManager.h"
+
+using namespace llvm;
+
+extern "C" {
+
+uint64_t LLVM_Hs_GetSymbolAddressInProcess(const char *name) {
+    std::string nameStr(name);
+    return RTDyldMemoryManager::getSymbolAddressInProcess(nameStr);
+}
+
+}

--- a/llvm-hs/src/LLVM/Internal/FFI/RTDyldMemoryManager.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/RTDyldMemoryManager.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+-- | FFI functions for handling the RTDyldMemoryManager class
+module LLVM.Internal.FFI.RTDyldMemoryManager where
+
+import LLVM.Prelude
+
+import Foreign.C.String
+import Foreign.Ptr
+
+-- | <https://llvm.org/doxygen/classllvm_1_1RTDyldMemoryManager.html#a5fee247bdc0c5af393b66bfd73a0a347>
+foreign import ccall safe "LLVM_Hs_GetSymbolAddressInProcess" getSymbolAddressInProcess ::
+  CString -> IO WordPtr

--- a/llvm-hs/src/LLVM/Internal/FFI/RTDyldMemoryManager.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/RTDyldMemoryManager.hs
@@ -5,9 +5,9 @@ module LLVM.Internal.FFI.RTDyldMemoryManager where
 
 import LLVM.Prelude
 
+import Data.Word
 import Foreign.C.String
-import Foreign.Ptr
 
 -- | <https://llvm.org/doxygen/classllvm_1_1RTDyldMemoryManager.html#a5fee247bdc0c5af393b66bfd73a0a347>
 foreign import ccall safe "LLVM_Hs_GetSymbolAddressInProcess" getSymbolAddressInProcess ::
-  CString -> IO WordPtr
+  CString -> IO Word64

--- a/llvm-hs/src/LLVM/Internal/Linking.hs
+++ b/llvm-hs/src/LLVM/Internal/Linking.hs
@@ -18,7 +18,7 @@ import LLVM.Internal.OrcJIT
 getSymbolAddressInProcess
   :: MangledSymbol -> IO WordPtr
 getSymbolAddressInProcess (MangledSymbol sym)
-  = BS.useAsCString sym Dyld.getSymbolAddressInProcess
+  = fromIntegral <$> BS.useAsCString sym Dyld.getSymbolAddressInProcess
 
 -- | Loads the given dynamic library permanently. If 'Nothing'
 --   is given, this will make the symbols from the current

--- a/llvm-hs/src/LLVM/Internal/Linking.hs
+++ b/llvm-hs/src/LLVM/Internal/Linking.hs
@@ -1,0 +1,30 @@
+module LLVM.Internal.Linking
+  ( loadLibraryPermanently
+  , getSymbolAddressInProcess
+  )where
+
+import LLVM.Prelude
+
+import qualified Data.ByteString as BS
+import Foreign.C.String
+import Foreign.Ptr
+import LLVM.Internal.Coding
+import qualified LLVM.Internal.FFI.DynamicLibrary as DL
+import qualified LLVM.Internal.FFI.RTDyldMemoryManager as Dyld
+import LLVM.Internal.OrcJIT
+
+-- | Get the address of the given symbol in
+--   the current process' address space.
+getSymbolAddressInProcess
+  :: MangledSymbol -> IO WordPtr
+getSymbolAddressInProcess (MangledSymbol sym)
+  = BS.useAsCString sym Dyld.getSymbolAddressInProcess
+
+-- | Loads the given dynamic library permanently. If 'Nothing'
+--   is given, this will make the symbols from the current
+--   process available.
+loadLibraryPermanently
+  :: Maybe FilePath
+  -> IO Bool
+loadLibraryPermanently (Just fp) = decodeM =<< withCString fp DL.loadLibraryPermanently
+loadLibraryPermanently Nothing = decodeM =<< DL.loadLibraryPermanently nullPtr

--- a/llvm-hs/src/LLVM/Linking.hs
+++ b/llvm-hs/src/LLVM/Linking.hs
@@ -1,0 +1,7 @@
+-- | Utility functions for resolving external symbols
+module LLVM.Linking
+  ( loadLibraryPermanently
+  , getSymbolAddressInProcess
+  ) where
+
+import LLVM.Internal.Linking


### PR DESCRIPTION
This was motivated by the fact that `llvm.exp.f64` and some other intrinsics could not be resolved by the JIT because of an error like: `LLVM ERROR: Program used external function 'exp' which could not be resolved!` when calling `findSymbol`.

With this patch, I simply have to use a resolver like `resolv` below:

``` haskell
resolver
  :: LLVMJIT.IRCompileLayer l -> LLVMJIT.MangledSymbol -> IO LLVMJIT.JITSymbol
resolver compileLayer symbol
  = LLVMJIT.findSymbol compileLayer symbol True

symbolFromProcess :: LLVMJIT.MangledSymbol -> IO LLVMJIT.JITSymbol
symbolFromProcess sym = (\addr -> LLVMJIT.JITSymbol addr (LLVMJIT.JITSymbolFlags False True))
    <$> LLVMJIT.getSymbolAddressInProcess sym

resolv :: LLVMJIT.IRCompileLayer l -> LLVMJIT.SymbolResolver
resolv cl = LLVMJIT.SymbolResolver (\sym -> LLVMJIT.findSymbol cl sym True) symbolFromProcess
```

as long as I call `loadLibraryPermanently` before using this resolver. You can see this at work [here](https://gist.github.com/alpmestan/5ebabe68fe96de2819d7e745b946c981) in a complete program.

I tried to stick the `foreign import`s in modules named after the class to which the functions belong, and am tentatively offering a higher level interface to those functions in `LLVM[.Internal].Linking`, following a suggestion by @cocreature. If anyone finds better names or a better way to organize things, let me know or feel free to push patches yourself.