### PR TITLE
Fix installation instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ inconveniences.
 Example using Homebrew on macOS:
 
 ```bash
-$ brew install llvm-hs/llvm/llvm-8.0
+$ brew install llvm-hs/llvm/llvm-8
 ```
 
 ### Debian/Ubuntu


### PR DESCRIPTION
The Homebrew formula is called llvm-8 and not llvm-8.0.