### PR TITLE
Extract the LinkingLayer into a separate module

### DIFF
--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -123,6 +123,7 @@ library
     LLVM.Internal.ObjectFile
     LLVM.Internal.OrcJIT
     LLVM.Internal.OrcJIT.CompileLayer
+    LLVM.Internal.OrcJIT.LinkingLayer
     LLVM.Internal.OrcJIT.CompileOnDemandLayer
     LLVM.Internal.OrcJIT.IRCompileLayer
     LLVM.Internal.OrcJIT.IRTransformLayer
@@ -166,6 +167,7 @@ library
     LLVM.Internal.FFI.ObjectFile
     LLVM.Internal.FFI.OrcJIT
     LLVM.Internal.FFI.OrcJIT.CompileLayer
+    LLVM.Internal.FFI.OrcJIT.LinkingLayer
     LLVM.Internal.FFI.OrcJIT.CompileOnDemandLayer
     LLVM.Internal.FFI.OrcJIT.IRCompileLayer
     LLVM.Internal.FFI.OrcJIT.IRTransformLayer

--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJIT.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJIT.hs
@@ -9,23 +9,13 @@ import Foreign.Ptr
 
 import LLVM.Internal.FFI.DataLayout
 import LLVM.Internal.FFI.LLVMCTypes
-import LLVM.Internal.FFI.PtrHierarchy
-import LLVM.Internal.FFI.ObjectFile
 
 data JITSymbol
 data LambdaResolver
 
-data LinkingLayer
-
-data ObjectLinkingLayer
-
-instance ChildOf LinkingLayer ObjectLinkingLayer
-
 newtype TargetAddress = TargetAddress Word64
 
 type SymbolResolverFn = CString -> Ptr JITSymbol -> IO ()
-
-newtype ObjectHandle = ObjectHandle Word
 
 foreign import ccall "wrapper" wrapSymbolResolverFn ::
   SymbolResolverFn -> IO (FunPtr SymbolResolverFn)
@@ -40,19 +30,6 @@ foreign import ccall safe "LLVM_Hs_createLambdaResolver" createLambdaResolver ::
 
 foreign import ccall safe "LLVM_Hs_disposeLambdaResolver" disposeLambdaResolver ::
   Ptr LambdaResolver -> IO ()
-
-foreign import ccall safe "LLVM_Hs_createObjectLinkingLayer" createObjectLinkingLayer ::
-  IO (Ptr ObjectLinkingLayer)
-
-foreign import ccall safe "LLVM_Hs_LinkingLayer_dispose" disposeLinkingLayer ::
-  Ptr LinkingLayer -> IO ()
-
-foreign import ccall safe "LLVM_Hs_LinkingLayer_addObject" addObjectFile ::
-  Ptr LinkingLayer ->
-  Ptr ObjectFile ->
-  Ptr LambdaResolver ->
-  Ptr (OwnerTransfered CString) ->
-  IO ObjectHandle
 
 foreign import ccall safe "LLVM_Hs_JITSymbol_getAddress" getAddress ::
   Ptr JITSymbol -> Ptr (OwnerTransfered CString) -> IO TargetAddress

--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJIT/IRCompileLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJIT/IRCompileLayer.hs
@@ -3,7 +3,7 @@ module LLVM.Internal.FFI.OrcJIT.IRCompileLayer where
 
 import LLVM.Prelude
 
-import LLVM.Internal.FFI.OrcJIT
+import LLVM.Internal.FFI.OrcJIT.LinkingLayer
 import LLVM.Internal.FFI.OrcJIT.CompileLayer
 import LLVM.Internal.FFI.PtrHierarchy
 import LLVM.Internal.FFI.Target

