### PR TITLE
Add missing srem instruction to IRBuilder.

### DIFF
--- a/llvm-hs-pure/src/LLVM/IRBuilder/Instruction.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Instruction.hs
@@ -54,6 +54,9 @@ sdiv a b = emitInstr (typeOf a) $ SDiv False a b []
 urem :: MonadIRBuilder m => Operand -> Operand -> m Operand
 urem a b = emitInstr (typeOf a) $ URem a b []
 
+srem :: MonadIRBuilder m => Operand -> Operand -> m Operand
+srem a b = emitInstr (typeOf a) $ SRem a b []
+
 shl :: MonadIRBuilder m => Operand -> Operand -> m Operand
 shl a b = emitInstr (typeOf a) $ Shl False False a b []
 


### PR DESCRIPTION
This just adds a missing function to the IRBuilder interface that generates an `srem` instruction.

I made the change against the llvm-6 branch since that's what I'm still using and can compile and test against. However, it should be trivial to merge to llvm-7.