### PR TITLE
Finding symbols at linking phase

### DIFF
--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -250,9 +250,8 @@ test-suite test
     transformers >= 0.3.0.0,
     temporary >= 1.2 && < 1.4,
     pretty-show >= 1.6 && < 1.8,
-    process >= 1.6.3.0,
-    unix >= 2.7.2.2,
-    directory >= 1.3.2.2
+    process,
+    temporary
   hs-source-dirs: test
   default-extensions:
     TupleSections

--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -249,7 +249,10 @@ test-suite test
     mtl >= 2.1,
     transformers >= 0.3.0.0,
     temporary >= 1.2 && < 1.4,
-    pretty-show >= 1.6 && < 1.8
+    pretty-show >= 1.6 && < 1.8,
+    process >= 1.6.3.0,
+    unix >= 2.7.2.2,
+    directory >= 1.3.2.2
   hs-source-dirs: test
   default-extensions:
     TupleSections

--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJIT/LinkingLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJIT/LinkingLayer.hs
@@ -30,3 +30,16 @@ foreign import ccall safe "LLVM_Hs_LinkingLayer_addObject" addObjectFile ::
   Ptr LambdaResolver ->
   Ptr (OwnerTransfered CString) ->
   IO ObjectHandle
+
+foreign import ccall safe "LLVM_Hs_LinkingLayer_findSymbol" findSymbol ::
+  Ptr LinkingLayer ->
+  CString ->
+  LLVMBool ->
+  IO (Ptr JITSymbol)
+
+foreign import ccall safe "LLVM_Hs_LinkingLayer_findSymbolIn" findSymbolIn ::
+  Ptr LinkingLayer ->
+  ObjectHandle ->
+  CString ->
+  LLVMBool ->
+  IO (Ptr JITSymbol)

