### PR TITLE
Export Semigroup((<>)) from LLVM.Prelude

### DIFF
--- a/llvm-hs-pure/src/LLVM/IRBuilder/Internal/SnocList.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Internal/SnocList.hs
@@ -1,12 +1,7 @@
 {-# LANGUAGE CPP #-}
 module LLVM.IRBuilder.Internal.SnocList where
 
-#if MIN_VERSION_base(4,11,0)
 import LLVM.Prelude
-#else
-import Data.Semigroup (Semigroup(..))
-import LLVM.Prelude hiding ((<>))
-#endif
 
 newtype SnocList a = SnocList { unSnocList :: [a] }
   deriving (Eq, Show)

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
@@ -16,11 +16,12 @@ import Control.Monad.Except
 import Control.Monad.Fail
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Identity
-import Control.Monad.Writer.Lazy as Lazy
-import Control.Monad.Writer.Strict as Strict
+import qualified Control.Monad.Writer.Lazy as Lazy
+import qualified Control.Monad.Writer.Strict as Strict
+import Control.Monad.Writer (MonadWriter)
 import Control.Monad.Reader
-import Control.Monad.RWS.Lazy as Lazy
-import Control.Monad.RWS.Strict as Strict
+import qualified Control.Monad.RWS.Lazy as Lazy
+import qualified Control.Monad.RWS.Strict as Strict
 import qualified Control.Monad.State.Lazy as Lazy
 import Control.Monad.State.Strict
 import Control.Monad.List

--- a/llvm-hs-pure/src/LLVM/Prelude.hs
+++ b/llvm-hs-pure/src/LLVM/Prelude.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE CPP #-}
 -- | This module is presents a prelude mostly like the post-Applicative-Monad world of
--- base >= 4.8 / ghc >= 7.10, even on earlier versions. It's intended as an internal library
+-- base >= 4.8 / ghc >= 7.10, as well as the post-Semigroup-Monoid world of
+-- base >= 4.11 / ghc >= 8.4, even on earlier versions. It's intended as an internal library
 -- for llvm-hs-pure and llvm-hs; it's exposed only to be shared between the two.
 module LLVM.Prelude (
     module Prelude,
@@ -10,6 +10,7 @@ module LLVM.Prelude (
     module Data.Word,
     module Data.Functor,
     module Data.Foldable,
+    module Data.Semigroup,
     module Data.Traversable,
     module Control.Applicative,
     module Control.Monad,
@@ -18,10 +19,7 @@ module LLVM.Prelude (
     fromMaybe,
     leftBiasedZip,
     findM,
-    ifM,
-#if !(MIN_VERSION_base(4,11,0))
-    (<>)
-#endif
+    ifM
     ) where
 
 import Prelude hiding (
@@ -37,10 +35,10 @@ import Data.Data (Data, Typeable)
 import GHC.Generics (Generic)
 import Data.Int
 import Data.Maybe (fromMaybe)
-import Data.Monoid ((<>))
 import Data.Word
 import Data.Functor
 import Data.Foldable
+import Data.Semigroup (Semigroup((<>)))
 import Data.Traversable
 import Control.Applicative
 import Control.Monad hiding (


### PR DESCRIPTION
In `base-4.11`/GHC 8.4.1, `Semigroup((<>))` is reexported from the `Prelude`. However, `LLVM.Prelude` does not do the same, which results in some ugly CPP in a couple parts of `llvm-hs`. We can remove this CPP with relative ease, thankfully, by just reexporting them from `LLVM.Prelude`.

(I originally punted on this idea in #175, but it seems much nicer to just do things this way.)