### PR TITLE
add llvm-config to extra-libs for stack2nix/cabal2nix compatibility

### DIFF
--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -64,7 +64,8 @@ library
   default-language: Haskell2010
   build-tools: hsc2hs, llvm-config
   ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-orphans
-
+  extra-libraries:
+    llvm-config
   build-depends:
     base >= 4.9 && < 5,
     attoparsec >= 0.13,


### PR DESCRIPTION
stack2nix and cabal2nix only inject external dependencies automatically from nixpkgs when they are specified under extra-libs. That way, a simple nixpkgs override with `llvm-config = llvm_5` can be used to build llvm-hs, without touching the stack2nix generated `default.nix` file. 