### PR TITLE
Update return type of FFI/MetadataC.cpp

### DIFF
--- a/llvm-hs/src/LLVM/Internal/FFI/MetadataC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/MetadataC.cpp
@@ -536,7 +536,7 @@ unsigned LLVM_Hs_DIExpression_GetNumElements(DIExpression* e) {
     return e->getNumElements();
 }
 
-unsigned LLVM_Hs_DIExpression_GetElement(DIExpression* e, unsigned i) {
+uint64_t LLVM_Hs_DIExpression_GetElement(DIExpression* e, unsigned i) {
     return e->getElement(i);
 }
 


### PR DESCRIPTION
**Problem:**
In Mac OS X, unsigned integers has 32 bit space, but the existing implementation of metadata tests can provide more than 32-bit integers, which cause metadata tests to fail on mac os x.

**Solution:**
This PR fixes the issue by explicitly stating uint64_t return type in `MetadataC`.