### PR TITLE
Support LLVM 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ cache:
   directories:
     - $HOME/.cabal/packages
     - $HOME/.cabal/store
-    - $HOME/llvm-build-5.0.0
-    - $HOME/llvm-src-5.0.0
+    - $HOME/llvm-build-6.0.0
+    - $HOME/llvm-src-6.0.0
 
 before_cache:
   - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
@@ -23,7 +23,7 @@ env:
   global:
     - GCC=gcc-5
     - GXX=g++-5
-    - LLVM_VER=5.0.0
+    - LLVM_VER=6.0.0
 
 matrix:
   include:
@@ -49,12 +49,15 @@ before_install:
  - export PATH=$HOME/bin:$PATH
 
 install:
- - curl https://cmake.org/files/v3.9/cmake-3.9.2-Linux-x86_64.tar.gz | tar -xzf - -C $HOME
- - export PATH=$HOME/cmake-3.9.2-Linux-x86_64/bin:$PATH
- - curl -L https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip -o ninja-linux.zip
+ - curl https://cmake.org/files/v3.10/cmake-3.10.1-Linux-x86_64.tar.gz | tar -xzf - -C $HOME
+ - export PATH=$HOME/cmake-3.10.1-Linux-x86_64/bin:$PATH
+ - curl -L https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip -o ninja-linux.zip
  - unzip ninja-linux.zip -d $HOME/bin
- - curl http://releases.llvm.org/${LLVM_VER}/llvm-${LLVM_VER}.src.tar.xz | tar -xJf - -C $HOME
- - rsync -ac $HOME/llvm-${LLVM_VER}.src/ $HOME/llvm-src-${LLVM_VER}
+ # - curl http://releases.llvm.org/${LLVM_VER}/llvm-${LLVM_VER}.src.tar.xz | tar -xJf - -C $HOME
+ # - rsync -ac $HOME/llvm-${LLVM_VER}.src/ $HOME/llvm-src-${LLVM_VER}
+ - curl -L https://github.com/llvm-mirror/llvm/archive/7ed4f7613a05b45aa77c473d2c84d915190c0427.zip -o out.zip
+ - unzip -q out.zip -d $HOME
+ - rsync -ac $HOME/llvm-7ed4f7613a05b45aa77c473d2c84d915190c0427/ $HOME/llvm-src-${LLVM_VER}
  - cd $HOME/llvm-src-${LLVM_VER}
  - mkdir -p build && cd build
  - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$HOME/llvm-build-${LLVM_VER} -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_BUILD_LLVM_DYLIB=True -DLLVM_LINK_LLVM_DYLIB=True -GNinja ..

--- a/llvm-hs-pure/CHANGELOG.md
+++ b/llvm-hs-pure/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 6.0.0 (unreleased)
+
+* Support for LLVM 6.0
+  * Add `StrictFP` and `SanitizeHWAddress` function attributes.
+  * Remove `UnsafeAlgebra` constructor from `FastMathFlags`.
+  * Add `allowReassoc`, `allowContract` and `approxFunc` fields to `FastMathFlags`.
+  * Remove `NoFastMathFlags` constructor since it is equivalent to
+    setting all fields in the `FastMathFlags` record to
+    `False`. Existing uses of `NoFastMathFlags` can be replaced by the
+    `noFastMathFlags` value.
+* Fixes and enhancements to the IRBuilder
+  * `sdiv` and `udiv` no longer default to exact.
+  * Fix type of global references.
+  * Add more instructions.
+
 ## 5.1.1 (2017-12-16)
 
 * Add a completely new API for building modules in a monadic style similar to the IRBuilder provided by LLVM’s C++ API. The modules can be found in `LLVM.IRBuilder`. An example can be found in the readme and in the test suite.

--- a/llvm-hs-pure/llvm-hs-pure.cabal
+++ b/llvm-hs-pure/llvm-hs-pure.cabal
@@ -1,5 +1,5 @@
 name: llvm-hs-pure
-version: 5.1.1
+version: 6.0.0
 license: BSD3
 license-file: LICENSE
 author: Anthony Cowley, Stephen Diehl, Moritz Kiefer <moritz.kiefer@purelyfunctional.org>, Benjamin S. Scarlet

