### PR TITLE
Fixes issue #287 and #295

### DIFF
--- a/llvm-hs-pure/src/LLVM/AST/Typed.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Typed.hs
@@ -34,7 +34,9 @@ instance Typed C.Constant where
   typeOf (C.Float t) = typeOf t
   typeOf (C.Null t)      = t
   typeOf (C.AggregateZero t) = t
-  typeOf (C.Struct {..}) = StructureType isPacked (map typeOf memberValues)
+  typeOf (C.Struct {..}) = case structName of
+                            Just n -> NamedTypeReference n
+                            Nothing -> StructureType isPacked (map typeOf memberValues)
   typeOf (C.Array {..})  = ArrayType (fromIntegral $ length memberValues) memberType
   typeOf (C.Vector {..}) = VectorType (fromIntegral $ length memberValues) $
                               case memberValues of


### PR DESCRIPTION
A constant struct will be given a `NamedTypeReference` instead of a `StructureType` if its structName field is Just _.

`extractValue` is modified so that it can reconstruct its return type even in the presence of `NamedTypeReference`.

This provides a simple fix to issue #287 and #295. The fix to #287 is not perfect since there are still constants for which `typeOf` can't reconstruct the type. E.g., `extractvalue` applied to a constant struct with a named type. However it solves the specific problem outlined in #287.

The only way I can think of to make it « better » is to have a version of `extractValueType` that also carries the constant whose type is being determined along, so that we can reconstruct the `StructureType` if needs be, like so:
```haskell
extractValueType' :: C.Constant -> [Word32] -> Type -> Type
extractValueType' _ [] ty = ty
extractValueType' ~C.Array { memberValues = elems } (i : is) (ArrayType numEls elTy)
  | fromIntegral i < numEls = extractValueType' (elems !! fromIntegral i) is elTy
  | fromIntegral i >= numEls = error "Expecting valid index into array type. (Malformed AST)"
extractValueType' ~C.Struct { memberValues = elems } (i : is) (StructureType _ elTys)
  | fromIntegral i < length elTys = extractValueType' (elems !! fromIntegral i) is (elTys !! fromIntegral i)
  | otherwise = error "Expecting valid index into structure type. (Malformed AST)"
extractValueType' constant@C.Struct {..} (i : is) (NamedTypeReference _) =
  extractValueType' constant (i : is) (StructureType isPacked (map typeOf memberValues))
extractValueType' _ _ _ = error "Expecting vector type. (Malformed AST)"
````
When `extractValueType'` hits a `NamedTypeReference`, it reconstructs the the type using the constant itself. This can only work if the constant is a `Struct` and not, for instance, a global reference. It also needs to keep track of what the right constant is when going down the list of indices, hence the patterns in the `ArrayType` and `StructureType` cases. The patterns are lazy to avoid unecessary failures if there is no `NamedTypeReference` in the type in question.

All of this is a bit messy though and still not perfect. I think a better solution would be to modify the definition of `NamedTypeReference` to carry both the `Name` and the type it aliases. I'll open a separate issue to discuss this :-)