### PR TITLE
Fix the type of operands generated by extractValue and extractElement.

### DIFF
--- a/llvm-hs-pure/src/LLVM/IRBuilder/Instruction.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Instruction.hs
@@ -133,7 +133,11 @@ bitcast :: MonadIRBuilder m => Operand -> Type -> m Operand
 bitcast a to = emitInstr to $ BitCast a to []
 
 extractElement :: MonadIRBuilder m => Operand -> Operand -> m Operand
-extractElement v i = emitInstr (typeOf v) $ ExtractElement v i []
+extractElement v i = emitInstr elemTyp $ ExtractElement v i []
+  where elemTyp =
+          case typeOf v of
+            VectorType _ typ -> typ
+            _ -> error "extractElement: Expected a vector type (malformed AST)."
 
 insertElement :: MonadIRBuilder m => Operand -> Operand -> Operand -> m Operand
 insertElement v e i = emitInstr (typeOf v) $ InsertElement v e i []
@@ -142,7 +146,7 @@ shuffleVector :: MonadIRBuilder m => Operand -> Operand -> C.Constant -> m Opera
 shuffleVector a b m = emitInstr (typeOf a) $ ShuffleVector a b m []
 
 extractValue :: MonadIRBuilder m => Operand -> [Word32] -> m Operand
-extractValue a i = emitInstr (typeOf a) $ ExtractValue a i []
+extractValue a i = emitInstr (extractValueType i (typeOf a)) $ ExtractValue a i []
 
 insertValue :: MonadIRBuilder m => Operand -> Operand -> [Word32] -> m Operand
 insertValue a e i = emitInstr (typeOf a) $ InsertValue a e i []


### PR DESCRIPTION
Currently, `extractValue` produces an operand with the same type as the structure it extracts an element from (similarly for `extractElement`, the operand has the type of the vector the element is extracted from) while it should have the type of the extracted element.

PS: I've corrected the same issue on the llvm-5 branch, should I create another pull request?