### PR TITLE
Metadata fixes

### DIFF
--- a/llvm-hs-pure/CHANGELOG.md
+++ b/llvm-hs-pure/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 6.2.0 (unreleased)
+
+* Remove field prefixes from `DIDerivedType` to make the API
+  consistent with the other debug metadata types.
+* Change the type of the scope fields in `DIModule` and `DINamespace`
+  to `Maybe (MDRef DIScope)` to reflect that they can be optional.
+
 ## 6.1.0 (2018-05-05)
 
 * IRBuilder: Ensure that automatically generated block labels are

--- a/llvm-hs-pure/CHANGELOG.md
+++ b/llvm-hs-pure/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 6.2.0 (unreleased)
 
-* Remove field prefixes from `DIDerivedType` to make the API
-  consistent with the other debug metadata types.
+* Remove field prefixes from `DIDerivedType`, `DIBasicType` and
+  `DISubroutineType` to make the API consistent with the other debug
+  metadata types.
 * Change the type of the scope fields in `DIModule` and `DINamespace`
   to `Maybe (MDRef DIScope)` to reflect that they can be optional.
 

--- a/llvm-hs-pure/llvm-hs-pure.cabal
+++ b/llvm-hs-pure/llvm-hs-pure.cabal
@@ -1,5 +1,5 @@
 name: llvm-hs-pure
-version: 6.1.0
+version: 6.2.0
 license: BSD3
 license-file: LICENSE
 author: Anthony Cowley, Stephen Diehl, Moritz Kiefer <moritz.kiefer@purelyfunctional.org>, Benjamin S. Scarlet

--- a/llvm-hs-pure/src/LLVM/AST/Operand.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Operand.hs
@@ -214,7 +214,7 @@ data DIScope
   deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
 
 data DIModule = Module
