### PR TITLE
GHC 8.6

### DIFF
--- a/llvm-hs/src/LLVM/Internal/DecodeAST.hs
+++ b/llvm-hs/src/LLVM/Internal/DecodeAST.hs
@@ -114,9 +114,12 @@ getLocalName v' = do
   let v = FFI.upCast v'
   getValueName v localVarNum $ do
                     nm <- gets localVarNum
-                    Just n <- gets localNameCounter
-                    modify $ \s -> s { localNameCounter = Just (1 + n), localVarNum = Map.insert v n nm }
-                    return n
+                    mn <- gets localNameCounter
+                    case mn of
+                      Just n -> do
+                        modify $ \s -> s { localNameCounter = Just (1 + n), localVarNum = Map.insert v n nm }
+                        return n
+                      Nothing -> error "No local name"
 
 getGlobalName :: FFI.DescendentOf FFI.GlobalValue v => Ptr v -> DecodeAST A.Name
 getGlobalName v' = do

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,4 +7,7 @@ flags:
   llvm-hs:
     shared-llvm: true
 
+extra-deps:
+- pretty-show-1.7
+
 extra-package-dbs: []


### PR DESCRIPTION
Should fix support for building ``llvm-hs`` and ``llvm-hs-pure`` under GHC 8.6.