### PR TITLE
withHostTargetMachine: make some options configurable

### DIFF
--- a/llvm-hs/CHANGELOG.md
+++ b/llvm-hs/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 8.1.0
+
+* Change `withHostTargetMachine` to accept the code model, relocation model,
+  and optimization level as arguments. The old behaviour is available
+  under the name `withHostTargetMachineDefault`.
+
 ## 8.0.0 (2019-03-10)
 
 * Upgrade to LLVM 8

--- a/llvm-hs/src/LLVM/CodeModel.hs
+++ b/llvm-hs/src/LLVM/CodeModel.hs
@@ -1,4 +1,4 @@
--- | Relocations, used in specifying TargetMachine
+-- | Code model, used in specifying TargetMachine
 module LLVM.CodeModel where
 
 import LLVM.Prelude

--- a/llvm-hs/src/LLVM/Target.hs
+++ b/llvm-hs/src/LLVM/Target.hs
@@ -7,7 +7,7 @@ module LLVM.Target (
    Target, TargetMachine, TargetLowering,
    CPUFeature(..),
    withTargetOptions, peekTargetOptions, pokeTargetOptions,
-   withTargetMachine, withHostTargetMachine, targetMachineOptions,
+   withTargetMachine, withHostTargetMachine, withHostTargetMachineDefault, targetMachineOptions,
    getTargetLowering,
    getTargetMachineTriple, getDefaultTargetTriple, getProcessTargetTriple, getHostCPUName, getHostCPUFeatures,
    getTargetMachineDataLayout, initializeNativeTarget, initializeAllTargets,

--- a/llvm-hs/test/LLVM/Test/Instrumentation.hs
+++ b/llvm-hs/test/LLVM/Test/Instrumentation.hs
@@ -39,7 +39,7 @@ instrument s m = withContext $ \context -> withModuleFromAST context m $ \mIn' -
   moduleAST mIn'
 
 ast = do
- dl <- withHostTargetMachine getTargetMachineDataLayout
+ dl <- withHostTargetMachineDefault getTargetMachineDataLayout
  triple <- liftIO getDefaultTargetTriple
  return $ Module "<string>" "<string>" (Just dl) (Just triple) [
   -- This function is needed for AddressSanitizerModule
@@ -149,7 +149,7 @@ tests = testGroup "Instrumentation" [
     testCase n $ do
       triple <- getProcessTargetTriple 
       withTargetLibraryInfo triple $ \tli -> do
-        dl <- withHostTargetMachine getTargetMachineDataLayout
+        dl <- withHostTargetMachineDefault getTargetMachineDataLayout
         ast <- ast
         ast' <- instrument (defaultPassSetSpec { transforms = [p], dataLayout = Just dl, targetLibraryInfo = Just tli }) ast
         let names ast = [ n | GlobalDefinition d <- moduleDefinitions ast, Name n <- return (G.name d) ]

--- a/llvm-hs/test/LLVM/Test/ObjectCode.hs
+++ b/llvm-hs/test/LLVM/Test/ObjectCode.hs
@@ -24,7 +24,7 @@ tests =
         withContext $ \ctx ->
           withSystemTempFile "foo" $ \objFile handle -> do
             hClose handle
-            withHostTargetMachine $ \machine ->
+            withHostTargetMachineDefault $ \machine ->
               withModuleFromLLVMAssembly ctx ll $ \mdl -> do
                 obj <- moduleObject machine mdl
                 _ <- writeObjectToFile machine (File objFile) mdl

--- a/llvm-hs/test/LLVM/Test/OrcJIT.hs
+++ b/llvm-hs/test/LLVM/Test/OrcJIT.hs
@@ -27,6 +27,9 @@ import LLVM.OrcJIT
 import qualified LLVM.Internal.OrcJIT.CompileLayer as CL
 import qualified LLVM.Internal.OrcJIT.LinkingLayer as LL
 import LLVM.Target
+import qualified LLVM.Relocation as Reloc
+import qualified LLVM.CodeModel as CodeModel
+import qualified LLVM.CodeGenOpt as CodeGenOpt
 
 testModule :: ByteString
 testModule =
@@ -76,7 +79,7 @@ tests =
     testCase "eager compilation" $ do
       resolvers <- newIORef Map.empty
       withTestModule $ \mod ->
-        withHostTargetMachine $ \tm ->
+        withHostTargetMachine Reloc.PIC CodeModel.Default CodeGenOpt.Default $ \tm ->
         withExecutionSession $ \es ->
         withObjectLinkingLayer es (\k -> fmap (\rs -> rs Map.! k) (readIORef resolvers)) $ \linkingLayer ->
         withIRCompileLayer linkingLayer tm $ \compileLayer -> do
@@ -100,7 +103,7 @@ tests =
       passmanagerSuccessful <- newIORef False
       resolvers <- newIORef Map.empty
       withTestModule $ \mod ->
-        withHostTargetMachine $ \tm ->
+        withHostTargetMachine Reloc.PIC CodeModel.Default CodeGenOpt.Default $ \tm ->
         withExecutionSession $ \es ->
         withObjectLinkingLayer es (\k -> fmap (\rs -> rs Map.! k) (readIORef resolvers)) $ \linkingLayer ->
         withIRCompileLayer linkingLayer tm $ \compileLayer ->
@@ -121,7 +124,7 @@ tests =
       let getResolver k = fmap (Map.! k) (readIORef resolvers)
           setResolver k r = modifyIORef' resolvers (Map.insert k r)
       withTestModule $ \mod ->
-        withHostTargetMachine $ \tm -> do
+        withHostTargetMachine Reloc.PIC CodeModel.Default CodeGenOpt.Default $ \tm -> do
           triple <- getTargetMachineTriple tm
           withExecutionSession $ \es ->
             withObjectLinkingLayer es getResolver $ \linkingLayer ->


### PR DESCRIPTION
Make withHostTargetMachine accept the code model, relocation model, and
optimization level as arguments rather than assume the defaults.

Closes #263.