### PR TITLE
Merge IRBuilder test suite into existing test suite

### DIFF
--- a/llvm-hs-pure/llvm-hs-pure.cabal
+++ b/llvm-hs-pure/llvm-hs-pure.cabal
@@ -116,20 +116,5 @@ test-suite test
   main-is: Test.hs
   other-modules:
     LLVM.Test.DataLayout
+    LLVM.Test.IRBuilder
     LLVM.Test.Tests
-
-test-suite test-irbuilder
-  type: exitcode-stdio-1.0
-  main-is: IRBuilder.hs
-  hs-source-dirs:
-      test
-  build-depends:
-      base >=4.8
-    , bytestring
-    , containers
-    , hspec
-    , llvm-hs-pure
-    , mtl
-    , text
-    , transformers
-    , unordered-containers

--- a/llvm-hs-pure/test/LLVM/Test/Tests.hs
+++ b/llvm-hs-pure/test/LLVM/Test/Tests.hs
@@ -3,7 +3,9 @@ module LLVM.Test.Tests where
 import Test.Tasty
 
 import qualified LLVM.Test.DataLayout as DataLayout
+import qualified LLVM.Test.IRBuilder as IRBuilder
 
-tests = testGroup "llvm-hs" [
-    DataLayout.tests
+tests = testGroup "llvm-hs"
+  [ DataLayout.tests
+  , IRBuilder.tests
   ]


### PR DESCRIPTION
The separate HSpec based test suite was an oversight on my part since I built it before we merged `llvm-hs-irbuilder` into `llvm-hs` and at that point I didn’t pay attention to the fact that we already have an existing tasty based testsuite. Merging these test suites makes things a bit simpler and lets us get rid of a bunch of dependencies.