### PR TITLE
More convenience functions for the IRBuilder

### DIFF
--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -267,5 +267,5 @@ instance MonadModuleBuilder m => MonadModuleBuilder (StateT s m)
 instance MonadModuleBuilder m => MonadModuleBuilder (Strict.StateT s m)
 instance (Monoid w, MonadModuleBuilder m) => MonadModuleBuilder (Strict.WriterT w m)
 
--- Not an mtl instance, but necessary in order for @globalStringPtr to compile
+-- Not an mtl instance, but necessary in order for @globalStringPtr@ to compile
 instance MonadModuleBuilder m => MonadModuleBuilder (IRBuilderT m)

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -170,15 +170,16 @@ extern nm argtys retty = do
 -- | A global variable definition
 global
   :: MonadModuleBuilder m
-  => Name -- ^ Variable name
-  -> Type -- ^ Type
+  => Name       -- ^ Variable name
+  -> Type       -- ^ Type
+  -> C.Constant -- ^ Initializer
   -> m Operand
-global nm ty = do
+global nm ty initVal = do
   emitDefn $ GlobalDefinition globalVariableDefaults
     { name                  = nm
     , LLVM.AST.Global.type' = ty
     , linkage               = Weak
-    , initializer           = Just $ C.Int 0 0
+    , initializer           = Just initVal
     }
   pure $ ConstantOperand $ C.GlobalReference (ptr ty) nm
 

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -196,7 +196,7 @@ global nm ty initVal = do
   emitDefn $ GlobalDefinition globalVariableDefaults
     { name                  = nm
     , LLVM.AST.Global.type' = ty
-    , linkage               = Weak
+    , linkage               = Common
     , initializer           = Just initVal
     }
   pure $ ConstantOperand $ C.GlobalReference (ptr ty) nm

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -202,7 +202,7 @@ global nm ty initVal = do
   pure $ ConstantOperand $ C.GlobalReference (ptr ty) nm
 
 -- | Creates a series of instructions to generate a pointer to a string
--- constant. Useful for making format strings to pass to `printf`, for example
+-- constant. Useful for making format strings to pass to @printf@, for example
 globalStringPtr
   :: MonadModuleBuilder m
   => String -- ^ The string to generate

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -47,6 +47,7 @@ import LLVM.AST hiding (function)
 import LLVM.AST.Global
 import LLVM.AST.Linkage
 import LLVM.AST.Type (ptr)
+import qualified LLVM.AST.Typed
 import qualified LLVM.AST.Constant as C
 
 import LLVM.IRBuilder.Internal.SnocList
@@ -183,6 +184,29 @@ global nm ty initVal = do
     }
   pure $ ConstantOperand $ C.GlobalReference (ptr ty) nm
 
+-- | Creates a series of instructions to generate a pointer to a string
+-- constant. Useful for making format strings to pass to `printf`, for example
+globalStringPtr 
+  :: MonadModuleBuilder m 
+  => String -- ^ The string to generate
+  -> Name   -- ^ The name by which to refer to it
+  -> m Operand
+globalStringPtr str nm = do
+  let asciiVals = map (fromIntegral . ord) str
+      llvmVals  = map (C.Int 8) (asciiVals ++ [0]) -- append null terminator
+      char = IntegerType 8
+      charStar = ptr char
+      charArray = C.Array char llvmVals
+  emitDefn $ GlobalDefinition globalVariableDefaults
+   { name = nm
+   , LLVM.AST.Global.type' = LLVM.AST.Typed.typeOf charArray
+   , linkage = Private
+   , isConstant = True
+   , initializer = Just charArray
+   , unnamedAddr = Just GlobalAddr
+   }
+  pure $ ConstantOperand $ C.BitCast (C.GlobalReference charStar nm) charStar
+
 -- | A named type definition
 typedef
   :: MonadModuleBuilder m
