### PR TITLE
Avoid constant folding during instruction encoding

### DIFF
--- a/llvm-hs/CHANGELOG.md
+++ b/llvm-hs/CHANGELOG.md
@@ -7,6 +7,10 @@
   JITSymbolError JITSymbol`. It is fine to return a 0 address in
   `Right` so existing resolvers can be adapted by wrapping the result
   in `Right`.
+* Fixed a bug where instructions were constant-folded during
+  encoding. This caused problems since the API available on a Constant
+  is not the same as the one on an Instruction (e.g., we cannot set
+  metadata on a Constant).
 
 ## 6.2.0 (2018-05-08)
 

--- a/llvm-hs/src/LLVM/Internal/FFI/Builder.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Builder.hs
@@ -83,7 +83,7 @@ $(do
       _ -> []
 
     let ats = map typeMapping (fieldTypes List.\\ [TH.ConT ''A.InstructionMetadata, TH.ConT ''A.FastMathFlags])
-        cName = (if hasFlags fieldTypes then "LLVM_Hs_" else "LLVM") ++ "Build" ++ a
+        cName = "LLVM_Hs_Build" ++ a
     rt <- case k of
             ID.Binary -> [[t| BinaryOperator |]]
             ID.Cast -> [[t| Instruction |]]
@@ -106,10 +106,10 @@ foreign import ccall unsafe "LLVM_Hs_BuildStore" buildStore' ::
 buildStore :: Ptr Builder -> LLVMBool -> Ptr Value -> Ptr Value -> (SynchronizationScope, MemoryOrdering) -> CUInt -> CString -> IO (Ptr Instruction)
 buildStore builder vol a' v' (ss, mo) al s = buildStore' builder vol a' v' mo ss al s
 
-foreign import ccall unsafe "LLVMBuildGEP" buildGetElementPtr' ::
+foreign import ccall unsafe "LLVM_Hs_BuildGEP" buildGetElementPtr' ::
   Ptr Builder -> Ptr Value -> Ptr (Ptr Value) -> CUInt -> CString -> IO (Ptr Instruction)
 
-foreign import ccall unsafe "LLVMBuildInBoundsGEP" buildInBoundsGetElementPtr' ::
+foreign import ccall unsafe "LLVM_Hs_BuildInBoundsGEP" buildInBoundsGetElementPtr' ::
   Ptr Builder -> Ptr Value -> Ptr (Ptr Value) -> CUInt -> CString -> IO (Ptr Instruction)
 
 buildGetElementPtr :: Ptr Builder -> LLVMBool -> Ptr Value -> (CUInt, Ptr (Ptr Value)) -> CString -> IO (Ptr Instruction)
@@ -135,7 +135,7 @@ foreign import ccall unsafe "LLVM_Hs_BuildAtomicRMW" buildAtomicRMW' ::
 buildAtomicRMW :: Ptr Builder -> LLVMBool -> RMWOperation -> Ptr Value -> Ptr Value -> (SynchronizationScope, MemoryOrdering) -> CString -> IO (Ptr Instruction)
 buildAtomicRMW builder vol rmwOp a v (ss, mo) s = buildAtomicRMW' builder vol rmwOp a v mo ss s
 
-foreign import ccall unsafe "LLVMBuildICmp" buildICmp ::
+foreign import ccall unsafe "LLVM_Hs_BuildICmp" buildICmp ::
   Ptr Builder -> ICmpPredicate -> Ptr Value -> Ptr Value -> CString -> IO (Ptr Instruction)
 
 foreign import ccall unsafe "LLVMBuildFCmp" buildFCmp ::
@@ -147,19 +147,19 @@ foreign import ccall unsafe "LLVMBuildPhi" buildPhi ::
 foreign import ccall unsafe "LLVMBuildCall" buildCall ::
   Ptr Builder -> Ptr Value -> Ptr (Ptr Value) -> CUInt -> CString -> IO (Ptr Instruction)
 
-foreign import ccall unsafe "LLVMBuildSelect" buildSelect ::
+foreign import ccall unsafe "LLVM_Hs_BuildSelect" buildSelect ::
   Ptr Builder -> Ptr Value -> Ptr Value -> Ptr Value -> CString -> IO (Ptr Instruction)
 
 foreign import ccall unsafe "LLVMBuildVAArg" buildVAArg ::
   Ptr Builder -> Ptr Value -> Ptr Type -> CString -> IO (Ptr Instruction)
 
-foreign import ccall unsafe "LLVMBuildExtractElement" buildExtractElement ::
+foreign import ccall unsafe "LLVM_Hs_BuildExtractElement" buildExtractElement ::
   Ptr Builder -> Ptr Value -> Ptr Value -> CString -> IO (Ptr Instruction)
 
-foreign import ccall unsafe "LLVMBuildInsertElement" buildInsertElement ::
+foreign import ccall unsafe "LLVM_Hs_BuildInsertElement" buildInsertElement ::
   Ptr Builder -> Ptr Value -> Ptr Value -> Ptr Value -> CString -> IO (Ptr Instruction)
 
-foreign import ccall unsafe "LLVMBuildShuffleVector" buildShuffleVector ::
+foreign import ccall unsafe "LLVM_Hs_BuildShuffleVector" buildShuffleVector ::
   Ptr Builder -> Ptr Value -> Ptr Value -> Ptr Constant -> CString -> IO (Ptr Instruction)
 
 foreign import ccall unsafe "LLVM_Hs_BuildExtractValue" buildExtractValue ::

--- a/llvm-hs/src/LLVM/Internal/FFI/BuilderC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/BuilderC.cpp
@@ -61,7 +61,10 @@ LLVMValueRef LLVM_Hs_Build ## Op(																	\
 	LLVMValueRef o1,																											\
 	const char *s																													\
 ) {																																			\
-	return wrap(unwrap(b)->Create ## Op(unwrap(o0), unwrap(o1), s, nuw, nsw)); \
+    BinaryOperator *BO = unwrap(b)->Insert(BinaryOperator::Create(Instruction::Op, unwrap(o0), unwrap(o1)), s); \
+    if (nuw) BO->setHasNoUnsignedWrap(); \
+    if (nsw) BO->setHasNoSignedWrap(); \
+    return wrap(BO);                   \
 }
 LLVM_HS_FOR_EACH_OVERFLOWING_BINARY_OPERATOR(ENUM_CASE)
 #undef ENUM_CASE
@@ -74,13 +77,74 @@ LLVMValueRef LLVM_Hs_Build ## Op(																	\
 	LLVMValueRef o1,																											\
 	const char *s																													\
 ) {																																			\
-	return wrap(unwrap(b)->Create ## Op(unwrap(o0), unwrap(o1), s, exact)); \
+    if (!exact) { \
+        return wrap(unwrap(b)->Insert(BinaryOperator::Create##Op(unwrap(o0), unwrap(o1)), s)); \
+    } \
+     return wrap(unwrap(b)->Insert(BinaryOperator::CreateExact##Op(unwrap(o0), unwrap(o1)), s)); \
 }
 LLVM_HS_FOR_EACH_POSSIBLY_EXACT_BINARY_OPERATOR(ENUM_CASE)
 #undef ENUM_CASE
 
+#define LLVM_HS_FOR_EACH_CAST_INSTR(macro) \
+    macro(AddrSpaceCast) \
+    macro(BitCast) \
+    macro(FPExt) \
+    macro(FPToSI) \
+    macro(FPToUI) \
+    macro(FPTrunc) \
+    macro(IntToPtr) \
+    macro(PtrToInt) \
+    macro(SExt) \
+    macro(SIToFP) \
+    macro(Trunc) \
+    macro(UIToFP) \
+    macro(ZExt)
+
+#define ENUM_CASE(Op) \
+LLVMValueRef LLVM_Hs_Build##Op(LLVMBuilderRef b, LLVMValueRef val, LLVMTypeRef destTy, const char *name) {\
+    return wrap(unwrap(b)->Insert(CastInst::Create(Instruction::Op, unwrap(val), unwrap(destTy)), name));\
+}
+LLVM_HS_FOR_EACH_CAST_INSTR(ENUM_CASE)
+#undef ENUM_CASE
+
+#define LLVM_HS_FOR_EACH_BINOP(macro) \
+    macro(And) \
+    macro(Or) \
+    macro(SRem) \
+    macro(URem) \
+    macro(Xor)
+
+#define ENUM_CASE(Op) \
+LLVMValueRef LLVM_Hs_Build##Op(LLVMBuilderRef b, LLVMValueRef lhs, LLVMValueRef rhs, const char *name) {\
+    return wrap(unwrap(b)->Insert(BinaryOperator::Create##Op(unwrap(lhs), unwrap(rhs)), name)); \
+}
+LLVM_HS_FOR_EACH_BINOP(ENUM_CASE)
+#undef ENUM_CASE
+
+#define LLVM_HS_FOR_EACH_FP_BINOP(macro) \
+    macro(FAdd) \
+    macro(FDiv) \
+    macro(FMul) \
+    macro(FRem) \
+    macro(FSub)
+
+#define ENUM_CASE(Op) \
+LLVMValueRef LLVM_Hs_Build##Op(LLVMBuilderRef b, LLVMValueRef lhs, LLVMValueRef rhs, const char *name) { \
+    BinaryOperator* bo = BinaryOperator::Create##Op(unwrap(lhs), unwrap(rhs)); \
+    bo->setFastMathFlags(unwrap(b)->getFastMathFlags()); \
+    return wrap(unwrap(b)->Insert(bo, name)); \
+}
+LLVM_HS_FOR_EACH_FP_BINOP(ENUM_CASE)
+#undef ENUM_CASE
+
 void LLVM_Hs_SetFastMathFlags(LLVMBuilderRef b, LLVMFastMathFlags f) {
 	unwrap(b)->setFastMathFlags(unwrap(f));
+}
+
+LLVMValueRef LLVM_Hs_BuildICmp(LLVMBuilderRef b, LLVMIntPredicate op, LLVMValueRef lhs, LLVMValueRef rhs, const char* name) {
+
+    return wrap(unwrap(b)->Insert(new ICmpInst(static_cast<ICmpInst::Predicate>(op),
+                                               unwrap(lhs), unwrap(rhs)), name));
 }
 
 LLVMValueRef LLVM_Hs_BuildLoad(
@@ -160,27 +224,6 @@ LLVMValueRef LLVM_Hs_BuildAtomicRMW(
 	return wrap(a);
 }
 
-LLVMValueRef LLVM_Hs_BuildExtractValue(
-	LLVMBuilderRef b,
-	LLVMValueRef a,
-	unsigned *idxs,
-	unsigned n,
-	const char *name
-) {
-	return wrap(unwrap(b)->CreateExtractValue(unwrap(a), ArrayRef<unsigned>(idxs, n), name));
-}
-
-LLVMValueRef LLVM_Hs_BuildInsertValue(
-	LLVMBuilderRef b,
-	LLVMValueRef a,
-	LLVMValueRef v,
-	unsigned *idxs,
-	unsigned n,
-	const char *name
-) {
-	return wrap(unwrap(b)->CreateInsertValue(unwrap(a), unwrap(v), ArrayRef<unsigned>(idxs, n), name));
-}
-
 LLVMValueRef LLVM_Hs_BuildCleanupPad(LLVMBuilderRef b, LLVMValueRef parentPad,
                                      LLVMValueRef *args, unsigned numArgs,
                                      const char *name) {
@@ -221,5 +264,68 @@ LLVMValueRef LLVM_Hs_BuildCatchSwitch(LLVMBuilderRef b, LLVMValueRef parentPad,
                                       unsigned numHandlers) {
     return wrap(unwrap(b)->CreateCatchSwitch(unwrap(parentPad),
                                              unwrap(unwindDest), numHandlers));
+}
+
+LLVMValueRef LLVM_Hs_BuildGEP(LLVMBuilderRef B, LLVMValueRef Pointer,
+                             LLVMValueRef *Indices, unsigned NumIndices,
+                             const char *Name) {
+  ArrayRef<Value *> IdxList(unwrap(Indices), NumIndices);
+  return wrap(unwrap(B)->Insert(GetElementPtrInst::Create(nullptr, unwrap(Pointer), IdxList), Name));
+}
+
+LLVMValueRef LLVM_Hs_BuildInBoundsGEP(LLVMBuilderRef B, LLVMValueRef Pointer,
+                                      LLVMValueRef *Indices, unsigned NumIndices,
+                                      const char *Name) {
+  ArrayRef<Value *> IdxList(unwrap(Indices), NumIndices);
+  return wrap(unwrap(B)->Insert(GetElementPtrInst::CreateInBounds(nullptr, unwrap(Pointer), IdxList), Name));
+}
+
+LLVMValueRef LLVM_Hs_BuildSelect(LLVMBuilderRef B, LLVMValueRef If,
+                                 LLVMValueRef Then, LLVMValueRef Else,
+                                 const char *Name) {
+    return wrap(unwrap(B)->Insert(SelectInst::Create(unwrap(If), unwrap(Then), unwrap(Else))));
+}
+
+LLVMValueRef LLVM_Hs_BuildExtractValue(
+	LLVMBuilderRef b,
+	LLVMValueRef a,
+	unsigned *idxs,
+	unsigned n,
+	const char *name
+) {
+	return wrap(unwrap(b)->Insert(ExtractValueInst::Create(unwrap(a), ArrayRef<unsigned>(idxs, n)), name));
+}
+
+LLVMValueRef LLVM_Hs_BuildInsertValue(
+	LLVMBuilderRef b,
+	LLVMValueRef a,
+	LLVMValueRef v,
+	unsigned *idxs,
+	unsigned n,
+	const char *name
+) {
+	return wrap(unwrap(b)->Insert(InsertValueInst::Create(unwrap(a), unwrap(v), ArrayRef<unsigned>(idxs, n)), name));
+}
+
+LLVMValueRef LLVM_Hs_BuildExtractElement(LLVMBuilderRef B, LLVMValueRef VecVal,
+                                         LLVMValueRef Index, const char *Name) {
+    return wrap(unwrap(B)->Insert(ExtractElementInst::Create(unwrap(VecVal), unwrap(Index)),
+                                  Name));
+}
+
+LLVMValueRef LLVM_Hs_BuildInsertElement(LLVMBuilderRef B, LLVMValueRef VecVal,
+                                        LLVMValueRef EltVal, LLVMValueRef Index,
+                                        const char *Name) {
+    return wrap(unwrap(B)->Insert(InsertElementInst::Create(unwrap(VecVal), unwrap(EltVal),
+                                                            unwrap(Index)),
+                                  Name));
+}
+
+LLVMValueRef LLVM_Hs_BuildShuffleVector(LLVMBuilderRef B, LLVMValueRef V1,
+                                        LLVMValueRef V2, LLVMValueRef Mask,
+                                        const char *Name) {
+    return wrap(unwrap(B)->Insert(new ShuffleVectorInst(unwrap(V1), unwrap(V2),
+                                                        unwrap(Mask)),
+                                  Name));
 }
 }

--- a/llvm-hs/test/LLVM/Test/Instructions.hs
+++ b/llvm-hs/test/LLVM/Test/Instructions.hs
@@ -624,11 +624,12 @@ tests = testGroup "Instructions" [
         mStr = "; ModuleID = '<string>'\n\
                \source_filename = \"<string>\"\n\
                \\n\
-               \@0 = constant i32 42\n\
+               \@fortytwo = constant i32 42\n\
                \\n\
-               \define i32 @1() {\n\
-               \  %1 = load i32, i32* @0, align 1\n\
-               \  ret i32 %1\n\
+               \define i32 @0() {\n\
+               \  %1 = getelementptr inbounds i32, i32* @fortytwo, i32 0\n\
+               \  %2 = load i32, i32* %1, align 1\n\
+               \  ret i32 %2\n\
                \}\n"
     s <- withContext $ \context -> withModuleFromAST context mAST moduleLLVMAssembly
     s @?= mStr,


### PR DESCRIPTION
The LLVM IRBuilder API that we use for encoding instructions does a
limited form of constant folding. This causes problems for us since
we expect that the result of encoding an instruction is an Instruction
and not a Constant (e.g., we try to set metadata which isn’t possible
for a Constant). In the best case this leads to an assertion failure,
in the worst case it will just segfault.