### PR TITLE
use c++11 language

### DIFF
--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -233,6 +233,8 @@ library
     src/LLVM/Internal/FFI/TypeC.cpp
     src/LLVM/Internal/FFI/ValueC.cpp
 
+  cc-options: -std=c++11
+
   if flag(debug)
     cc-options: -g
 


### PR DESCRIPTION
C+11 became a requirement recently.
It does not compile otherwise. (Ubuntu 16.04)