--- a/llvm-hs-pure/src/LLVM/AST/FunctionAttribute.hs
+++ b/llvm-hs-pure/src/LLVM/AST/FunctionAttribute.hs
@@ -18,6 +18,7 @@ data FunctionAttribute
     | StackProtect
     | StackProtectReq
     | StackProtectStrong
+    | StrictFP
     | NoRedZone
     | NoImplicitFloat
     | Naked
@@ -32,6 +33,7 @@ data FunctionAttribute
     | JumpTable
     | NoDuplicate
     | SanitizeAddress
+    | SanitizeHWAddress
     | SanitizeThread
     | SanitizeMemory
     | Speculatable

--- a/llvm-hs-pure/src/LLVM/AST/Instruction.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Instruction.hs
@@ -85,15 +85,28 @@ data Terminator
 
 -- | <http://llvm.org/docs/LangRef.html#fast-math-flags>
 data FastMathFlags 
-  = NoFastMathFlags
-  | UnsafeAlgebra
-  | FastMathFlags {
+  = FastMathFlags {
+      allowReassoc :: Bool,
       noNaNs :: Bool,
       noInfs :: Bool,
       noSignedZeros :: Bool,
-      allowReciprocal :: Bool
+      allowReciprocal :: Bool,
+      allowContract :: Bool,
+      approxFunc :: Bool
     }
   deriving (Eq, Ord, Read, Show, Data, Typeable, Generic)
+
+noFastMathFlags :: FastMathFlags
+noFastMathFlags =
+  FastMathFlags {
+    allowReassoc = False,
+    noNaNs = False,
+    noInfs = False,
+    noSignedZeros = False,
+    allowReciprocal = False,
+    allowContract = False,
+    approxFunc = False
+  }
 
 -- | <http://llvm.org/docs/LangRef.html#atomic-memory-ordering-constraints>
 -- <http://llvm.org/docs/Atomics.html>

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Constant.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Constant.hs
@@ -2,10 +2,7 @@ module LLVM.IRBuilder.Constant where
 import           Data.Word
 import           LLVM.Prelude
 import           LLVM.AST             hiding (args, dests)
-import qualified LLVM.AST.Constant    as C
-import           LLVM.AST.Type        as AST
 import           LLVM.AST.Typed
-import           LLVM.IRBuilder.Monad
 
 import           LLVM.AST.Constant
 import           LLVM.AST.Float

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Instruction.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Instruction.hs
@@ -19,19 +19,19 @@ import qualified LLVM.AST.FloatingPointPredicate as FP
 import LLVM.IRBuilder.Monad
 
 fadd :: MonadIRBuilder m => Operand -> Operand -> m Operand
-fadd a b = emitInstr (typeOf a) $ FAdd NoFastMathFlags a b []
+fadd a b = emitInstr (typeOf a) $ FAdd noFastMathFlags a b []
 
 fmul :: MonadIRBuilder m => Operand -> Operand -> m Operand
-fmul a b = emitInstr (typeOf a) $ FMul NoFastMathFlags a b []
+fmul a b = emitInstr (typeOf a) $ FMul noFastMathFlags a b []
 
 fsub :: MonadIRBuilder m => Operand -> Operand -> m Operand
-fsub a b = emitInstr (typeOf a) $ FSub NoFastMathFlags a b []
+fsub a b = emitInstr (typeOf a) $ FSub noFastMathFlags a b []
 
 fdiv :: MonadIRBuilder m => Operand -> Operand -> m Operand
-fdiv a b = emitInstr (typeOf a) $ FDiv NoFastMathFlags a b []
+fdiv a b = emitInstr (typeOf a) $ FDiv noFastMathFlags a b []
 
 frem :: MonadIRBuilder m => Operand -> Operand -> m Operand
-frem a b = emitInstr (typeOf a) $ FRem NoFastMathFlags a b []
+frem a b = emitInstr (typeOf a) $ FRem noFastMathFlags a b []
 
 add :: MonadIRBuilder m => Operand -> Operand -> m Operand
 add a b = emitInstr (typeOf a) $ Add False False a b []

--- a/llvm-hs-pure/test/IRBuilder.hs
+++ b/llvm-hs-pure/test/IRBuilder.hs
@@ -52,7 +52,7 @@ main =
         }
       it "builds the example" $ do
         let f10 = ConstantOperand (C.Float (F.Double 10))
