### PR TITLE
 Introduce `AggregateZero` and error on usage of `Null` at non-pointer types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,9 @@ install:
  - unzip ninja-linux.zip -d $HOME/bin
  # - curl http://releases.llvm.org/${LLVM_VER}/llvm-${LLVM_VER}.src.tar.xz | tar -xJf - -C $HOME
  # - rsync -ac $HOME/llvm-${LLVM_VER}.src/ $HOME/llvm-src-${LLVM_VER}
- - curl -L https://github.com/llvm-mirror/llvm/archive/7ed4f7613a05b45aa77c473d2c84d915190c0427.zip -o out.zip
+ - curl -L https://github.com/llvm-mirror/llvm/archive/f1286127b73c0d81ced8595af62e78ed703ced8b.zip -o out.zip
  - unzip -q out.zip -d $HOME
- - rsync -ac $HOME/llvm-7ed4f7613a05b45aa77c473d2c84d915190c0427/ $HOME/llvm-src-${LLVM_VER}
+ - rsync -ac $HOME/llvm-f1286127b73c0d81ced8595af62e78ed703ced8b/ $HOME/llvm-src-${LLVM_VER}
  - cd $HOME/llvm-src-${LLVM_VER}
  - mkdir -p build && cd build
  - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$HOME/llvm-build-${LLVM_VER} -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_BUILD_LLVM_DYLIB=True -DLLVM_LINK_LLVM_DYLIB=True -GNinja ..

--- a/llvm-hs-pure/CHANGELOG.md
+++ b/llvm-hs-pure/CHANGELOG.md
@@ -8,6 +8,10 @@
     setting all fields in the `FastMathFlags` record to
     `False`. Existing uses of `NoFastMathFlags` can be replaced by the
     `noFastMathFlags` value.
+* Add `AggregateZero` for zero-initializing structs, arrays and vectors. Previously `Null`
+  was used for null pointers as  well as zero-inializing aggregates. The new behavior reflects
+  LLVM’s internal representation and the C++-API. Existing uses of `Null` on non-pointer types
+  must be changed to `AggregateZero`.
 
 ## 5.1.2 (2018-01-06)
 

--- a/llvm-hs-pure/src/LLVM/AST/Constant.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Constant.hs
@@ -25,6 +25,7 @@ data Constant
     = Int { integerBits :: Word32, integerValue :: Integer }
     | Float { floatValue :: F.SomeFloat }
     | Null { constantType :: Type }
+    | AggregateZero { constantType :: Type }
     | Struct { structName :: Maybe Name, isPacked :: Bool, memberValues :: [ Constant ] }
     | Array { memberType :: Type, memberValues :: [ Constant ] }
     | Vector { memberValues :: [ Constant ] }

--- a/llvm-hs-pure/src/LLVM/AST/Typed.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Typed.hs
@@ -33,6 +33,7 @@ instance Typed C.Constant where
   typeOf (C.Int bits _)  = IntegerType bits
   typeOf (C.Float t) = typeOf t
   typeOf (C.Null t)      = t
+  typeOf (C.AggregateZero t) = t
   typeOf (C.Struct {..}) = StructureType isPacked (map typeOf memberValues)
   typeOf (C.Array {..})  = ArrayType (fromIntegral $ length memberValues) memberType
   typeOf (C.Vector {..}) = VectorType (fromIntegral $ length memberValues) $

--- a/llvm-hs/CHANGELOG.md
+++ b/llvm-hs/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 6.0.0 (unreleased)
 
 * Support for LLVM 6.0, take a look at the changelog of llvm-hs-pure for details.
+* Add `AggregateZero` for zero-initializing structs, arrays and vectors. Previously `Null`
+  was used for null pointers as  well as zero-inializing aggregates. The new behavior reflects
+  LLVM’s internal representation and the C++-API.
+* Enforce that `Null` is only used on pointer types. Existing uses of `Null` on arrays, structs and
+  vector must be changed to the newly introduced `AggregateZero`.
 
 ## 5.1.3 (2018-01-06)
 

--- a/llvm-hs/test/LLVM/Test/Instructions.hs
+++ b/llvm-hs/test/LLVM/Test/Instructions.hs
@@ -513,7 +513,7 @@ tests = testGroup "Instructions" [
             [Catch (C.Null (ptr i8))],
             "\n          catch i8* null"),
            ("filter",
-            [Filter (C.Null (ArrayType 1 (ptr i8)))],
+            [Filter (C.AggregateZero (ArrayType 1 (ptr i8)))],
             "\n          filter [1 x i8*] zeroinitializer")
           ],
           (cpn, cp, cps) <- [ ("-cleanup", True, "\n          cleanup"), ("", False, "") ],

--- a/llvm-hs/test/LLVM/Test/Optimization.hs
+++ b/llvm-hs/test/LLVM/Test/Optimization.hs
@@ -246,7 +246,7 @@ tests = testGroup "Optimization" [
                 G.name = Name "a",
                 G.linkage = L.Common,
                 G.type' = A.T.ArrayType 2048 i32,
-                G.initializer = Just (C.Null (A.T.ArrayType 2048 i32))
+                G.initializer = Just (C.AggregateZero (A.T.ArrayType 2048 i32))
                },
               GlobalDefinition $ functionDefaults {
                 G.returnType = A.T.void,


### PR DESCRIPTION
This addresses https://github.com/llvm-hs/llvm-hs-pretty/issues/38 by throwing an exception when `Null` is used at non-pointer types. It turns out that previously this was actually necessary in `llvm-hs` since we didn’t differentiate between `AggregateZero` and `Null`, so this is a breaking change even for ASTs that were previously valid.