### PR TITLE
Add support for additional DW_OPs

### DIFF
--- a/llvm-hs-pure/src/LLVM/AST/Operand.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Operand.hs
@@ -65,10 +65,20 @@ data DWOp
   | DW_OP_StackValue -- ^ Must be the last one or followed by a DW_OP_LLVM_Fragment
   | DW_OP_Swap
   | DW_OP_ConstU Word64
+  | DW_OP_Lit0
   | DW_OP_PlusUConst Word64
   | DW_OP_Plus
   | DW_OP_Minus
   | DW_OP_Mul
+  | DW_OP_Div
+  | DW_OP_Not
+  | DW_OP_Or
+  | DW_OP_Xor
+  | DW_OP_And
+  | DW_OP_Shr
+  | DW_OP_Shra
+  | DW_OP_Shl
+  | DW_OP_Dup
   | DW_OP_Deref
   | DW_OP_XDeref
   deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)

--- a/llvm-hs/src/LLVM/Internal/FFI/Metadata.h
+++ b/llvm-hs/src/LLVM/Internal/FFI/Metadata.h
@@ -51,10 +51,20 @@ enum LLVM_Hs_DwOp {
     macro(stack_value)                \
     macro(swap)                       \
     macro(constu)                     \
+    macro(lit0)                       \
     macro(plus_uconst)                \
     macro(plus)                       \
     macro(minus)                      \
     macro(mul)                        \
+    macro(div)                        \
+    macro(not)                        \
+    macro(or)                         \
+    macro(xor)                        \
+    macro(and)                        \
+    macro(shr)                        \
+    macro(shra)                       \
+    macro(shl)                        \
+    macro(dup)                        \
     macro(deref)                      \
     macro(xderef)
 

--- a/llvm-hs/src/LLVM/Internal/Operand.hs
+++ b/llvm-hs/src/LLVM/Internal/Operand.hs
@@ -981,6 +981,7 @@ encodeDWOp op =
     A.DW_OP_Minus -> [FFI.DwOp_minus]
     A.DW_OP_Mul -> [FFI.DwOp_mul]
     A.DW_OP_Div -> [FFI.DwOp_div]
+    A.DW_OP_Not -> [FFI.DwOp_not]
     A.DW_OP_Or -> [FFI.DwOp_or]
     A.DW_OP_Xor -> [FFI.DwOp_xor]
     A.DW_OP_And -> [FFI.DwOp_and]

--- a/llvm-hs/src/LLVM/Internal/Operand.hs
+++ b/llvm-hs/src/LLVM/Internal/Operand.hs
@@ -975,10 +975,19 @@ encodeDWOp op =
     A.DW_OP_StackValue -> [FFI.DwOp_stack_value]
     A.DW_OP_Swap -> [FFI.DwOp_swap]
     A.DW_OP_ConstU arg -> [FFI.DwOp_constu, arg]
+    A.DW_OP_Lit0 -> [FFI.DwOp_lit0]
     A.DW_OP_PlusUConst arg -> [FFI.DwOp_plus_uconst, arg]
     A.DW_OP_Plus -> [FFI.DwOp_plus]
     A.DW_OP_Minus -> [FFI.DwOp_minus]
     A.DW_OP_Mul -> [FFI.DwOp_mul]
+    A.DW_OP_Div -> [FFI.DwOp_div]
+    A.DW_OP_Or -> [FFI.DwOp_or]
+    A.DW_OP_Xor -> [FFI.DwOp_xor]
+    A.DW_OP_And -> [FFI.DwOp_and]
+    A.DW_OP_Shr -> [FFI.DwOp_shr]
+    A.DW_OP_Shra -> [FFI.DwOp_shra]
+    A.DW_OP_Shl -> [FFI.DwOp_shl]
+    A.DW_OP_Dup -> [FFI.DwOp_dup]
     A.DW_OP_Deref -> [FFI.DwOp_deref]
     A.DW_OP_XDeref -> [FFI.DwOp_xderef]
 
@@ -1064,6 +1073,7 @@ instance DecodeM DecodeAST A.DIExpression (Ptr FFI.DIExpression) where
                   expectElems "constu" i 1
                   arg <- FFI.getDIExpressionElement diExpr (i + 1)
                   (A.DW_OP_ConstU arg:) <$> go (i + 2)
+                FFI.DwOp_lit0 -> (A.DW_OP_Lit0 :) <$> go (i + 1)
                 FFI.DwOp_plus_uconst -> do
                   expectElems "uconst" i 1
                   arg <- FFI.getDIExpressionElement diExpr (i + 1)
@@ -1071,6 +1081,15 @@ instance DecodeM DecodeAST A.DIExpression (Ptr FFI.DIExpression) where
                 FFI.DwOp_plus -> (A.DW_OP_Plus :) <$> go (i + 1)
                 FFI.DwOp_minus -> (A.DW_OP_Minus :) <$> go (i + 1)
                 FFI.DwOp_mul -> (A.DW_OP_Mul :) <$> go (i + 1)
+                FFI.DwOp_div -> (A.DW_OP_Div :) <$> go (i + 1)
+                FFI.DwOp_not -> (A.DW_OP_Not :) <$> go (i + 1)
+                FFI.DwOp_or -> (A.DW_OP_Or :) <$> go (i + 1)
+                FFI.DwOp_xor -> (A.DW_OP_Xor :) <$> go (i + 1)
+                FFI.DwOp_and -> (A.DW_OP_And :) <$> go (i + 1)
+                FFI.DwOp_shr -> (A.DW_OP_Shr :) <$> go (i + 1)
+                FFI.DwOp_shra -> (A.DW_OP_Shra :) <$> go (i + 1)
+                FFI.DwOp_shl -> (A.DW_OP_Shl :) <$> go (i + 1)
+                FFI.DwOp_dup -> (A.DW_OP_Dup :) <$> go (i + 1)
                 FFI.DwOp_deref -> (A.DW_OP_Deref :) <$> go (i + 1)
                 FFI.DwOp_xderef -> (A.DW_OP_XDeref :) <$> go (i + 1)
                 _ -> throwM (DecodeException ("Unknown DW_OP " <> show op))

--- a/llvm-hs/test/LLVM/Test/Metadata.hs
+++ b/llvm-hs/test/LLVM/Test/Metadata.hs
@@ -671,11 +671,21 @@ instance Arbitrary DWOp where
       [ DwOpFragment <$> (DW_OP_LLVM_Fragment <$> arbitrary <*> arbitrary)
       , pure DW_OP_StackValue
       , pure DW_OP_Swap
+      , pure DW_OP_Lit0
       , DW_OP_ConstU <$> arbitrary
       , DW_OP_PlusUConst <$> arbitrary
       , pure DW_OP_Plus
       , pure DW_OP_Minus
       , pure DW_OP_Mul
+      , pure DW_OP_Div
+      , pure DW_OP_Not
+      , pure DW_OP_Or
+      , pure DW_OP_Xor
+      , pure DW_OP_And
+      , pure DW_OP_Shr
+      , pure DW_OP_Shra
+      , pure DW_OP_Shl
+      , pure DW_OP_Dup
       , pure DW_OP_Deref
       , pure DW_OP_XDeref
       ]
@@ -695,6 +705,11 @@ testFile = do
            pure ()
     ,  testCase "test/debug_metadata_3.ll" $ do
          fStr <- B.readFile "test/debug_metadata_3.ll"
+         withContext $ \context -> do
+           a <- withModuleFromLLVMAssembly' context fStr moduleAST
+           pure ()
+    ,  testCase "test/debug_metadata_4.ll" $ do
+         fStr <- B.readFile "test/debug_metadata_4.ll"
          withContext $ \context -> do
            a <- withModuleFromLLVMAssembly' context fStr moduleAST
            pure ()


### PR DESCRIPTION
We ran into a few decoder errors. LLVM generates more opcodes than the docs claim. This PR adds support for them, but I'm honestly not sure if `no` and `lit0` are correct. One thing I observed in Firefox generated code is that `lit0` appears as an op code but `lit2` etc. don't (they appear as names).