--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJIT/LinkingLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJIT/LinkingLayer.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE ForeignFunctionInterface, MultiParamTypeClasses #-}
+
+module LLVM.Internal.FFI.OrcJIT.LinkingLayer where
+
+import LLVM.Prelude
+
+import Foreign.C
+import Foreign.Ptr
+
+import LLVM.Internal.FFI.OrcJIT
+import LLVM.Internal.FFI.LLVMCTypes
+import LLVM.Internal.FFI.PtrHierarchy
+import LLVM.Internal.FFI.ObjectFile
+
+data LinkingLayer
+data ObjectLinkingLayer
+instance ChildOf LinkingLayer ObjectLinkingLayer
+
+newtype ObjectHandle = ObjectHandle Word
+
+foreign import ccall safe "LLVM_Hs_createObjectLinkingLayer" createObjectLinkingLayer ::
+  IO (Ptr ObjectLinkingLayer)
+
+foreign import ccall safe "LLVM_Hs_LinkingLayer_dispose" disposeLinkingLayer ::
+  Ptr LinkingLayer -> IO ()
+
+foreign import ccall safe "LLVM_Hs_LinkingLayer_addObject" addObjectFile ::
+  Ptr LinkingLayer ->
+  Ptr ObjectFile ->
+  Ptr LambdaResolver ->
+  Ptr (OwnerTransfered CString) ->
+  IO ObjectHandle

--- a/llvm-hs/src/LLVM/Internal/ObjectFile.hs
+++ b/llvm-hs/src/LLVM/Internal/ObjectFile.hs
@@ -16,7 +16,7 @@ disposeObjectFile :: ObjectFile -> IO ()
 disposeObjectFile (ObjectFile obj) = FFI.disposeObjectFile obj
 
 -- | Create a object file which can later be linked with the
--- 'LLVM.OrcJIT.LinkingLayer'.
+-- 'LLVM.Internal.OrcJIT.LinkingLayer'.
 --
 -- Note that the file at `path` should already be a compiled object file i.e a
 -- `.o` file. This does *not* compile source files.

--- a/llvm-hs/src/LLVM/Internal/OrcJIT.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT.hs
@@ -13,12 +13,10 @@ import Foreign.C.String
 import Foreign.Ptr
 
 import LLVM.Internal.Coding
-import LLVM.Internal.ObjectFile
 import LLVM.Internal.Target
 import qualified LLVM.Internal.FFI.DataLayout as FFI
 import qualified LLVM.Internal.FFI.LLVMCTypes as FFI
 import qualified LLVM.Internal.FFI.OrcJIT as FFI
-import qualified LLVM.Internal.FFI.PtrHierarchy as FFI
 import qualified LLVM.Internal.FFI.Target as FFI
 
 -- | A mangled symbol which can be used in 'findSymbol'. This can be
@@ -61,22 +59,6 @@ data SymbolResolver =
     -- 'externalResolver' is used as a fallback to find external symbols.
     externalResolver :: !SymbolResolverFn
   }
