### PR TITLE
Rename type in a GlobalReference before checking if it matches the

### DIFF
--- a/llvm-hs/src/LLVM/Internal/Constant.hs
+++ b/llvm-hs/src/LLVM/Internal/Constant.hs
@@ -47,7 +47,7 @@ import LLVM.Internal.DecodeAST
 import LLVM.Internal.EncodeAST
 import LLVM.Internal.FloatingPointPredicate ()
 import LLVM.Internal.IntegerPredicate ()
-import LLVM.Internal.Type ()
+import LLVM.Internal.Type (renameType)
 import LLVM.Internal.Value
 
 allocaWords :: forall a m . (Storable a, MonadAnyCont IO m, Monad m, MonadIO m) => Word32 -> m (Ptr a)
@@ -99,7 +99,8 @@ instance EncodeM EncodeAST A.Constant (Ptr FFI.Constant) where
     A.C.GlobalReference ty n -> do
       ref <- FFI.upCast <$> referGlobal n
       ty' <- (liftIO . runDecodeAST . typeOf) ref
-      if ty /= ty'
+      renamedTy <- renameType ty
+      if renamedTy /= ty'
         then throwM
                (EncodeException
                   ("The serialized GlobalReference " ++ show n  ++ " has type " ++ show ty ++ " but should have type " ++ show ty'))

--- a/llvm-hs/src/LLVM/Internal/FFI/LLVMCTypes.hsc
+++ b/llvm-hs/src/LLVM/Internal/FFI/LLVMCTypes.hsc
@@ -98,7 +98,7 @@ newtype LLVMBool = LLVMBool CUInt
 -- this value needs to be freed after it has been processed. Usually
 -- this is done automatically in the 'DecodeM' instance.
 newtype OwnerTransfered a = OwnerTransfered a
-  deriving (Storable)
+  deriving (Eq, Storable)
 
 newtype NothingAsMinusOne h = NothingAsMinusOne CInt
   deriving (Storable)

--- a/llvm-hs/src/LLVM/Internal/FFI/Type.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Type.hs
@@ -78,7 +78,7 @@ structTypeInContext :: Ptr Context -> (CUInt, Ptr (Ptr Type)) -> LLVMBool -> IO 
 structTypeInContext ctx (n, ts) p = structTypeInContext' ctx ts n p
 
 foreign import ccall unsafe "LLVM_Hs_StructCreateNamed" structCreateNamed ::
-  Ptr Context -> CString -> IO (Ptr Type)
+  Ptr Context -> CString -> Ptr (OwnerTransfered CString) -> IO (Ptr Type)
 
 foreign import ccall unsafe "LLVMGetStructName" getStructName ::
   Ptr Type -> IO CString

--- a/llvm-hs/src/LLVM/Internal/FFI/TypeC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/TypeC.cpp
@@ -8,10 +8,13 @@ using namespace llvm;
 
 extern "C" {
 
-LLVMTypeRef LLVM_Hs_StructCreateNamed(LLVMContextRef C, const char *Name) {
+LLVMTypeRef LLVM_Hs_StructCreateNamed(LLVMContextRef C, const char *Name, char** renamedName) {
     if (Name) {
-        return wrap(StructType::create(*unwrap(C), Name));
+        auto t = StructType::create(*unwrap(C), Name);
+        *renamedName = strdup(t->getName().str().c_str());
+        return wrap(t);
     } else {
+        *renamedName = nullptr;
         return wrap(StructType::create(*unwrap(C)));
     }
 }

--- a/llvm-hs/src/LLVM/Internal/Module.hs
+++ b/llvm-hs/src/LLVM/Internal/Module.hs
@@ -259,8 +259,8 @@ withModuleFromAST context@(Context c) (A.Module moduleId sourceFileName dataLayo
       sequencePhases l = (l >>= (sequence >=> sequence >=> sequence >=> sequence)) >> (return ())
   sequencePhases $ forM definitions $ \d -> case d of
    A.TypeDefinition n t -> do
-     t' <- createNamedType n
-     defineType n t'
+     (t', n') <- createNamedType n
+     defineType n n' t'
      return $ do
        traverse_ (setNamedType t') t
        return . return . return . return $ ()


### PR DESCRIPTION
type of a reference

LLVM will automatically rename types if a type of that name
already exists. The existing check would thus fail since the type
fetched from LLVM is renamed while the type on the Haskell side still
uses the original name. This patch addresses this problem by renaming
the type on the Haskell side according to the names chosen by LLVM
before comparing them.

@JLimperg This should fix the issue you found in #200.