### PR TITLE
[#119] Fix an error message for a deserialization check

### DIFF
--- a/llvm-hs/src/LLVM/Internal/Constant.hs
+++ b/llvm-hs/src/LLVM/Internal/Constant.hs
@@ -102,7 +102,7 @@ instance EncodeM EncodeAST A.Constant (Ptr FFI.Constant) where
       if ty /= ty'
         then throwM
                (EncodeException
-                  ("The serialized GlobalReference has type " ++ show ty' ++ " but should have type " ++ show ty))
+                  ("The serialized GlobalReference has type " ++ show ty ++ " but should have type " ++ show ty'))
         else return ref
     A.C.BlockAddress f b -> do
       f' <- referGlobal f

--- a/llvm-hs/test/LLVM/Test/Regression.hs
+++ b/llvm-hs/test/LLVM/Test/Regression.hs
@@ -95,5 +95,5 @@ tests =
     , testCase
         "no implicit casts"
         (example2 `shouldThrowEncodeException`
-         "The serialized GlobalReference has type PointerType {pointerReferent = FunctionType {resultType = VoidType, argumentTypes = [], isVarArg = False}, pointerAddrSpace = AddrSpace 0} but should have type FunctionType {resultType = VoidType, argumentTypes = [], isVarArg = False}")
+         "The serialized GlobalReference has type FunctionType {resultType = VoidType, argumentTypes = [], isVarArg = False} but should have type PointerType {pointerReferent = FunctionType {resultType = VoidType, argumentTypes = [], isVarArg = False}, pointerAddrSpace = AddrSpace 0}")
     ]


### PR DESCRIPTION
`The expected type is the one which is inferred from the AST while the actual type is given by the user.`

Does this sound right ? I wasn't sure if I should've submitted this against the newer `llvm6` branch. But I can do that as well.