-
--- | After a 'CompileLayer' has compiled the modules to object code,
--- it passes the resulting object files to a 'LinkingLayer'.
-class LinkingLayer l where
-  getLinkingLayer :: l -> Ptr FFI.LinkingLayer
-  getCleanups :: l -> IORef [IO ()]
-
--- | Bare bones implementation of a 'LinkingLayer'.
-data ObjectLinkingLayer = ObjectLinkingLayer {
-   linkingLayer :: !(Ptr FFI.ObjectLinkingLayer),
-   cleanupActions :: !(IORef [IO ()])
-  }
-
-instance LinkingLayer ObjectLinkingLayer where
-  getLinkingLayer (ObjectLinkingLayer ptr _) = FFI.upCast ptr
-  getCleanups = cleanupActions
 
 instance Monad m => EncodeM m JITSymbolFlags FFI.JITSymbolFlags where
   encodeM f = return $ foldr1 (.|.) [
@@ -130,27 +112,9 @@ allocWithCleanup cleanups alloc free = mask $ \restore -> do
   modifyIORef cleanups (free a :)
   pure a
 
--- | allocate a function pointer and register it for cleanup.
+-- | Allocate a function pointer and register it for cleanup.
 allocFunPtr :: IORef [IO ()] -> IO (FunPtr a) -> IO (FunPtr a)
 allocFunPtr cleanups alloc = allocWithCleanup cleanups alloc freeHaskellFunPtr
-
--- | Dispose of a 'LinkingLayer'.
-disposeLinkingLayer :: LinkingLayer l => l -> IO ()
-disposeLinkingLayer l = do
-  FFI.disposeLinkingLayer (getLinkingLayer l)
-  sequence_ =<< readIORef (getCleanups l)
-
--- | Create a new 'ObjectLinkingLayer'. This should be disposed using
--- 'disposeLinkingLayer' when it is no longer needed.
-newObjectLinkingLayer :: IO ObjectLinkingLayer
-newObjectLinkingLayer = do
-  linkingLayer <- FFI.createObjectLinkingLayer
-  cleanups <- liftIO (newIORef [])
-  return $ ObjectLinkingLayer linkingLayer cleanups
-
--- | 'bracket'-style wrapper around 'newObjectLinkingLayer' and 'disposeLinkingLayer'.
-withObjectLinkingLayer :: (ObjectLinkingLayer -> IO a) -> IO a
-withObjectLinkingLayer = bracket newObjectLinkingLayer disposeLinkingLayer
 
 createRegisteredDataLayout :: (MonadAnyCont IO m) => TargetMachine -> IORef [IO ()] -> m (Ptr FFI.DataLayout)
 createRegisteredDataLayout (TargetMachine tm) cleanups =
@@ -159,18 +123,3 @@ createRegisteredDataLayout (TargetMachine tm) cleanups =
         modifyIORef' cleanups (FFI.disposeDataLayout dl :)
         pure dl
   in anyContToM $ bracketOnError createDataLayout FFI.disposeDataLayout
-
--- | Add an object file to the 'LinkingLayer'. The 'SymbolResolver' is used
--- to resolve external symbols in the module.
-addObjectFile :: LinkingLayer l => l -> ObjectFile -> SymbolResolver
-              -> IO FFI.ObjectHandle
-addObjectFile linkingLayer (ObjectFile obj) resolver = flip runAnyContT return $ do
-  resolverAct <- encodeM resolver
-  resolver'   <- liftIO $ resolverAct (getCleanups linkingLayer)
-  errMsg <- alloca
-  liftIO $
-    FFI.addObjectFile
-      (getLinkingLayer linkingLayer)
-      obj
-      resolver'
-      errMsg

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/CompileLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/CompileLayer.hs
@@ -16,7 +16,7 @@ import qualified LLVM.Internal.FFI.DataLayout as FFI
 import qualified LLVM.Internal.FFI.OrcJIT as FFI
 import qualified LLVM.Internal.FFI.OrcJIT.CompileLayer as FFI
 import LLVM.Internal.Module hiding (getDataLayout)
-import LLVM.Internal.OrcJIT hiding (LinkingLayer(..))
+import LLVM.Internal.OrcJIT
 
 -- | There are two main types of operations provided by instances of 'CompileLayer'.
 --

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/CompileOnDemandLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/CompileOnDemandLayer.hs
@@ -10,7 +10,7 @@ import Data.IORef
 import Foreign.Ptr
 
 import LLVM.Internal.Coding
-import LLVM.Internal.OrcJIT hiding (ObjectLinkingLayer(..))
+import LLVM.Internal.OrcJIT
 import LLVM.Internal.OrcJIT.CompileLayer
 import LLVM.Internal.Target
 import qualified LLVM.Internal.FFI.DataLayout as FFI

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/IRCompileLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/IRCompileLayer.hs
@@ -12,8 +12,9 @@ import qualified LLVM.Internal.FFI.DataLayout as FFI
 import qualified LLVM.Internal.FFI.OrcJIT.CompileLayer as FFI
 import qualified LLVM.Internal.FFI.OrcJIT.IRCompileLayer as FFI
 import qualified LLVM.Internal.FFI.PtrHierarchy as FFI
-import LLVM.Internal.OrcJIT hiding (ObjectLinkingLayer(..))
+import LLVM.Internal.OrcJIT
 import LLVM.Internal.OrcJIT.CompileLayer
+import LLVM.Internal.OrcJIT.LinkingLayer (LinkingLayer(..), getLinkingLayer)
 import LLVM.Internal.Target
 
 -- | 'IRCompileLayer' compiles modules immediately when they are

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/IRTransformLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/IRTransformLayer.hs
@@ -12,7 +12,7 @@ import qualified LLVM.Internal.FFI.DataLayout as FFI
 import qualified LLVM.Internal.FFI.Module as FFI
 import qualified LLVM.Internal.FFI.OrcJIT.IRTransformLayer as FFI
 import qualified LLVM.Internal.FFI.PtrHierarchy as FFI
-import LLVM.Internal.OrcJIT hiding (ObjectLinkingLayer(..))
+import LLVM.Internal.OrcJIT
 import LLVM.Internal.OrcJIT.CompileLayer
 import LLVM.Internal.Target
 

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/LinkingLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/LinkingLayer.hs
@@ -1,0 +1,64 @@
+module LLVM.Internal.OrcJIT.LinkingLayer where
+
+import LLVM.Prelude
+
+import Control.Exception
+import Control.Monad.AnyCont
+import Control.Monad.IO.Class
+import Data.IORef
+import Foreign.Ptr
+
+import LLVM.Internal.OrcJIT
+import LLVM.Internal.Coding
+import LLVM.Internal.ObjectFile
+import qualified LLVM.Internal.FFI.PtrHierarchy as FFI
+import qualified LLVM.Internal.FFI.OrcJIT.LinkingLayer as FFI
+
+-- | After a 'CompileLayer' has compiled the modules to object code,
+-- it passes the resulting object files to a 'LinkingLayer'.
+class LinkingLayer l where
+  getLinkingLayer :: l -> Ptr FFI.LinkingLayer
+  getCleanups :: l -> IORef [IO ()]
+
+-- | Dispose of a 'LinkingLayer'.
+disposeLinkingLayer :: LinkingLayer l => l -> IO ()
+disposeLinkingLayer l = do
+  FFI.disposeLinkingLayer (getLinkingLayer l)
+  sequence_ =<< readIORef (getCleanups l)
+
+-- | Add an object file to the 'LinkingLayer'. The 'SymbolResolver' is used
+-- to resolve external symbols in the module.
+addObjectFile :: LinkingLayer l => l -> ObjectFile -> SymbolResolver
+              -> IO FFI.ObjectHandle
+addObjectFile linkingLayer (ObjectFile obj) resolver = flip runAnyContT return $ do
+  resolverAct <- encodeM resolver
+  resolver'   <- liftIO $ resolverAct (getCleanups linkingLayer)
+  errMsg <- alloca
+  liftIO $
+    FFI.addObjectFile
+      (getLinkingLayer linkingLayer)
+      obj
+      resolver'
+      errMsg
+
+-- | Bare bones implementation of a 'LinkingLayer'.
+data ObjectLinkingLayer = ObjectLinkingLayer {
+   linkingLayer :: !(Ptr FFI.ObjectLinkingLayer),
+   cleanupActions :: !(IORef [IO ()])
+  }
+
+instance LinkingLayer ObjectLinkingLayer where
+  getLinkingLayer (ObjectLinkingLayer ptr _) = FFI.upCast ptr
+  getCleanups = cleanupActions
+
+-- | Create a new 'ObjectLinkingLayer'. This should be disposed using
+-- 'disposeLinkingLayer' when it is no longer needed.
+newObjectLinkingLayer :: IO ObjectLinkingLayer
+newObjectLinkingLayer = do
+  linkingLayer <- FFI.createObjectLinkingLayer
+  cleanups <- liftIO (newIORef [])
+  return $ ObjectLinkingLayer linkingLayer cleanups
+
+-- | 'bracket'-style wrapper around 'newObjectLinkingLayer' and 'disposeLinkingLayer'.
+withObjectLinkingLayer :: (ObjectLinkingLayer -> IO a) -> IO a
+withObjectLinkingLayer = bracket newObjectLinkingLayer disposeLinkingLayer

--- a/llvm-hs/src/LLVM/OrcJIT.hs
+++ b/llvm-hs/src/LLVM/OrcJIT.hs
@@ -53,6 +53,7 @@ module LLVM.OrcJIT (
 
 import LLVM.Internal.OrcJIT
 import LLVM.Internal.OrcJIT.CompileLayer
+import LLVM.Internal.OrcJIT.LinkingLayer
 import LLVM.Internal.OrcJIT.CompileOnDemandLayer
 import LLVM.Internal.OrcJIT.IRCompileLayer
 import LLVM.Internal.OrcJIT.IRTransformLayer


### PR DESCRIPTION
This implements the second bullet point listed in #189.

> Move the LinkingLayer related things out into a new module.
This would be a good refactor. Currently, the LinkingLayer resides in Internal.OrcJIT. But now it has enough things associated with it (which would only increase after we implement (1)) that having a separate module would be better.

