### PR TITLE
Fix typeOf const struct whose type is named

### DIFF
--- a/llvm-hs-pure/src/LLVM/AST/Typed.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Typed.hs
@@ -36,7 +36,9 @@ instance Typed C.Constant where
   typeOf (C.Float t) = typeOf t
   typeOf (C.Null t)      = t
   typeOf (C.AggregateZero t) = t
-  typeOf (C.Struct {..}) = StructureType isPacked (map typeOf memberValues)
+  typeOf (C.Struct {..}) = case structName of
+                             Nothing -> StructureType isPacked (map typeOf memberValues)
+                             Just sn -> NamedTypeReference sn
   typeOf (C.Array {..})  = ArrayType (fromIntegral $ length memberValues) memberType
   typeOf (C.Vector {..}) = VectorType (fromIntegral $ length memberValues) $
                               case memberValues of


### PR DESCRIPTION
For a constant structure `c`, `typeOf c` would always return a structure type with the type of all the values. However, when the constant structure has a named type reference as type, that should be used instead.

This issue manifests when using llvm-hs-pretty, that can then produce invalid LLVM IR. For example, if we read the following code:

```llvm
%t = type { i8 }
@g = global { i32, %t } {i32 42, %t {i8 42}}
```

When pretty-printed we get:

```llvm
%t = type { i8 }
@g = global { i32, %t } {i32 42, {i8} {i8 42}}
```

which LLVM rejects due to the `%t` vs `{i8}` mismatch.