-  { scope :: MDRef DIScope
+  { scope :: Maybe (MDRef DIScope)
   , name :: ShortByteString
   , configurationMacros :: ShortByteString
   , includePath :: ShortByteString
@@ -223,7 +223,7 @@ data DIModule = Module
 
 data DINamespace = Namespace
   { name :: ShortByteString
-  , scope :: MDRef DIScope
+  , scope :: Maybe (MDRef DIScope)
   , exportSymbols :: Bool
   } deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
 

--- a/llvm-hs-pure/src/LLVM/AST/Operand.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Operand.hs
@@ -342,17 +342,17 @@ data DerivedTypeTag
 -- | <https://llvm.org/docs/LangRef.html#diderivedtype>
 data DIDerivedType =
   DerivedType
-    { derivedTag :: DerivedTypeTag
-    , derivedName :: ShortByteString
-    , derivedFile :: Maybe (MDRef DIFile)
-    , derivedLine :: Word32
-    , derivedScope :: Maybe (MDRef DIScope)
-    , derivedBaseType :: MDRef DIType
+    { tag :: DerivedTypeTag
+    , name :: ShortByteString
+    , file :: Maybe (MDRef DIFile)
+    , line :: Word32
+    , scope :: Maybe (MDRef DIScope)
+    , baseType :: MDRef DIType
     , sizeInBits :: Word64
     , alignInBits :: Word32
-    , derivedOffsetInBits :: Word64
-    , derivedAddressSpace :: Maybe Word32
-    , derivedFlags :: [DIFlag]
+    , offsetInBits :: Word64
+    , addressSpace :: Maybe Word32
+    , flags :: [DIFlag]
     } deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
 
 -- | <https://llvm.org/docs/LangRef.html#dicompositetype>

--- a/llvm-hs-pure/src/LLVM/AST/Operand.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Operand.hs
@@ -308,18 +308,18 @@ data DIType
 
 -- | <https://llvm.org/docs/LangRef.html#dibasictype>
 data DIBasicType = BasicType
-  { typeName :: ShortByteString
+  { name :: ShortByteString
   , sizeInBits :: Word64
   , alignInBits :: Word32
-  , typeEncoding :: Maybe Encoding
-  , typeTag :: BasicTypeTag
+  , encoding :: Maybe Encoding
+  , tag :: BasicTypeTag
   } deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
 
 -- | <https://llvm.org/docs/LangRef.html#disubroutinetype>
 data DISubroutineType = SubroutineType
-  { typeFlags :: [DIFlag]
-  , typeCC :: Word8
-  , typeTypeArray :: [Maybe (MDRef DIType)]
+  { flags :: [DIFlag]
+  , cc :: Word8
+  , typeArray :: [Maybe (MDRef DIType)]
   -- ^ The first element is the return type, the following are the
   -- operand types. `Nothing` corresponds to @void@.
   } deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)

--- a/llvm-hs/CHANGELOG.md
+++ b/llvm-hs/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 6.2.0 (unreleased)
+
+* Remove field prefixes from `DIDerivedType` to make the API
+  consistent with the other debug metadata types.
+* Change the type of the scope fields in `DIModule` and `DINamespace`
+  to `Maybe (MDRef DIScope)` to reflect that they can be optional.
+
 ## 6.1.1 (2018-05-06)
 
 * Fix the source distribution by adding missing files to extra-source-files.

--- a/llvm-hs/CHANGELOG.md
+++ b/llvm-hs/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 6.2.0 (unreleased)
 
-* Remove field prefixes from `DIDerivedType` to make the API
-  consistent with the other debug metadata types.
+* Remove field prefixes from `DIDerivedType`, `DIBasicType` and
+  `DISubroutineType` to make the API consistent with the other debug
+  metadata types.
 * Change the type of the scope fields in `DIModule` and `DINamespace`
   to `Maybe (MDRef DIScope)` to reflect that they can be optional.
 

--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -1,5 +1,5 @@
 name: llvm-hs
-version: 6.1.1
+version: 6.2.0
 license: BSD3
 license-file: LICENSE
 author: Anthony Cowley, Stephen Diehl, Moritz Kiefer <moritz.kiefer@purelyfunctional.org>, Benjamin S. Scarlet
@@ -75,7 +75,7 @@ library
     template-haskell >= 2.5.0.0,
     containers >= 0.4.2.1,
     array >= 0.4.0.0,
-    llvm-hs-pure == 6.1.*
+    llvm-hs-pure == 6.2.*
   hs-source-dirs: src
   default-extensions:
     NoImplicitPrelude

--- a/llvm-hs/src/LLVM/Internal/Operand.hs
+++ b/llvm-hs/src/LLVM/Internal/Operand.hs
@@ -542,19 +542,19 @@ instance DecodeM DecodeAST A.DIBasicType (Ptr FFI.DIBasicType) where
 
 instance EncodeM EncodeAST A.DIBasicType (Ptr FFI.DIBasicType) where
   encodeM A.BasicType {..} = do
-    tag <- encodeM typeTag
-    typeName <- encodeM typeName
-    typeEncoding <- encodeM typeEncoding
+    tag <- encodeM tag
+    name <- encodeM name
+    encoding <- encodeM encoding
     Context c <- gets encodeStateContext
-    liftIO (FFI.getDIBasicType c tag typeName sizeInBits alignInBits typeEncoding)
+    liftIO (FFI.getDIBasicType c tag name sizeInBits alignInBits encoding)
 
 
 instance EncodeM EncodeAST A.DISubroutineType (Ptr FFI.DISubroutineType) where
   encodeM A.SubroutineType {..} = do
-    flags <- encodeM typeFlags
-    types <- encodeM typeTypeArray
+    flags <- encodeM flags
+    types <- encodeM typeArray
     Context c <- gets encodeStateContext
-    liftIO (FFI.getDISubroutineType c flags typeCC types)
+    liftIO (FFI.getDISubroutineType c flags cc types)
 
 instance DecodeM DecodeAST A.DISubroutineType (Ptr FFI.DISubroutineType) where
   decodeM p = do
@@ -562,9 +562,9 @@ instance DecodeM DecodeAST A.DISubroutineType (Ptr FFI.DISubroutineType) where
     cc <-  liftIO (FFI.getSubroutineCC p)
     arr <- decodeM =<< liftIO (FFI.getSubroutineTypeArray p)
     pure A.SubroutineType
-      { A.typeFlags = flags
-      , A.typeCC = cc
-      , A.typeTypeArray = arr
+      { A.flags = flags
+      , A.cc = cc
+      , A.typeArray = arr
       }
 
 instance EncodeM EncodeAST A.DIDerivedType (Ptr FFI.DIDerivedType) where

--- a/llvm-hs/src/LLVM/Internal/Operand.hs
+++ b/llvm-hs/src/LLVM/Internal/Operand.hs
@@ -569,16 +569,16 @@ instance DecodeM DecodeAST A.DISubroutineType (Ptr FFI.DISubroutineType) where
 
 instance EncodeM EncodeAST A.DIDerivedType (Ptr FFI.DIDerivedType) where
   encodeM A.DerivedType {..} = do
-    tag <- encodeM derivedTag
-    name <- encodeM derivedName
-    file <- encodeM derivedFile
-    line <- encodeM derivedLine
-    scope <- encodeM derivedScope
-    type' <- encodeM derivedBaseType
-    (addrSpace, addrSpacePresent) <- encodeM derivedAddressSpace
-    flags <- encodeM derivedFlags
+    tag <- encodeM tag
+    name <- encodeM name
+    file <- encodeM file
+    line <- encodeM line
+    scope <- encodeM scope
+    type' <- encodeM baseType
+    (addrSpace, addrSpacePresent) <- encodeM addressSpace
+    flags <- encodeM flags
     Context c <- gets encodeStateContext
-    FFI.upCast <$> liftIO (FFI.getDIDerivedType c tag name file line scope type' sizeInBits alignInBits derivedOffsetInBits addrSpace addrSpacePresent flags)
+    FFI.upCast <$> liftIO (FFI.getDIDerivedType c tag name file line scope type' sizeInBits alignInBits offsetInBits addrSpace addrSpacePresent flags)
 
 instance DecodeM DecodeAST A.DIDerivedType (Ptr FFI.DIDerivedType) where
   decodeM diTy = do
@@ -595,17 +595,17 @@ instance DecodeM DecodeAST A.DIDerivedType (Ptr FFI.DIDerivedType) where
     flags <- decodeM =<< liftIO (FFI.getTypeFlags diTy')
     addressSpace <- decodeOptional (FFI.getDerivedAddressSpace diTy')
     pure A.DerivedType
-      { A.derivedTag = tag
-      , A.derivedName = name
-      , A.derivedFile = file
-      , A.derivedLine = line
-      , A.derivedScope = scope
-      , A.derivedBaseType = ty
+      { A.tag = tag
+      , A.name = name
+      , A.file = file
+      , A.line = line
+      , A.scope = scope
+      , A.baseType = ty
       , A.sizeInBits = size
       , A.alignInBits = align
-      , A.derivedOffsetInBits = offset
-      , A.derivedAddressSpace = addressSpace
-      , A.derivedFlags = flags
+      , A.offsetInBits = offset
+      , A.addressSpace = addressSpace
+      , A.flags = flags
       }
 
 genCodingInstance [t|A.DerivedTypeTag|] ''FFI.DwTag

--- a/llvm-hs/test/LLVM/Test/Metadata.hs
+++ b/llvm-hs/test/LLVM/Test/Metadata.hs
@@ -612,6 +612,7 @@ roundtripDINamespace = testProperty "rountrip DINamespace" $ \diFile ->
       let mod = defaultModule
             { moduleDefinitions =
                 [ NamedMetadataDefinition "dummy" [namespaceID]
+                , NamedMetadataDefinition "dummy2" [fileID]
                 , MetadataNodeDefinition namespaceID (DINode (DIScope (DINamespace diNamespace)))
                 , MetadataNodeDefinition fileID (DINode (DIScope (DIFile diFile)))
                 ]
@@ -622,7 +623,7 @@ roundtripDINamespace = testProperty "rountrip DINamespace" $ \diFile ->
         fileID = MetadataNodeID 1
 
 genDINamespace :: MDRef DIScope -> Gen DINamespace
-genDINamespace scope = Namespace <$> arbitrarySbs <*> pure scope <*> arbitrary
+genDINamespace scope = Namespace <$> arbitrarySbs <*> QC.elements [Nothing, Just scope] <*> arbitrary
 
 diFlagName :: TestTree
 diFlagName =


### PR DESCRIPTION
This fixes a bug that I noticed while updating `llvm-hs-pretty` where some fields are required to be present in the textual IR but can be set to `null` explicitely and thereby need to be represented by a Maybe anyway. I’ve also noticed some inconsistencies that I’m a bit embarrassed by where I forgot to remove field prefixes after I switched the API to use `DuplicateRecordFields`. Luckily 6.1 has only just been released so I expect that changing this now will break very few if any projects at all. 