### PR TITLE
Remove dumpModule and dumpMetadata functions

### DIFF
--- a/llvm-hs-pure/src/LLVM/AST/Typed.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Typed.hs
@@ -133,3 +133,6 @@ instance Typed Global where
                                    in FunctionType returnType (map typeOf params) isVarArg
 instance Typed Parameter where
   typeOf (Parameter t _ _) = t
+
+instance Typed [Int32] where
+  typeOf mask = VectorType (fromIntegral $ length mask) i32

--- a/llvm-hs/src/LLVM/Internal/FFI/Metadata.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Metadata.hs
@@ -60,8 +60,10 @@ foreign import ccall unsafe "LLVM_Hs_Get_DILocation" getDILocation ::
 foreign import ccall unsafe "LLVM_Hs_GetMDValue" getMDValue ::
   Ptr MDValue -> IO (Ptr Value)
 
+{-
 foreign import ccall unsafe "LLVM_Hs_DumpMetadata" dumpMetadata ::
   Ptr Metadata -> IO ()
+-}
 
 foreign import ccall unsafe "LLVM_Hs_GetMetadataOperand" getMetadataOperand ::
   Ptr MetadataAsVal -> IO (Ptr Metadata)

--- a/llvm-hs/src/LLVM/Internal/FFI/MetadataC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/MetadataC.cpp
@@ -79,9 +79,11 @@ MDTuple* LLVM_Hs_Get_MDTuple(LLVMContextRef c,
     return MDTuple::get(*unwrap(c), {unwrap(mds), count});
 }
 
+/*
 void LLVM_Hs_DumpMetadata(LLVMMetadataRef md) {
     unwrap(md)->dump();
 }
+*/
 
 unsigned LLVM_Hs_GetMDKindNames(
 	LLVMContextRef c,

--- a/llvm-hs/src/LLVM/Internal/FFI/Module.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Module.hs
@@ -37,9 +37,6 @@ foreign import ccall unsafe "LLVMGetTarget" getTargetTriple ::
 foreign import ccall unsafe "LLVMSetTarget" setTargetTriple ::
   Ptr Module -> CString -> IO ()
 
-foreign import ccall unsafe "LLVM_Hs_DumpModule" dumpModule ::
-  Ptr Module -> IO ()
-
 foreign import ccall unsafe "LLVM_Hs_GetModuleIdentifier" getModuleIdentifier ::
   Ptr Module -> IO (OwnerTransfered CString)
 

--- a/llvm-hs/src/LLVM/Internal/FFI/ModuleC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/ModuleC.cpp
@@ -6,10 +6,6 @@ using namespace llvm;
 
 extern "C" {
 
-void LLVM_Hs_DumpModule(LLVMModuleRef m) {
-	unwrap(m)->dump();
-}
-
 char *LLVM_Hs_GetModuleIdentifier(LLVMModuleRef val) {
 	return strdup(unwrap(val)->getModuleIdentifier().c_str());
 }

--- a/llvm-hs/src/LLVM/Internal/Module.hs
+++ b/llvm-hs/src/LLVM/Internal/Module.hs
@@ -564,9 +564,3 @@ moduleAST m = runDecodeAST $ do
         metadata ++
         functionAttributes ++
         comdats)
-
--- | Dump LLVM IR contained in a module to standard error output (stderr).
-dumpModule :: Module -> IO ()
-dumpModule m = do
-  mPtr <- readModule m
-  FFI.dumpModule mPtr

--- a/llvm-hs/src/LLVM/Module.hs
+++ b/llvm-hs/src/LLVM/Module.hs
@@ -25,9 +25,7 @@ module LLVM.Module (
     moduleObject,
     writeObjectToFile,
 
-    linkModules,
-
-    dumpModule
+    linkModules
   ) where
 
 import LLVM.Internal.Module


### PR DESCRIPTION
 They use unresolvable symbols in the FFI layer when linking against the LLVM 12 release branch (as of 12 Apr 2021 and possibly before). It seems reasonable to replace these with pure Haskell viz. `writeFile stderr . moduleAST` or so.

Tests pass for llvm-hs and llvm-hs-pure.