### PR TITLE
Identified struct types may be const zero-initialized

### DIFF
--- a/llvm-hs/src/LLVM/Internal/Constant.hs
+++ b/llvm-hs/src/LLVM/Internal/Constant.hs
@@ -159,6 +159,7 @@ instance EncodeM EncodeAST A.Constant (Ptr FFI.Constant) where
                              A.ArrayType {} -> pure ()
                              A.StructureType {} -> pure ()
                              A.VectorType {} -> pure ()
+                             A.NamedTypeReference {} -> pure ()
                              _ ->
                                throwM
                                  (EncodeException


### PR DESCRIPTION
Add NamedTypeReference to the set of allowable types in constant zero-initialization (addressing #262)