### PR TITLE
Build fix for C++11 narrowing conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cabal.sandbox.config
 cabal.project.local
 *.dwo
 .ghc.environment.*
+/stack.yaml.lock

--- a/llvm-hs/src/LLVM/Internal/FFI/PassManagerC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/PassManagerC.cpp
@@ -31,11 +31,11 @@ typedef struct LLVMOpaqueTargetMachine *LLVMTargetMachineRef;
 }
 
 namespace llvm {
-inline TargetLowering *unwrap(LLVMTargetLoweringRef P) { 
+inline TargetLowering *unwrap(LLVMTargetLoweringRef P) {
 	return reinterpret_cast<TargetLowering *>(P);
 }
 
-inline LLVMTargetLoweringRef wrap(const TargetLowering *P) { 
+inline LLVMTargetLoweringRef wrap(const TargetLowering *P) {
 	return reinterpret_cast<LLVMTargetLoweringRef>(const_cast<TargetLowering *>(P));
 }
 
@@ -86,7 +86,7 @@ LLVM_HS_FOR_EACH_PASS_WITHOUT_LLVM_C_BINDING(ENUM_CASE)
 void LLVM_Hs_AddCodeGenPreparePass(LLVMPassManagerRef PM) {
 	unwrap(PM)->add(createCodeGenPreparePass());
 }
-	
+
 void LLVM_Hs_AddGlobalValueNumberingPass(LLVMPassManagerRef PM, LLVMBool noLoads) {
 	unwrap(PM)->add(createGVNPass(noLoads));
 }
@@ -114,7 +114,7 @@ void LLVM_Hs_AddLoopStrengthReducePass(LLVMPassManagerRef PM) {
 void LLVM_Hs_AddLowerInvokePass(LLVMPassManagerRef PM) {
 	unwrap(PM)->add(createLowerInvokePass());
 }
-	
+
 void LLVM_Hs_AddSROAPass(LLVMPassManagerRef PM) {
 	unwrap(PM)->add(createSROAPass());
 }
@@ -156,7 +156,7 @@ void LLVM_Hs_AddMemorySanitizerPass(
     LLVMBool recover,
     LLVMBool kernel
 ) {
-	unwrap(PM)->add(createMemorySanitizerLegacyPassPass({trackOrigins, recover, kernel}));
+	unwrap(PM)->add(createMemorySanitizerLegacyPassPass({trackOrigins, static_cast<bool>(recover), static_cast<bool>(kernel)}));
 }
 
 void LLVM_Hs_AddThreadSanitizerPass(

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,8 @@
-resolver: lts-10.8
+resolver: lts-14.7
 
 packages:
-- 'llvm-hs'
-- 'llvm-hs-pure'
-flags:
-  llvm-hs:
-    shared-llvm: true
+- llvm-hs
+- llvm-hs-pure
 
 extra-package-dbs: []
+


### PR DESCRIPTION
This is required to build `llvm-hs` on MacOS, so a new Hackage release is required. Tested with ghc-8.6.5.

MacOS 11.14.6 (latest)
Xcode 11.0 (latest)

```sh
$ clang++ --version
Apple clang version 11.0.0 (clang-1100.0.33.8)
Target: x86_64-apple-darwin18.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```