### PR TITLE
Fix the build on GHC 8.4

### DIFF
--- a/llvm-hs-pure/src/LLVM/IRBuilder/Internal/SnocList.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Internal/SnocList.hs
@@ -1,12 +1,23 @@
+{-# LANGUAGE CPP #-}
 module LLVM.IRBuilder.Internal.SnocList where
 
+#if MIN_VERSION_base(4,11,0)
 import LLVM.Prelude
+#else
+import Data.Semigroup (Semigroup(..))
+import LLVM.Prelude hiding ((<>))
+#endif
 
 newtype SnocList a = SnocList { unSnocList :: [a] }
   deriving (Eq, Show)
 
+instance Semigroup (SnocList a) where
+  SnocList xs <> SnocList ys = SnocList $ ys ++ xs
+
 instance Monoid (SnocList a) where
-  mappend (SnocList xs) (SnocList ys) = SnocList $ ys ++ xs
+#if !(MIN_VERSION_base(4,11,0))
+  mappend = (<>)
+#endif
   mempty = SnocList []
 
 snoc :: SnocList a -> a -> SnocList a

--- a/llvm-hs/Setup.hs
+++ b/llvm-hs/Setup.hs
@@ -35,6 +35,11 @@ mkFlagName :: String -> FlagName
 mkFlagName = FlagName
 #endif
 
+#if !(MIN_VERSION_Cabal(2,1,0))
+lookupFlagAssignment :: FlagName -> FlagAssignment -> Maybe Bool
+lookupFlagAssignment = lookup
+#endif
+
 llvmVersion :: Version
 llvmVersion = mkVersion [5,0]
 
@@ -125,7 +130,7 @@ main = do
       [llvmVersion] <- liftM lines $ llvmConfig ["--version"]
       let getLibs = liftM (map (fromJust . stripPrefix "-l") . words) . llvmConfig
           flags    = configConfigurationsFlags confFlags
-          linkFlag = case lookup (mkFlagName "shared-llvm") flags of
+          linkFlag = case lookupFlagAssignment (mkFlagName "shared-llvm") flags of
                        Nothing     -> "--link-shared"
                        Just shared -> if shared then "--link-shared" else "--link-static"
       libs       <- getLibs ["--libs", linkFlag]


### PR DESCRIPTION
Two things need to be patched in order for these libraries to build with GHC 8.4:

* Since `Semigroup` is now a superclass of `Monoid`, a `Semigroup` instance needs to be added for `SnocList` in `llvm-hs-pure`.
* The `FlagAssignment` type from `Cabal` is now abstract, so we need to use a `Cabal` function to look up a value from it nowadays. This requires some CPP in `llvm-hs`'s `Setup.hs` script for compatibility with older `Cabal`s.