@@ -225,5 +249,6 @@ instance (MonadModuleBuilder m, Monoid w) => MonadModuleBuilder (Lazy.RWST r w s
 instance MonadModuleBuilder m => MonadModuleBuilder (StateT s m)
 instance MonadModuleBuilder m => MonadModuleBuilder (Strict.StateT s m)
 instance (Monoid w, MonadModuleBuilder m) => MonadModuleBuilder (Strict.WriterT w m)
-instance (Monoid w, MonadModuleBuilder m) => MonadModuleBuilder (Lazy.WriterT w m)
+
+-- Not an mtl instance, but necessary in order for @globalStringPtr to compile
 instance MonadModuleBuilder m => MonadModuleBuilder (IRBuilderT m)

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -168,6 +168,23 @@ extern nm argtys retty = do
   let funty = ptr $ FunctionType retty argtys False
   pure $ ConstantOperand $ C.GlobalReference funty nm
 
+-- | An external variadic argument function definition
+externVarArgs 
+  :: MonadModuleBuilder m
+  => Name   -- ^ Definition name
+  -> [Type] -- ^ Parameter types
+  -> Type   -- ^ Type
+  -> m Operand
+externVarArgs nm argtys retty = do
+  emitDefn $ GlobalDefinition functionDefaults
+    { name        = nm
+    , linkage     = External
+    , parameters  = ([Parameter ty (mkName "") [] | ty <- argtys], True)
+    , returnType  = retty
+    }
+  let funty = ptr $ FunctionType retty argtys True
+  pure $ ConstantOperand $ C.GlobalReference funty nm
+
 -- | A global variable definition
 global
   :: MonadModuleBuilder m

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -186,25 +186,25 @@ global nm ty initVal = do
 
 -- | Creates a series of instructions to generate a pointer to a string
 -- constant. Useful for making format strings to pass to `printf`, for example
-globalStringPtr 
-  :: MonadModuleBuilder m 
+globalStringPtr
+  :: MonadModuleBuilder m
   => String -- ^ The string to generate
   -> Name   -- ^ The name by which to refer to it
   -> m Operand
 globalStringPtr str nm = do
   let asciiVals = map (fromIntegral . ord) str
       llvmVals  = map (C.Int 8) (asciiVals ++ [0]) -- append null terminator
-      char = IntegerType 8
-      charStar = ptr char
+      char      = IntegerType 8
+      charStar  = ptr char
       charArray = C.Array char llvmVals
   emitDefn $ GlobalDefinition globalVariableDefaults
-   { name = nm
-   , LLVM.AST.Global.type' = LLVM.AST.Typed.typeOf charArray
-   , linkage = Private
-   , isConstant = True
-   , initializer = Just charArray
-   , unnamedAddr = Just GlobalAddr
-   }
+    { name                  = nm
+    , LLVM.AST.Global.type' = LLVM.AST.Typed.typeOf charArray
+    , linkage               = Private
+    , isConstant            = True
+    , initializer           = Just charArray
+    , unnamedAddr           = Just GlobalAddr
+    }
   pure $ ConstantOperand $ C.BitCast (C.GlobalReference charStar nm) charStar
 
 -- | A named type definition

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -196,7 +196,7 @@ global nm ty initVal = do
   emitDefn $ GlobalDefinition globalVariableDefaults
     { name                  = nm
     , LLVM.AST.Global.type' = ty
-    , linkage               = Common
+    , linkage               = External
     , initializer           = Just initVal
     }
   pure $ ConstantOperand $ C.GlobalReference (ptr ty) nm
@@ -205,8 +205,8 @@ global nm ty initVal = do
 -- constant. Useful for making format strings to pass to @printf@, for example
 globalStringPtr
   :: MonadModuleBuilder m
-  => String -- ^ The string to generate
-  -> Name   -- ^ The name by which to refer to it
+  => String       -- ^ The string to generate
+  -> Name         -- ^ Variable name of the pointer
   -> m Operand
 globalStringPtr str nm = do
   let asciiVals = map (fromIntegral . ord) str
@@ -217,7 +217,7 @@ globalStringPtr str nm = do
   emitDefn $ GlobalDefinition globalVariableDefaults
     { name                  = nm
     , LLVM.AST.Global.type' = LLVM.AST.Typed.typeOf charArray
-    , linkage               = Private
+    , linkage               = External
     , isConstant            = True
     , initializer           = Just charArray
     , unnamedAddr           = Just GlobalAddr

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -167,6 +167,21 @@ extern nm argtys retty = do
   let funty = ptr $ FunctionType retty argtys False
   pure $ ConstantOperand $ C.GlobalReference funty nm
 
+-- | A global variable definition
+global
+  :: MonadModuleBuilder m
+  => Name -- ^ Variable name
+  -> Type -- ^ Type
+  -> m Operand
+global nm ty = do
+  emitDefn $ GlobalDefinition globalVariableDefaults
+    { name                  = nm
+    , LLVM.AST.Global.type' = ty
+    , linkage               = Weak
+    , initializer           = Just $ C.Int 0 0
+    }
+  pure $ ConstantOperand $ C.GlobalReference (ptr ty) nm
+
 -- | A named type definition
 typedef
   :: MonadModuleBuilder m

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
@@ -264,7 +264,7 @@ currentBlock = liftIRState $ do
 
 -- | Find out if the currently active block has a terminator.
 --
--- This function will fail under the same condition as @currentBlock
+-- This function will fail under the same condition as @currentBlock@
 hasTerminator :: MonadIRBuilder m => m Bool
 hasTerminator = do
   current <- liftIRState $ gets builderBlock

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
@@ -262,6 +262,18 @@ currentBlock = liftIRState $ do
     Just n -> pure n
     Nothing -> error "Called currentBlock when no block was active"
 
+-- | Find out if the currently active block has a terminator.
+--
+-- This function will fail under the same condition as @currentBlock
+hasTerminator :: MonadIRBuilder m => m Bool
+hasTerminator = do
+  current <- liftIRState $ gets builderBlock
+  case current of
+    Nothing    -> error "Called hasTerminator when no block was active"
+    Just block -> case partialBlockTerm block of
+      Nothing  -> return False
+      Just _   -> return True
+
 -------------------------------------------------------------------------------
 -- mtl instances
 -------------------------------------------------------------------------------

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
@@ -270,7 +270,7 @@ hasTerminator = do
   current <- liftIRState $ gets builderBlock
   case current of
     Nothing    -> error "Called hasTerminator when no block was active"
-    Just block -> case partialBlockTerm block of
+    Just blk -> case partialBlockTerm blk of
       Nothing  -> return False
       Just _   -> return True
 


### PR DESCRIPTION
Provides convenience functions to generate global variables, global strings, and external varargs functions. Also provides the capability to easily check if the current block has a terminator and another instance for `MonadModuleBuilder` to allow functions with type
`type Codegen = IRBuilderT (MonadModuleBuilderT (State SomeEnvironment))` to work as expected when passed as the `body` parameter of `LLVM.IRBuilder.Module.function`. 