### PR TITLE
Fix documentation links for token and label types

### DIFF
--- a/llvm-hs-pure/src/LLVM/AST/Type.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Type.hs
@@ -38,9 +38,9 @@ data Type
   | NamedTypeReference Name
   -- | <http://llvm.org/docs/LangRef.html#metadata-type>
   | MetadataType -- only to be used as a parameter type for a few intrinsics
-  -- | <http://llvm.org/docs/LangRef.html#token-type>
-  | LabelType -- only to be used as the type of block names
   -- | <http://llvm.org/docs/LangRef.html#label-type>
+  | LabelType -- only to be used as the type of block names
+  -- | <http://llvm.org/docs/LangRef.html#token-type>
   | TokenType
   deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
 


### PR DESCRIPTION
Documentation links for token and label types are swapped. The patch fixers this.