-            fadd a b = FAdd { operand0 = a, operand1 = b, fastMathFlags = NoFastMathFlags, metadata = [] }
+            fadd a b = FAdd { operand0 = a, operand1 = b, fastMathFlags = noFastMathFlags, metadata = [] }
             add a b = Add { operand0 = a, operand1 = b, nsw = False, nuw = False, metadata = [] }
         example `shouldBe`
           defaultModule {

--- a/llvm-hs/CHANGELOG.md
+++ b/llvm-hs/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.0.0 (unreleased)
+
+* Support for LLVM 6.0, take a look at the changelog of llvm-hs-pure for details.
+* Add bindings to `loadLibraryPermamently` and `getSymbolAddressInProcess`.
+
 ## 5.1.2 (2017-12-19)
 
 * Reupload of 5.1.1 since [Hackage broke](https://github.com/haskell/hackage-server/issues/643) during the original upload.

--- a/llvm-hs/Setup.hs
+++ b/llvm-hs/Setup.hs
@@ -36,7 +36,7 @@ mkFlagName = FlagName
 #endif
 
 llvmVersion :: Version
-llvmVersion = mkVersion [5,0]
+llvmVersion = mkVersion [6,0]
 
 llvmConfigNames :: [String]
 llvmConfigNames = [
@@ -88,21 +88,23 @@ addLLVMToLdLibraryPath confFlags = do
 -- | These flags are not relevant for us and dropping them allows
 -- linking against LLVM build with Clang using GCC
 ignoredCxxFlags :: [String]
-ignoredCxxFlags =
-  ["-Wcovered-switch-default", "-fcolor-diagnostics"] ++ map ("-D" ++) uncheckedHsFFIDefines
+ignoredCxxFlags = ["-fcolor-diagnostics"] ++ map ("-D" ++) uncheckedHsFFIDefines
 
 ignoredCFlags :: [String]
-ignoredCFlags = ["-Wcovered-switch-default", "-Wdelete-non-virtual-dtor", "-fcolor-diagnostics"]
+ignoredCFlags = ["-fcolor-diagnostics"]
 
 -- | Header directories are added separately to configExtraIncludeDirs
 isIncludeFlag :: String -> Bool
 isIncludeFlag flag = "-I" `isPrefixOf` flag
 
+isWarningFlag :: String -> Bool
+isWarningFlag flag = "-W" `isPrefixOf` flag
+
 isIgnoredCFlag :: String -> Bool
-isIgnoredCFlag flag = flag `elem` ignoredCFlags || isIncludeFlag flag
+isIgnoredCFlag flag = flag `elem` ignoredCFlags || isIncludeFlag flag || isWarningFlag flag
 
 isIgnoredCxxFlag :: String -> Bool
-isIgnoredCxxFlag flag = flag `elem` ignoredCxxFlags || isIncludeFlag flag
+isIgnoredCxxFlag flag = flag `elem` ignoredCxxFlags || isIncludeFlag flag || isWarningFlag flag
 
 main :: IO ()
 main = do

--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -1,5 +1,5 @@
 name: llvm-hs
-version: 5.1.2
+version: 6.0.0
 license: BSD3
 license-file: LICENSE
 author: Anthony Cowley, Stephen Diehl, Moritz Kiefer <moritz.kiefer@purelyfunctional.org>, Benjamin S. Scarlet
@@ -80,7 +80,7 @@ library
     template-haskell >= 2.5.0.0,
     containers >= 0.4.2.1,
     array >= 0.4.0.0,
-    llvm-hs-pure == 5.1.*
+    llvm-hs-pure == 6.0.*
   hs-source-dirs: src
   extensions:
     NoImplicitPrelude
@@ -250,7 +250,7 @@ test-suite test
     tasty-quickcheck >= 0.8,
     QuickCheck >= 2.5.1.1,
     llvm-hs,
-    llvm-hs-pure == 5.1.*,
+    llvm-hs-pure,
     containers >= 0.4.2.1,
     mtl >= 2.1,
     transformers >= 0.3.0.0,

--- a/llvm-hs/src/LLVM/Internal/Attribute.hs
+++ b/llvm-hs/src/LLVM/Internal/Attribute.hs
@@ -96,6 +96,7 @@ instance Monad m => EncodeM m A.FA.FunctionAttribute (Ptr FFI.FunctionAttrBuilde
       A.FA.StackProtect -> FFI.functionAttributeKindStackProtect
       A.FA.StackProtectReq -> FFI.functionAttributeKindStackProtectReq
       A.FA.StackProtectStrong -> FFI.functionAttributeKindStackProtectStrong
+      A.FA.StrictFP -> FFI.functionAttributeKindStrictFP
       A.FA.NoRedZone -> FFI.functionAttributeKindNoRedZone
       A.FA.NoImplicitFloat -> FFI.functionAttributeKindNoImplicitFloat
       A.FA.Naked -> FFI.functionAttributeKindNaked
@@ -109,6 +110,7 @@ instance Monad m => EncodeM m A.FA.FunctionAttribute (Ptr FFI.FunctionAttrBuilde
       A.FA.JumpTable -> FFI.functionAttributeKindJumpTable
       A.FA.NoDuplicate -> FFI.functionAttributeKindNoDuplicate
       A.FA.SanitizeAddress -> FFI.functionAttributeKindSanitizeAddress
+      A.FA.SanitizeHWAddress -> FFI.functionAttributeKindSanitizeHWAddress
       A.FA.SanitizeThread -> FFI.functionAttributeKindSanitizeThread
       A.FA.SanitizeMemory -> FFI.functionAttributeKindSanitizeMemory
       A.FA.SafeStack -> FFI.functionAttributeKindSafeStack
@@ -181,6 +183,7 @@ instance DecodeM DecodeAST A.FA.FunctionAttribute FFI.FunctionAttribute where
            [functionAttributeKindP|StackProtect|] -> return A.FA.StackProtect
            [functionAttributeKindP|StackProtectReq|] -> return A.FA.StackProtectReq
            [functionAttributeKindP|StackProtectStrong|] -> return A.FA.StackProtectStrong
+           [functionAttributeKindP|StrictFP|] -> return A.FA.StrictFP
            [functionAttributeKindP|NoRedZone|] -> return A.FA.NoRedZone
            [functionAttributeKindP|NoImplicitFloat|] -> return A.FA.NoImplicitFloat
            [functionAttributeKindP|Naked|] -> return A.FA.Naked
@@ -195,6 +198,7 @@ instance DecodeM DecodeAST A.FA.FunctionAttribute FFI.FunctionAttribute where
            [functionAttributeKindP|JumpTable|] -> return A.FA.JumpTable
            [functionAttributeKindP|NoDuplicate|] -> return A.FA.NoDuplicate
            [functionAttributeKindP|SanitizeAddress|] -> return A.FA.SanitizeAddress
+           [functionAttributeKindP|SanitizeHWAddress|] -> return A.FA.SanitizeHWAddress
            [functionAttributeKindP|SanitizeThread|] -> return A.FA.SanitizeThread
            [functionAttributeKindP|SanitizeMemory|] -> return A.FA.SanitizeMemory
            [functionAttributeKindP|ArgMemOnly|] -> return A.FA.ArgMemOnly

--- a/llvm-hs/src/LLVM/Internal/FFI/Attribute.h
+++ b/llvm-hs/src/LLVM/Internal/FFI/Attribute.h
@@ -46,6 +46,7 @@
 	macro(SExt,T,T,F)                                 \
 	macro(SafeStack,F,F,T)                            \
 	macro(SanitizeAddress,F,F,T)                      \
+    macro(SanitizeHWAddress,F,F,T)                    \
 	macro(SanitizeMemory,F,F,T)                       \
 	macro(SanitizeThread,F,F,T)                       \
     macro(Speculatable,F,F,T)                         \
@@ -53,6 +54,7 @@
 	macro(StackProtect,F,F,T)                         \
 	macro(StackProtectReq,F,F,T)                      \
 	macro(StackProtectStrong,F,F,T)                   \
+    macro(StrictFP,F,F,T)                             \
 	macro(StructRet,T,F,F)                            \
 	macro(SwiftError,T,F,F)                           \
 	macro(SwiftSelf,T,F,F)                            \

--- a/llvm-hs/src/LLVM/Internal/FFI/Instruction.h
+++ b/llvm-hs/src/LLVM/Internal/FFI/Instruction.h
@@ -37,12 +37,13 @@ LLVM_HS_FOR_EACH_SYNCRONIZATION_SCOPE(ENUM_CASE)
 
 /* The last parameter to the macro indicates whether the set<param> function takes a boolean argument or not */
 #define LLVM_HS_FOR_EACH_FAST_MATH_FLAG(macro) \
-	macro(UnsafeAlgebra, unsafeAlgebra, F)								\
+	macro(AllowReassoc, allowReassoc, F)								\
 	macro(NoNaNs, noNaNs, F)                                              \
 	macro(NoInfs, noInfs, F)                                              \
 	macro(NoSignedZeros, noSignedZeros, F)								\
 	macro(AllowReciprocal, allowReciprocal, F)                            \
-    macro(AllowContract, allowContract, T)
+    macro(AllowContract, allowContract, T) \
+    macro(ApproxFunc, approxFunc, F)
 
 typedef enum {
 #define ENUM_CASE(x,l,takesArg) LLVM ## x ## Bit,

--- a/llvm-hs/src/LLVM/Internal/FFI/PassManagerC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/PassManagerC.cpp
@@ -9,6 +9,7 @@
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #include "llvm/Transforms/Vectorize.h"
 #include "llvm/Transforms/Instrumentation.h"
+#include "llvm/Transforms/Instrumentation/BoundsChecking.h"
 #include "llvm/CodeGen/Passes.h"
 #include "llvm-c/Target.h"
 #include "llvm-c/Transforms/PassManagerBuilder.h"
@@ -159,7 +160,7 @@ void LLVM_Hs_AddThreadSanitizerPass(
 }
 
 void LLVM_Hs_AddBoundsCheckingPass(LLVMPassManagerRef PM) {
-	unwrap(PM)->add(createBoundsCheckingPass());
+	unwrap(PM)->add(createBoundsCheckingLegacyPass());
 }
 
 void LLVM_Hs_AddLoopVectorizePass(

--- a/llvm-hs/src/LLVM/Internal/FFI/RTDyldMemoryManager.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/RTDyldMemoryManager.hs
@@ -5,7 +5,6 @@ module LLVM.Internal.FFI.RTDyldMemoryManager where
 
 import LLVM.Prelude
 
-import Data.Word
 import Foreign.C.String
 
 -- | <https://llvm.org/doxygen/classllvm_1_1RTDyldMemoryManager.html#a5fee247bdc0c5af393b66bfd73a0a347>

--- a/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
@@ -163,11 +163,11 @@ static DebuggerKind unwrap(LLVM_Hs_DebuggerKind x) {
     switch (x) {
 #define ENUM_CASE(x)                                                           \
     case LLVM_Hs_DebuggerKind_##x:                                             \
-      return DebuggerKind::x;
-      LLVM_HS_FOR_EACH_DEBUGGER_KIND(ENUM_CASE)
+        return DebuggerKind::x;
+        LLVM_HS_FOR_EACH_DEBUGGER_KIND(ENUM_CASE)
 #undef ENUM_CASE
     default:
-      return DebuggerKind(0);
+        return DebuggerKind(0);
     }
 }
 
@@ -270,8 +270,8 @@ void LLVM_Hs_SetTargetOptionFlag(TargetOptions *to, LLVM_Hs_TargetOptionFlag f,
     }
 }
 
-void LLVM_Hs_SetMCTargetOptionFlag(MCTargetOptions *to, LLVM_Hs_MCTargetOptionFlag f,
-                                   unsigned v) {
+void LLVM_Hs_SetMCTargetOptionFlag(MCTargetOptions *to,
+                                   LLVM_Hs_MCTargetOptionFlag f, unsigned v) {
     switch (f) {
 #define ENUM_CASE(op)                                                          \
     case LLVM_Hs_MCTargetOptionFlag_##op:                                      \
@@ -494,11 +494,10 @@ void LLVM_Hs_InitializeAllTargets() {
     // None of the other components are bound yet
 }
 
-LLVMTargetMachineRef
-LLVM_Hs_CreateTargetMachine(LLVMTargetRef T, const char *Triple,
-                            const char *CPU, const char *Features,
-                            TargetOptions *TO, LLVMRelocMode Reloc,
-                            LLVMCodeModel CodeModel, LLVMCodeGenOptLevel Level) {
+LLVMTargetMachineRef LLVM_Hs_CreateTargetMachine(
+    LLVMTargetRef T, const char *Triple, const char *CPU, const char *Features,
+    TargetOptions *TO, LLVMRelocMode Reloc, LLVMCodeModel CodeModel,
+    LLVMCodeGenOptLevel Level) {
     Optional<Reloc::Model> RM;
     switch (Reloc) {
     case LLVMRelocStatic:
@@ -514,7 +513,8 @@ LLVM_Hs_CreateTargetMachine(LLVMTargetRef T, const char *Triple,
         break;
     }
 
-    CodeModel::Model CM = unwrap(CodeModel);
+    bool JIT;
+    Optional<CodeModel::Model> CM = unwrap(CodeModel, JIT);
 
     CodeGenOpt::Level OL;
     switch (Level) {
@@ -532,8 +532,8 @@ LLVM_Hs_CreateTargetMachine(LLVMTargetRef T, const char *Triple,
         break;
     }
 
-    return wrap(
-        unwrap(T)->createTargetMachine(Triple, CPU, Features, *TO, RM, CM, OL));
+    return wrap(unwrap(T)->createTargetMachine(Triple, CPU, Features, *TO, RM,
+                                               CM, OL, JIT));
 }
 
 TargetOptions *LLVM_Hs_TargetMachineOptions(LLVMTargetMachineRef TM) {

--- a/llvm-hs/src/LLVM/Internal/FastMathFlags.hs
+++ b/llvm-hs/src/LLVM/Internal/FastMathFlags.hs
@@ -21,15 +21,16 @@ import LLVM.Internal.EncodeAST
 import qualified LLVM.AST as A
 
 instance EncodeM IO A.FastMathFlags FFI.FastMathFlags where
-  encodeM A.NoFastMathFlags = return 0
-  encodeM A.UnsafeAlgebra = return FFI.fastMathFlagsUnsafeAlgebra
-  encodeM f = return $ foldr1 (.|.) [ 
+  encodeM f = return $ foldr1 (.|.) [
                if a f then b else 0
                | (a,b) <- [
+                (A.allowReassoc, FFI.fastMathFlagsAllowReassoc),
                 (A.noNaNs, FFI.fastMathFlagsNoNaNs),
                 (A.noInfs, FFI.fastMathFlagsNoInfs),
                 (A.noSignedZeros, FFI.fastMathFlagsNoSignedZeros),
-                (A.allowReciprocal, FFI.fastMathFlagsAllowReciprocal)
+                (A.allowReciprocal, FFI.fastMathFlagsAllowReciprocal),
+                (A.allowContract, FFI.fastMathFlagsAllowContract),
+                (A.approxFunc, FFI.fastMathFlagsApproxFunc)
                ] 
               ]
 
@@ -40,12 +41,13 @@ instance EncodeM EncodeAST A.FastMathFlags () where
     anyContToM $ bracket (FFI.setFastMathFlags builder f) (\() -> FFI.setFastMathFlags builder 0)
 
 instance Monad m => DecodeM m A.FastMathFlags FFI.FastMathFlags where
-  decodeM 0 = return A.NoFastMathFlags
-  decodeM f | FFI.fastMathFlagsUnsafeAlgebra .&. f /= 0 = return A.UnsafeAlgebra
   decodeM f = return A.FastMathFlags {
+                A.allowReassoc = FFI.fastMathFlagsAllowReassoc .&. f /= 0,
                 A.noNaNs = FFI.fastMathFlagsNoNaNs .&. f /= 0,
                 A.noInfs = FFI.fastMathFlagsNoInfs .&. f /= 0,
                 A.noSignedZeros = FFI.fastMathFlagsNoSignedZeros .&. f /= 0,
-                A.allowReciprocal = FFI.fastMathFlagsAllowReciprocal .&. f /= 0
+                A.allowReciprocal = FFI.fastMathFlagsAllowReciprocal .&. f /= 0,
+                A.allowContract = FFI.fastMathFlagsAllowContract .&. f /= 0,
+                A.approxFunc = FFI.fastMathFlagsApproxFunc .&. f /= 0
               }
 

--- a/llvm-hs/src/LLVM/Internal/OrcJIT.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT.hs
@@ -7,7 +7,7 @@ import Control.Exception
 import Control.Monad.AnyCont
 import Control.Monad.IO.Class
 import Data.Bits
-import Data.ByteString (ByteString, packCString, useAsCString)
+import Data.ByteString (packCString, useAsCString)
 import Data.IORef
 import Foreign.C.String
 import Foreign.Ptr

--- a/llvm-hs/src/LLVM/Internal/String.hs
+++ b/llvm-hs/src/LLVM/Internal/String.hs
@@ -10,7 +10,6 @@ import Control.Arrow
 import Control.Monad.AnyCont
 import Control.Monad.IO.Class
 import Control.Exception (finally)
-import Data.Maybe (fromMaybe)
 import Foreign.C (CString, CChar)
 import Foreign.Ptr
 import Foreign.Storable (Storable)

--- a/llvm-hs/test/LLVM/Test/FunctionAttribute.hs
+++ b/llvm-hs/test/LLVM/Test/FunctionAttribute.hs
@@ -39,6 +39,7 @@ instance Arbitrary FunctionAttribute where
     , return StackProtect
     , return StackProtectReq
     , return StackProtectStrong
+    , return StrictFP
     , return NoRedZone
     , return NoImplicitFloat
     , return Naked
@@ -53,6 +54,7 @@ instance Arbitrary FunctionAttribute where
     , return JumpTable
     , return NoDuplicate
     , return SanitizeAddress
+    , return SanitizeHWAddress
     , return SanitizeThread
     , return SanitizeMemory
     , StringAttribute <$> (B.pack <$> arbitrary) <*> (B.pack <$> arbitrary)

--- a/llvm-hs/test/LLVM/Test/Optimization.hs
+++ b/llvm-hs/test/LLVM/Test/Optimization.hs
@@ -177,7 +177,7 @@ tests = testGroup "Optimization" [
     testCase "SLPVectorization" $ do
       let
         fadd op0 op1 =
-          FAdd { fastMathFlags = NoFastMathFlags, operand0 = op0, operand1 = op1, metadata = [] }
+          FAdd { fastMathFlags = noFastMathFlags, operand0 = op0, operand1 = op1, metadata = [] }
         doubleVec = VectorType 2 double
         constInt i = ConstantOperand (C.Int {C.integerBits = 32, C.integerValue = i})
         undef = ConstantOperand (C.Undef doubleVec)

--- a/llvm-hs/test/LLVM/Test/OrcJIT.hs
+++ b/llvm-hs/test/LLVM/Test/OrcJIT.hs
@@ -102,7 +102,7 @@ tests =
                     JITSymbol mainFn _ <- findSymbol compileLayer mainSymbol True
                     result <- mkMain (castPtrToFunPtr (wordPtrToPtr mainFn))
                     result @?= 42
-                    assert (readIORef passmanagerSuccessful),
+                    readIORef passmanagerSuccessful @? "passmanager failed",
 
     testCase "lazy compilation" $ do
       withTestModule $ \mod ->


### PR DESCRIPTION
This fixes the build and the tests against the just branched LLVM 6.0. Before merging this I still need to do some cleanup, update the changelogs and make sure Travis is happy but the existing test should already be passing.