### PR TITLE
Gardening on the LLVM 9 branch

### DIFF
--- a/llvm-hs-pure/src/LLVM/AST/Constant.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Constant.hs
@@ -239,9 +239,9 @@ unsignedIntegerValue (Int nBits bits) =
 unsignedIntegerValue _ = error "unsignedIntegerValue is only defined for Int"
 
 -- platform independant sizeof: a gep to the end of a nullptr and some bitcasting.
-sizeof :: Type -> Constant
-sizeof t = PtrToInt szPtr (IntegerType 32)
+sizeof :: Word32 -> Type -> Constant
+sizeof szBits t = PtrToInt szPtr (IntegerType szBits)
   where
      ptrType = PointerType t (AddrSpace 0)
-     nullPtr = IntToPtr (Int 32 0) ptrType
-     szPtr   = GetElementPtr True nullPtr [Int 32 1]
+     nullPtr = IntToPtr (Int szBits 0) ptrType
+     szPtr   = GetElementPtr True nullPtr [Int szBits 1]

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Instruction.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Instruction.hs
@@ -330,3 +330,9 @@ globalStringPtr str nm = do
   return $ C.GetElementPtr True
                            (C.GlobalReference (ptr ty) nm)
                            [(C.Int 32 0), (C.Int 32 0)]
+
+sizeof :: (MonadModuleBuilder m, MonadIRBuilder m) => Word32 -> Type -> m Operand
+sizeof szBits ty = do
+  tyNullPtr <- inttoptr (ConstantOperand $ C.Int szBits 0) (ptr ty)
+  tySzPtr <- gep tyNullPtr [ConstantOperand $ C.Int szBits 1]
+  ptrtoint tySzPtr $ IntegerType szBits

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -16,7 +16,6 @@ import Prelude hiding (and, or)
 import Control.Applicative
 import Control.Monad.Cont
 import Control.Monad.Except
-import Control.Monad.Fail
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Identity
 import Control.Monad.Writer.Lazy as Lazy
@@ -26,7 +25,6 @@ import Control.Monad.RWS.Lazy as Lazy
 import Control.Monad.RWS.Strict as Strict
 import qualified Control.Monad.State.Strict as Strict
 import Control.Monad.State.Lazy
-import Control.Monad.List
 import Control.Monad.Trans.Maybe
 #if !(MIN_VERSION_mtl(2,2,2))
 import Control.Monad.Trans.Identity
@@ -168,7 +166,7 @@ extern nm argtys retty = do
   pure $ ConstantOperand $ C.GlobalReference funty nm
 
 -- | An external variadic argument function definition
-externVarArgs 
+externVarArgs
   :: MonadModuleBuilder m
   => Name   -- ^ Definition name
   -> [Type] -- ^ Parameter types
@@ -234,7 +232,6 @@ instance MonadState s m => MonadState s (ModuleBuilderT m) where
 instance MonadModuleBuilder m => MonadModuleBuilder (ContT r m)
 instance MonadModuleBuilder m => MonadModuleBuilder (ExceptT e m)
 instance MonadModuleBuilder m => MonadModuleBuilder (IdentityT m)
-instance MonadModuleBuilder m => MonadModuleBuilder (ListT m)
 instance MonadModuleBuilder m => MonadModuleBuilder (MaybeT m)
 instance MonadModuleBuilder m => MonadModuleBuilder (ReaderT r m)
 instance (MonadModuleBuilder m, Monoid w) => MonadModuleBuilder (Strict.RWST r w s m)

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
@@ -13,7 +13,6 @@ import LLVM.Prelude
 
 import Control.Monad.Cont
 import Control.Monad.Except
-import Control.Monad.Fail
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Identity
 import qualified Control.Monad.Writer.Lazy as Lazy
