### PR TITLE
Make it possible to manage Contexts and Modules in a non-bracketed way

### DIFF
--- a/llvm-hs/src/LLVM/Context.hs
+++ b/llvm-hs/src/LLVM/Context.hs
@@ -1,7 +1,9 @@
 -- | functions for the LLVM Context object which holds thread-scope state
 module LLVM.Context (
   Context,
-  withContext
+  withContext,
+  createContext,
+  disposeContext
   ) where
 
 import LLVM.Internal.Context

--- a/llvm-hs/src/LLVM/Internal/Context.hs
+++ b/llvm-hs/src/LLVM/Internal/Context.hs
@@ -18,3 +18,11 @@ data Context = Context (Ptr FFI.Context)
 withContext :: (Context -> IO a) -> IO a
 withContext = runBound . bracket FFI.contextCreate FFI.contextDispose . (. Context)
   where runBound = if rtsSupportsBoundThreads then runInBoundThread else id
+
+-- | Create a Context.
+createContext :: IO Context
+createContext = Context <$> FFI.contextCreate
+
+-- | Destroy a context created by 'createContext'.
+disposeContext :: Context -> IO ()
+disposeContext (Context ptr) = FFI.contextDispose ptr

--- a/llvm-hs/src/LLVM/Module.hs
+++ b/llvm-hs/src/LLVM/Module.hs
@@ -5,6 +5,10 @@ module LLVM.Module (
     File(..),
 
     withModuleFromAST,
+    createModuleFromAST,
+    disposeModule,
+
+    moduleContext,
     moduleAST,
 
     withModuleFromLLVMAssembly,


### PR DESCRIPTION
This is useful when the compilation process is driven from outside of
Haskell, making it impossible to know the regions in which they are
valid ahead of time.