### PR TITLE
Fix the type of global references

### DIFF
--- a/llvm-hs-pure/src/LLVM/AST/Typed.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Typed.hs
@@ -41,7 +41,7 @@ instance Typed C.Constant where
                                   (x:_) -> typeOf x
   typeOf (C.Undef t)     = t
   typeOf (C.BlockAddress {..})   = ptr i8
-  typeOf (C.GlobalReference t _) = ptr t
+  typeOf (C.GlobalReference t _) = t
   typeOf (C.Add {..})     = typeOf operand0
   typeOf (C.FAdd {..})    = typeOf operand0
   typeOf (C.FDiv {..})    = typeOf operand0

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -40,6 +40,7 @@ import GHC.Generics(Generic)
 import LLVM.AST hiding (function)
 import LLVM.AST.Global
 import LLVM.AST.Linkage
+import LLVM.AST.Type (ptr)
 import qualified LLVM.AST.Constant as C
 
 import LLVM.IRBuilder.Internal.SnocList
@@ -135,7 +136,7 @@ function label argtys retty body = do
       , returnType  = retty
       , basicBlocks = blocks
       }
-    funty = FunctionType retty (fst <$> argtys) False
+    funty = ptr $ FunctionType retty (fst <$> argtys) False
   emitDefn def
   pure $ ConstantOperand $ C.GlobalReference funty label
 
@@ -153,7 +154,7 @@ extern nm argtys retty = do
     , parameters  = ([Parameter ty (mkName "") [] | ty <- argtys], False)
     , returnType  = retty
     }
-  let funty = FunctionType retty argtys False
+  let funty = ptr $ FunctionType retty argtys False
   pure $ ConstantOperand $ C.GlobalReference funty nm
 
 -- | A named type definition

--- a/llvm-hs-pure/test/IRBuilder.hs
+++ b/llvm-hs-pure/test/IRBuilder.hs
@@ -12,8 +12,9 @@ import qualified LLVM.AST.Constant as C
 import qualified LLVM.AST.Float as F
 import           LLVM.AST.Global (basicBlocks, name, parameters, returnType)
 import qualified LLVM.AST.Type as AST
+import qualified LLVM.AST.CallingConvention as CC
 import           Test.Hspec hiding (example)
-
+import qualified LLVM.AST.Instruction as I (function)
 import           LLVM.IRBuilder
 
 main :: IO ()
@@ -50,6 +51,8 @@ main =
               }
             ]
         }
+      it "calls constant globals" $ do
+        callWorksWithConstantGlobals
       it "builds the example" $ do
         let f10 = ConstantOperand (C.Float (F.Double 10))
             fadd a b = FAdd { operand0 = a, operand1 = b, fastMathFlags = NoFastMathFlags, metadata = [] }
@@ -164,6 +167,43 @@ main =
               ]
           }
 