@@ -24,7 +23,6 @@ import qualified Control.Monad.RWS.Lazy as Lazy
 import qualified Control.Monad.RWS.Strict as Strict
 import qualified Control.Monad.State.Lazy as Lazy
 import Control.Monad.State.Strict
-import Control.Monad.List
 import Control.Monad.Trans.Maybe
 #if !(MIN_VERSION_mtl(2,2,2))
 import Control.Monad.Trans.Identity
@@ -286,7 +284,6 @@ instance MonadState s m => MonadState s (IRBuilderT m) where
 instance MonadIRBuilder m => MonadIRBuilder (ContT r m)
 instance MonadIRBuilder m => MonadIRBuilder (ExceptT e m)
 instance MonadIRBuilder m => MonadIRBuilder (IdentityT m)
-instance MonadIRBuilder m => MonadIRBuilder (ListT m)
 instance MonadIRBuilder m => MonadIRBuilder (MaybeT m)
 instance MonadIRBuilder m => MonadIRBuilder (ReaderT r m)
 instance (MonadIRBuilder m, Monoid w) => MonadIRBuilder (Strict.RWST r w s m)

--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -236,7 +236,7 @@ library
     src/LLVM/Internal/FFI/TypeC.cpp
     src/LLVM/Internal/FFI/ValueC.cpp
 
-  cc-options: -std=c++11
+  cc-options: -std=c++11 -Wno-stringop-overflow
 
   if flag(debug)
     cc-options: -g

--- a/llvm-hs/src/LLVM/Internal/DecodeAST.hs
+++ b/llvm-hs/src/LLVM/Internal/DecodeAST.hs
@@ -8,7 +8,6 @@ module LLVM.Internal.DecodeAST where
 
 import LLVM.Prelude
 
-import Control.Monad.Fail
 import Control.Monad.Catch
 import Control.Monad.State
 import Control.Monad.AnyCont
@@ -100,7 +99,7 @@ getName getCString v getNameMap generate = do
   name <- liftIO $ do
             n <- getCString v
             if n == nullPtr then return "" else decodeM n
-  if name /= "" 
+  if name /= ""
      then
        return $ A.Name name
      else
@@ -149,7 +148,7 @@ getMetadataNodeID p = do
     Just r -> return r
     Nothing -> do
       let r = A.MetadataNodeID (fromIntegral (Map.size mdns))
