### PR TITLE
Add call stacks to partial functions

### DIFF
--- a/llvm-hs-pure/src/LLVM/AST/Typed.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Typed.hs
@@ -10,6 +10,8 @@ module LLVM.AST.Typed (
 
 import LLVM.Prelude
 
+import GHC.Stack
+
 import LLVM.AST
 import LLVM.AST.Global
 import LLVM.AST.Type
@@ -18,7 +20,7 @@ import qualified LLVM.AST.Constant as C
 import qualified LLVM.AST.Float as F
 
 class Typed a where
-    typeOf :: a -> Type
+    typeOf :: HasCallStack => a -> Type
 
 instance Typed Operand where
   typeOf (LocalReference t _) = t

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
@@ -34,6 +34,7 @@ import Data.Bifunctor
 import Data.String
 import Data.Map.Strict(Map)
 import qualified Data.Map.Strict as M
+import GHC.Stack
 
 import LLVM.AST
 
@@ -256,7 +257,7 @@ named ir name = do
 -- This function will throw an error if there is no active block. The
 -- only situation in which this can occur is if it is called before
 -- any call to `block` and before emitting any instructions.
-currentBlock :: MonadIRBuilder m => m Name
+currentBlock :: HasCallStack => MonadIRBuilder m => m Name
 currentBlock = liftIRState $ do
   name <- gets (fmap partialBlockName . builderBlock)
   case name of
@@ -266,7 +267,7 @@ currentBlock = liftIRState $ do
 -- | Find out if the currently active block has a terminator.
 --
 -- This function will fail under the same condition as @currentBlock@
-hasTerminator :: MonadIRBuilder m => m Bool
+hasTerminator :: HasCallStack => MonadIRBuilder m => m Bool
 hasTerminator = do
   current <- liftIRState $ gets builderBlock
   case current of

--- a/llvm-hs/src/LLVM/Internal/Coding.hs
+++ b/llvm-hs/src/LLVM/Internal/Coding.hs
@@ -20,14 +20,15 @@ import Foreign.Storable (Storable)
 import qualified Foreign.Storable
 import qualified Foreign.Marshal.Alloc
 import qualified Foreign.Marshal.Array
+import GHC.Stack
 
 import qualified LLVM.Internal.FFI.LLVMCTypes as FFI
 
 class EncodeM e h c where
-  encodeM :: h -> e c
+  encodeM :: HasCallStack => h -> e c
 
 class DecodeM d h c where
-  decodeM :: c -> d h
+  decodeM :: HasCallStack => c -> d h
 
 genCodingInstance :: (Data c, Data h) => TypeQ -> Name -> [(c, h)] -> Q [Dec]
 genCodingInstance ht ctn chs = do

--- a/llvm-hs/src/LLVM/Internal/ExecutionEngine.hs
+++ b/llvm-hs/src/LLVM/Internal/ExecutionEngine.hs
@@ -28,6 +28,7 @@ import LLVM.Internal.Coding
 import qualified LLVM.CodeModel as CodeModel
 import LLVM.Internal.Target
 import qualified LLVM.AST as A
+import GHC.Stack
 
 removeModule :: Ptr FFI.ExecutionEngine -> Ptr FFI.Module -> IO ()
 removeModule e m = flip runAnyContT return $ do
@@ -43,7 +44,7 @@ data ExecutableModule e = ExecutableModule e (Ptr FFI.Module)
 -- | <http://llvm.org/doxygen/classllvm_1_1ExecutionEngine.html>
 class ExecutionEngine e f | e -> f where
   withModuleInEngine :: e -> Module -> (ExecutableModule e -> IO a) -> IO a
-  getFunction :: ExecutableModule e -> A.Name -> IO (Maybe f)
+  getFunction :: HasCallStack => ExecutableModule e -> A.Name -> IO (Maybe f)
 
 instance ExecutionEngine (Ptr FFI.ExecutionEngine) (FunPtr ()) where
   withModuleInEngine e m f = do

--- a/llvm-hs/src/LLVM/Internal/FFI/Builder.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Builder.hs
@@ -13,6 +13,7 @@ import qualified Language.Haskell.TH as TH
 
 import Foreign.Ptr
 import Foreign.C
+import GHC.Stack
 
 import qualified Data.List as List
 import qualified Data.Map as Map
@@ -112,7 +113,7 @@ foreign import ccall unsafe "LLVM_Hs_BuildGEP" buildGetElementPtr' ::
 foreign import ccall unsafe "LLVM_Hs_BuildInBoundsGEP" buildInBoundsGetElementPtr' ::
   Ptr Builder -> Ptr Value -> Ptr (Ptr Value) -> CUInt -> CString -> IO (Ptr Instruction)
 
-buildGetElementPtr :: Ptr Builder -> LLVMBool -> Ptr Value -> (CUInt, Ptr (Ptr Value)) -> CString -> IO (Ptr Instruction)
+buildGetElementPtr :: HasCallStack => Ptr Builder -> LLVMBool -> Ptr Value -> (CUInt, Ptr (Ptr Value)) -> CString -> IO (Ptr Instruction)
 buildGetElementPtr builder (LLVMBool 1) a (n, is) s = buildInBoundsGetElementPtr' builder a is n s
 buildGetElementPtr builder (LLVMBool 0) a (n, is) s = buildGetElementPtr' builder a is n s
 buildGetElementPtr _ (LLVMBool i) _ _ _ = error ("LLVMBool should be 0 or 1 but is " <> show i)

--- a/llvm-hs/src/LLVM/Internal/ObjectFile.hs
+++ b/llvm-hs/src/LLVM/Internal/ObjectFile.hs
@@ -4,6 +4,7 @@ import Control.Exception (bracket)
 import Control.Monad.IO.Class
 import Control.Monad.AnyCont
 import Foreign.Ptr
+import GHC.Stack
 
 import LLVM.Prelude
 import LLVM.Internal.Coding
@@ -22,7 +23,7 @@ disposeObjectFile (ObjectFile obj) = FFI.disposeObjectFile obj
 --
 -- Note that the file at `path` should already be a compiled object file i.e a
 -- `.o` file. This does *not* compile source files.
-createObjectFile :: FilePath -> IO ObjectFile
+createObjectFile :: HasCallStack => FilePath -> IO ObjectFile
 createObjectFile path = flip runAnyContT return $ do
   -- The ownership of the object file is transfered to the object
   -- file, so we need to make sure that we do not free it here.

--- a/llvm-hs/src/LLVM/Internal/PassManager.hs
+++ b/llvm-hs/src/LLVM/Internal/PassManager.hs
@@ -17,6 +17,7 @@ import qualified Data.ByteString.Short as ByteString
 
 import Foreign.C (CString)
 import Foreign.Ptr
+import GHC.Stack
 
 import qualified LLVM.Internal.FFI.PassManager as FFI
 import qualified LLVM.Internal.FFI.Transforms as FFI
@@ -91,7 +92,7 @@ instance (Monad m, MonadThrow m, MonadAnyCont IO m) => EncodeM m GCOVVersion CSt
     | ByteString.length cs == 4 = encodeM cs
     | otherwise = throwM (EncodeException "GCOVVersion should consist of exactly 4 characters")
 
-createPassManager :: PassSetSpec -> IO (Ptr FFI.PassManager)
+createPassManager :: HasCallStack => PassSetSpec -> IO (Ptr FFI.PassManager)
 createPassManager pss = flip runAnyContT return $ do
   pm <- liftIO $ FFI.createPassManager
   forM_ (targetLibraryInfo pss) $ \(TargetLibraryInfo tli) -> do

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.7
+resolver: nightly-2020-01-30
 
 packages:
 - llvm-hs


### PR DESCRIPTION
This makes error messages more helpful for the user. I tried to add call stacks to all functions where the error could plausibly be caused by the user (as opposed to internal errors).