--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp
@@ -301,6 +301,21 @@ void LLVM_Hs_LinkingLayer_dispose(LinkingLayer *linkingLayer) {
 
 void LLVM_Hs_disposeJITSymbol(LLVMJITSymbolRef symbol) { delete symbol; }
 
+LLVMJITSymbolRef LLVM_Hs_LinkingLayer_findSymbol(LinkingLayer *linkingLayer,
+                                     StringRef name,
+                                     LLVMBool exportedSymbolsOnly) {
+  JITSymbol symbol = linkingLayer->findSymbol(name, exportedSymbolsOnly);
+  return new JITSymbol(std::move(symbol));
+}
+
+LLVMJITSymbolRef LLVM_Hs_LinkingLayer_findSymbolIn(LinkingLayer *linkingLayer,
+                                                   LLVMObjectHandle handle,
+                                                   const char *name,
+                                                   LLVMBool exportedSymbolsOnly) {
+  JITSymbol symbol = linkingLayer->findSymbolIn(handle, name, exportedSymbolsOnly);
+  return new JITSymbol(std::move(symbol));
+}
+
 LLVMLambdaResolverRef LLVM_Hs_createLambdaResolver(
     void (*dylibResolver)(const char *, LLVMJITSymbolRef),
     void (*externalResolver)(const char *, LLVMJITSymbolRef)) {

--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp
@@ -302,7 +302,7 @@ void LLVM_Hs_LinkingLayer_dispose(LinkingLayer *linkingLayer) {
 void LLVM_Hs_disposeJITSymbol(LLVMJITSymbolRef symbol) { delete symbol; }
 
 LLVMJITSymbolRef LLVM_Hs_LinkingLayer_findSymbol(LinkingLayer *linkingLayer,
-                                     StringRef name,
+                                     const char *name,
                                      LLVMBool exportedSymbolsOnly) {
   JITSymbol symbol = linkingLayer->findSymbol(name, exportedSymbolsOnly);
   return new JITSymbol(std::move(symbol));

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/LinkingLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/LinkingLayer.hs
@@ -68,7 +68,7 @@ withObjectLinkingLayer = bracket newObjectLinkingLayer disposeLinkingLayer
 -- | @'findSymbol' layer symbol exportedSymbolsOnly@ searches for
 -- @symbol@ in all modules added to @layer@. If @exportedSymbolsOnly@
 -- is 'True' only exported symbols are searched.
-findSymbol :: LinkingLayer l => l -> ShortByteString -> Bool -> IO JITSymbol
+findSymbol :: LinkingLayer l => l -> ShortByteString -> Bool -> IO (Either JITSymbolError JITSymbol)
 findSymbol linkingLayer symbol exportedSymbolsOnly =
   SBS.useAsCString symbol $ \symbol' ->
     flip runAnyContT return $ do
@@ -80,7 +80,7 @@ findSymbol linkingLayer symbol exportedSymbolsOnly =
 -- | @'findSymbolIn' layer handle symbol exportedSymbolsOnly@ searches for
 -- @symbol@ in the context of the module represented by @handle@. If
 -- @exportedSymbolsOnly@ is 'True' only exported symbols are searched.
-findSymbolIn :: LinkingLayer l => l -> FFI.ObjectHandle -> ShortByteString -> Bool -> IO JITSymbol
+findSymbolIn :: LinkingLayer l => l -> FFI.ObjectHandle -> ShortByteString -> Bool -> IO (Either JITSymbolError JITSymbol)
 findSymbolIn linkingLayer handle symbol exportedSymbolsOnly =
   SBS.useAsCString symbol $ \symbol' ->
     flip runAnyContT return $ do

--- a/llvm-hs/src/LLVM/OrcJIT.hs
+++ b/llvm-hs/src/LLVM/OrcJIT.hs
@@ -7,8 +7,6 @@ module LLVM.OrcJIT (
     removeModule,
     withModule,
     -- ** Search for symbols
-    findSymbol,
-    findSymbolIn,
     JITSymbol(..),
     JITSymbolFlags(..),
     SymbolResolver(..),

--- a/llvm-hs/test/LLVM/Test/OrcJIT.hs
+++ b/llvm-hs/test/LLVM/Test/OrcJIT.hs
@@ -136,8 +136,7 @@ tests =
                 mod
                 (SymbolResolver (resolver testFunc compileLayer) nullResolver) $
                 \moduleHandle -> do
-                  mainSymbol <- mangleSymbol compileLayer "main"
-                  JITSymbol mainFn _ <- LL.findSymbol linkingLayer mainSymbol True
+                  JITSymbol mainFn _ <- LL.findSymbol linkingLayer "main" True
                   result <- mkMain (castPtrToFunPtr (wordPtrToPtr mainFn))
                   result @?= 42
   ]

--- a/llvm-hs/test/LLVM/Test/OrcJIT.hs
+++ b/llvm-hs/test/LLVM/Test/OrcJIT.hs
@@ -90,7 +90,7 @@ tests =
                   result <- mkMain (castPtrToFunPtr (wordPtrToPtr mainFn))
                   result @?= 42
                   unknownSymbol <- mangleSymbol compileLayer "unknownSymbol"
-                  unknownSymbolRes <- findSymbol compileLayer unknownSymbol True
+                  unknownSymbolRes <- CL.findSymbol compileLayer unknownSymbol True
                   unknownSymbolRes @?= Left (JITSymbolError mempty),
 
     testCase "IRTransformLayer" $ do
@@ -143,12 +143,12 @@ tests =
           objectHandle <- addObjectFile linkingLayer objFile resl
 
           -- Find main symbol by looking into global linking context
-          JITSymbol mainFn _ <- LL.findSymbol linkingLayer "main" True
+          Right (JITSymbol mainFn _) <- LL.findSymbol linkingLayer "main" True
           result <- mkMain (castPtrToFunPtr (wordPtrToPtr mainFn))
           result @?= 38
 
           -- Find main symbol by specificly using object handle for given object file
-          JITSymbol mainFn _ <- LL.findSymbolIn linkingLayer objectHandle "main" True
+          Right (JITSymbol mainFn _) <- LL.findSymbolIn linkingLayer objectHandle "main" True
           result <- mkMain (castPtrToFunPtr (wordPtrToPtr mainFn))
           result @?= 38
     ]

--- a/llvm-hs/test/main_return_38.c
+++ b/llvm-hs/test/main_return_38.c
@@ -1,0 +1,3 @@
+int main() {
+  return 38;
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,6 +8,3 @@ flags:
     shared-llvm: true
 
 extra-package-dbs: []
-extra-deps:
-  - 'process-1.6.3.0'
-  - 'directory-1.3.2.2'

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,3 +8,6 @@ flags:
     shared-llvm: true
 
 extra-package-dbs: []
+extra-deps:
+  - 'process-1.6.3.0'
+  - 'directory-1.3.2.2'


### PR DESCRIPTION
Closes #189.

Given an object file, by utilising `findSymbol` function in linking phase, we can now find symbols from object files.

A test case, given a `C` file, compiles `C` files to an object file, then looks up for `main` symbol in this object file and asserts the results.