-      modify $ \s -> s { 
+      modify $ \s -> s {
         metadataNodesToDefine = (r, p) Seq.<| metadataNodesToDefine s,
         metadataNodes = Map.insert p r (metadataNodes s)
       }
@@ -163,7 +162,7 @@ takeTypeToDefine = state $ \s -> case Seq.viewr (typesToDefine s) of
 takeMetadataNodeToDefine :: DecodeAST (Maybe (A.MetadataNodeID, Ptr FFI.MDNode))
 takeMetadataNodeToDefine = state $ \s -> case Seq.viewr (metadataNodesToDefine s) of
   remaining Seq.:> md -> (Just md, s { metadataNodesToDefine = remaining })
-  _ -> (Nothing, s)                              
+  _ -> (Nothing, s)
 
 instance DecodeM DecodeAST A.Name (Ptr FFI.BasicBlock) where
   decodeM = getLocalName

--- a/llvm-hs/src/LLVM/Internal/Target.hs
+++ b/llvm-hs/src/LLVM/Internal/Target.hs
@@ -11,7 +11,6 @@ import LLVM.Prelude
 
 import Control.Monad.AnyCont
 import Control.Monad.Catch
-import Control.Monad.Fail (MonadFail)
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Except
 
@@ -136,7 +135,7 @@ instance (MonadFail d, DecodeM d ByteString es) => DecodeM d (Map CPUFeature Boo
     case parseOnly (features <* endOfInput) s of
       Right features -> return features
       Left err -> fail ("failure to parse CPUFeature string: " <> err)
-                       
+
 -- | Find a 'Target' given an architecture and/or a \"triple\".
 -- | <http://llvm.org/doxygen/structllvm_1_1TargetRegistry.html#a3105b45e546c9cc3cf78d0f2ec18ad89>
 -- | Be sure to run either 'initializeAllTargets' or

--- a/llvm-hs/test/LLVM/Test/Constants.hs
+++ b/llvm-hs/test/LLVM/Test/Constants.hs
@@ -137,7 +137,7 @@ tests = testGroup "Constants" [
     ), (
       "selectvalue",
       i32,
-      C.Select (C.PtrToInt (C.GlobalReference (ptr i32) (UnName 1)) i1) 
+      C.Select (C.PtrToInt (C.GlobalReference (ptr i32) (UnName 1)) i1)
          (C.Int 32 1)
          (C.Int 32 2),
       "global i32 select (i1 ptrtoint (i32* @1 to i1), i32 1, i32 2)"
@@ -155,29 +155,30 @@ tests = testGroup "Constants" [
      (PointerType i32 (AddrSpace 1)),
      C.AddrSpaceCast (C.GlobalReference (ptr i32) (UnName 1)) (PointerType i32 (AddrSpace 1)),
      "global i32 addrspace(1)* addrspacecast (i32* @1 to i32 addrspace(1)*)"
-{-
-    ), (
---  This test made llvm abort as of llvm-3.2.  Now, as a new feature in llvm-3.4, it makes it report a fatal error!
+{-    ), (
+-- This test fails since LLVM 3.2!
+-- LLVM parses the extractValue instruction from a file via llvm-as properly, but it does not here.
+-- Rewritten by Andrew April 2021 to match the specific example in the LLVM language reference:
+-- https://llvm.org/docs/LangRef.html#extractvalue-instruction
+-- Bug filed with upstream here: https://bugs.llvm.org/show_bug.cgi?id=50092
       "extractvalue",
-      i8,
+      i32,
       C.ExtractValue
-        (C.Select (C.PtrToInt (C.GlobalReference (p i32) (UnName 1)) i1) 
-         (C.Array i8 [C.Int 8 0])
-         (C.Array i8 [C.Int 8 1]))
+        (C.Struct Nothing False [C.Int 32 0, C.Int 32 1])
         [0],
-      "global i8 extractvalue ([1 x i8] select (i1 ptrtoint (i32* @1 to i1), [1 x i8] [ i8 1 ], [1 x i8] [ i8 2 ]), 0)"
+      "global i32 extractvalue ({i32, i32} {i32 0, i32 1}, 0)"
 -}
     )
    ],
    let mAST = Module "<string>" "<string>" Nothing Nothing [
              GlobalDefinition $ globalVariableDefaults {
-               G.name = UnName 0, G.type' = type', G.initializer = Just value 
+               G.name = UnName 0, G.type' = type', G.initializer = Just value
              },
              GlobalDefinition $ globalVariableDefaults {
-               G.name = UnName 1, G.type' = i32, G.initializer = Nothing 
+               G.name = UnName 1, G.type' = i32, G.initializer = Nothing
              },
              GlobalDefinition $ globalVariableDefaults {
-               G.name = UnName 2, G.type' = i32, G.initializer = Nothing 
+               G.name = UnName 2, G.type' = i32, G.initializer = Nothing
              }
            ]
        mStr = "; ModuleID = '<string>'\nsource_filename = \"<string>\"\n\n@0 = " <> str <> "\n\


### PR DESCRIPTION
 * Gardening

- Fix all outstanding warnings when building against LLVM 9.0.1
- Remove deprecated `ListT` instances
- Remove redundant imports
- Correct hard-coded assumption that size_t is 32 bits in `LLVM.AST.Constant`
- Add a matching non-constant sizeof in `LLVM.IRBuilder.Instruction`
- Add -Wno-stringop-overflow when building the FFI modules, because LLVM 9.0.1 has multiple spurious build errors otherwise