+callWorksWithConstantGlobals = do
+  funcCall `shouldBe` defaultModule
+    { moduleName = "exampleModule"
+    , moduleDefinitions =
+      [ GlobalDefinition functionDefaults {
+          returnType = AST.ptr AST.i8,
+          name = Name "malloc",
+          parameters = ([Parameter (IntegerType {typeBits = 64}) (Name "") []],False),
+          basicBlocks = []
+        }
+      , GlobalDefinition functionDefaults {
+          returnType = VoidType,
+          name = Name "omg",
+          parameters = ([],False),
+          basicBlocks = [
+            BasicBlock (UnName 1) [
+              UnName 0 := Call { tailCallKind = Nothing
+                , I.function = Right (
+                  ConstantOperand (
+                    C.GlobalReference
+                      (AST.ptr $ FunctionType {resultType = AST.ptr $ IntegerType {typeBits = 8}, argumentTypes = [IntegerType {typeBits = 64}], isVarArg = False})
+                      (Name "malloc")
+                    )
+                  )
+                , callingConvention = CC.C
+                , returnAttributes = []
+                , arguments = [(ConstantOperand (C.Int {C.integerBits = 64, C.integerValue = 10}),[])]
+                , functionAttributes = []
+                , metadata = []
+                }
+              ]
+              (Do (Unreachable {metadata' = []}))
+          ]
+        }
+      ]
+    }
+
 simple :: Module
 simple = buildModule "exampleModule" $ mdo
 
@@ -231,6 +271,19 @@ example = mkModule $ execModuleBuilder emptyModuleBuilder $ mdo
   where
     mkModule ds = defaultModule { moduleName = "exampleModule", moduleDefinitions = ds }
     cons = ConstantOperand
+
+funcCall :: Module
+funcCall = mkModule $ execModuleBuilder emptyModuleBuilder $ mdo
+  extern "malloc" [AST.i64] (AST.ptr AST.i8)
+
+  let mallocTy = AST.ptr $ AST.FunctionType (AST.ptr AST.i8) [AST.i64] False
+
+  function "omg" [] (AST.void) $ \_ -> do
+    size <- int64 10
+    call (ConstantOperand $ C.GlobalReference mallocTy "malloc") [(size, [])]
+    unreachable
+  where
+  mkModule ds = defaultModule { moduleName = "exampleModule", moduleDefinitions = ds }
 
 c1 :: Operand
 c1 = ConstantOperand $ C.Float (F.Double 10)

--- a/llvm-hs/src/LLVM/Internal/Constant.hs
+++ b/llvm-hs/src/LLVM/Internal/Constant.hs
@@ -64,7 +64,7 @@ instance EncodeM EncodeAST A.Constant (Ptr FFI.Constant) where
       t <- encodeM (A.IntegerType bits)
       words <- encodeM [
         fromIntegral ((v `shiftR` (w*64)) .&. 0xffffffffffffffff) :: Word64
-        | w <- [0 .. ((fromIntegral bits-1) `div` 64)] 
+        | w <- [0 .. ((fromIntegral bits-1) `div` 64)]
        ]
       liftIO $ FFI.constantIntOfArbitraryPrecision t words
     A.C.Float { A.C.floatValue = v } -> do
@@ -102,7 +102,7 @@ instance EncodeM EncodeAST A.Constant (Ptr FFI.Constant) where
       if ty /= ty'
         then throwM
                (EncodeException
-                  ("The serialized GlobalReference has type " ++ show ty ++ " but should have type " ++ show ty'))
+                  ("The serialized GlobalReference " ++ show n  ++ " has type " ++ show ty ++ " but should have type " ++ show ty'))
         else return ref
     A.C.BlockAddress f b -> do
       f' <- referGlobal f
@@ -163,11 +163,11 @@ instance DecodeM DecodeAST A.Constant (Ptr FFI.Constant) where
     t <- decodeM ft
     valueSubclassId <- liftIO $ FFI.getValueSubclassId v
     nOps <- liftIO $ FFI.getNumOperands u
-    let globalRef = return A.C.GlobalReference 
+    let globalRef = return A.C.GlobalReference
                     `ap` (return t)
                     `ap` (getGlobalName =<< liftIO (FFI.isAGlobalValue v))
         op = decodeM <=< liftIO . FFI.getConstantOperand c
-        getConstantOperands = mapM op [0..nOps-1] 
+        getConstantOperands = mapM op [0..nOps-1]
         getConstantData = do
           let nElements =
                 case t of
@@ -210,8 +210,8 @@ instance DecodeM DecodeAST A.Constant (Ptr FFI.Constant) where
       [valueSubclassIdP|ConstantPointerNull|] -> return $ A.C.Null t
       [valueSubclassIdP|ConstantAggregateZero|] -> return $ A.C.Null t
       [valueSubclassIdP|UndefValue|] -> return $ A.C.Undef t
-      [valueSubclassIdP|BlockAddress|] -> 
-            return A.C.BlockAddress 
+      [valueSubclassIdP|BlockAddress|] ->
+            return A.C.BlockAddress
                `ap` (getGlobalName =<< do liftIO $ FFI.isAGlobalValue =<< FFI.getBlockAddressFunction c)
                `ap` (getLocalName =<< do liftIO $ FFI.getBlockAddressBlock c)
       [valueSubclassIdP|ConstantStruct|] -> do
@@ -219,11 +219,11 @@ instance DecodeM DecodeAST A.Constant (Ptr FFI.Constant) where
                `ap` (return $ case t of A.NamedTypeReference n -> Just n; _ -> Nothing)
                `ap` (decodeM =<< liftIO (FFI.isPackedStruct ft))
                `ap` getConstantOperands
-      [valueSubclassIdP|ConstantDataArray|] -> 
+      [valueSubclassIdP|ConstantDataArray|] ->
             return A.C.Array `ap` (return $ A.elementType t) `ap` getConstantData
-      [valueSubclassIdP|ConstantArray|] -> 
+      [valueSubclassIdP|ConstantArray|] ->
             return A.C.Array `ap` (return $ A.elementType t) `ap` getConstantOperands
-      [valueSubclassIdP|ConstantDataVector|] -> 
+      [valueSubclassIdP|ConstantDataVector|] ->
             return A.C.Vector `ap` getConstantData
       [valueSubclassIdP|ConstantVector|] ->
             A.C.Vector <$> getConstantOperands
@@ -277,5 +277,5 @@ instance DecodeM DecodeAST A.Constant (Ptr FFI.Constant) where
       _ -> error $ "unhandled constant valueSubclassId: " ++ show valueSubclassId
 
 
-  
-  
+
+

--- a/llvm-hs/test/LLVM/Test/Regression.hs
+++ b/llvm-hs/test/LLVM/Test/Regression.hs
@@ -95,5 +95,5 @@ tests =
     , testCase
         "no implicit casts"
         (example2 `shouldThrowEncodeException`
-         "The serialized GlobalReference has type FunctionType {resultType = VoidType, argumentTypes = [], isVarArg = False} but should have type PointerType {pointerReferent = FunctionType {resultType = VoidType, argumentTypes = [], isVarArg = False}, pointerAddrSpace = AddrSpace 0}")
+         "The serialized GlobalReference Name \"test\" has type FunctionType {resultType = VoidType, argumentTypes = [], isVarArg = False} but should have type PointerType {pointerReferent = FunctionType {resultType = VoidType, argumentTypes = [], isVarArg = False}, pointerAddrSpace = AddrSpace 0}")
     ]


### PR DESCRIPTION
This PR solves the issue I was having with https://github.com/llvm-hs/llvm-hs/issues/168.

The problem is that in `llvm-hs/src/LLVM/Internal/Constant.hs` we look at the type stored inside of a `GlobalReference` and compare it with the type we obtain from FFI. This we want to store a function _pointer_ when we're referencing functions. However, in `llvm-hs-pure/src/LLVM/AST/Typed.hs`, `typeOf` `C.GlobalReference` is `ptr t`, which makes it impossible for the IR builder to generate calls to constant `GlobalReference`s. 

This PR fixes this by removing the `ptr t` in `Typed` and instead making sure the IRBuilder emits pointer types in `function` and `extern`.  

