### PR TITLE
Revert "Add support for atomicrmw on floating point types (#280)"

### DIFF
--- a/llvm-hs-pure/src/LLVM/AST/RMWOperation.hs
+++ b/llvm-hs-pure/src/LLVM/AST/RMWOperation.hs
@@ -16,7 +16,7 @@ data RMWOperation
   | Min
   | UMax
   | UMin
-  | FAdd
-  | FSub
   deriving (Eq, Ord, Read, Show, Data, Typeable, Generic)
+
+
 

--- a/llvm-hs/src/LLVM/Internal/FFI/BuilderC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/BuilderC.cpp
@@ -29,9 +29,9 @@ LLVM_HS_FOR_EACH_SYNCRONIZATION_SCOPE(ENUM_CASE)
 	}
 }
 
-static AtomicRMWInst::BinOp unwrap(LLVMAtomicRMWBinOp_ l) {
+static AtomicRMWInst::BinOp unwrap(LLVMAtomicRMWBinOp l) {
 	switch(l) {
-#define ENUM_CASE(x) case LLVMAtomicRMWBinOp_ ## x: return AtomicRMWInst::x;
+#define ENUM_CASE(x) case LLVMAtomicRMWBinOp ## x: return AtomicRMWInst::x;
 LLVM_HS_FOR_EACH_RMW_OPERATION(ENUM_CASE)
 #undef ENUM_CASE
 	default: return AtomicRMWInst::BinOp(0);
@@ -209,7 +209,7 @@ LLVMValueRef LLVM_Hs_BuildAtomicCmpXchg(
 LLVMValueRef LLVM_Hs_BuildAtomicRMW(
 	LLVMBuilderRef b,
 	LLVMBool v,
-	LLVMAtomicRMWBinOp_ rmwOp,
+	LLVMAtomicRMWBinOp rmwOp,
 	LLVMValueRef ptr, 
 	LLVMValueRef val, 
 	LLVMAtomicOrdering lao,

--- a/llvm-hs/src/LLVM/Internal/FFI/Instruction.h
+++ b/llvm-hs/src/LLVM/Internal/FFI/Instruction.h
@@ -4,38 +4,30 @@
 #include "llvm/Config/llvm-config.h"
 
 #define LLVM_HS_FOR_EACH_ATOMIC_ORDERING(macro) \
-    macro(NotAtomic) \
-    macro(Unordered) \
-    macro(Monotonic) \
-    macro(Acquire) \
-    macro(Release) \
-    macro(AcquireRelease) \
-    macro(SequentiallyConsistent)
+	macro(NotAtomic) \
+	macro(Unordered) \
+	macro(Monotonic) \
+	macro(Acquire) \
+	macro(Release) \
+	macro(AcquireRelease) \
+	macro(SequentiallyConsistent)
 
 #define LLVM_HS_FOR_EACH_RMW_OPERATION(macro) \
-    macro(Xchg) \
-    macro(Add) \
-    macro(Sub) \
-    macro(And) \
-    macro(Nand) \
-    macro(Or) \
-    macro(Xor) \
-    macro(Max) \
-    macro(Min) \
-    macro(UMax) \
-    macro(UMin) \
-    macro(FAdd) \
-    macro(FSub)
-
-typedef enum {
-#define ENUM_CASE(x) LLVMAtomicRMWBinOp_ ## x,
-LLVM_HS_FOR_EACH_RMW_OPERATION(ENUM_CASE)
-#undef ENUM_CASE
-} LLVMAtomicRMWBinOp_;
+	macro(Xchg) \
+	macro(Add) \
+	macro(Sub) \
+	macro(And) \
+	macro(Nand) \
+	macro(Or) \
+	macro(Xor) \
+	macro(Max) \
+	macro(Min) \
+	macro(UMax) \
+	macro(UMin)
 
 #define LLVM_HS_FOR_EACH_SYNCRONIZATION_SCOPE(macro) \
-    macro(SingleThread) \
-    macro(System)
+	macro(SingleThread) \
+	macro(System)
 
 typedef enum {
 #define ENUM_CASE(x) LLVM ## x ## SynchronizationScope,
@@ -45,12 +37,12 @@ LLVM_HS_FOR_EACH_SYNCRONIZATION_SCOPE(ENUM_CASE)
 
 /* The last parameter to the macro indicates whether the set<param> function takes a boolean argument or not */
 #define LLVM_HS_FOR_EACH_FAST_MATH_FLAG(macro) \
-    macro(AllowReassoc, allowReassoc, F)              \
-    macro(NoNaNs, noNaNs, F)                          \
-    macro(NoInfs, noInfs, F)                          \
-    macro(NoSignedZeros, noSignedZeros, F)            \
-    macro(AllowReciprocal, allowReciprocal, F)        \
-    macro(AllowContract, allowContract, T)            \
+	macro(AllowReassoc, allowReassoc, F)								\
+	macro(NoNaNs, noNaNs, F)                                              \
+	macro(NoInfs, noInfs, F)                                              \
+	macro(NoSignedZeros, noSignedZeros, F)								\
+	macro(AllowReciprocal, allowReciprocal, F)                            \
+    macro(AllowContract, allowContract, T) \
     macro(ApproxFunc, approxFunc, F)
 
 typedef enum {
@@ -66,10 +58,10 @@ LLVM_HS_FOR_EACH_FAST_MATH_FLAG(ENUM_CASE)
 } LLVMFastMathFlags;
 
 #define LLVM_HS_FOR_EACH_TAIL_CALL_KIND(macro) \
-    macro(None)                                       \
-    macro(Tail)                                       \
-    macro(MustTail)                                   \
-    macro(NoTail)
+	macro(None)                                       \
+	macro(Tail)                                       \
+	macro(MustTail)                                   \
+	macro(NoTail)
 
 typedef enum {
 #define ENUM_CASE(x) LLVM_Hs_TailCallKind_ ## x,

--- a/llvm-hs/src/LLVM/Internal/FFI/InstructionC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/InstructionC.cpp
@@ -36,12 +36,12 @@ LLVM_HS_FOR_EACH_SYNCRONIZATION_SCOPE(ENUM_CASE)
 	}
 }
 
-static LLVMAtomicRMWBinOp_ wrap(AtomicRMWInst::BinOp l) {
+static LLVMAtomicRMWBinOp wrap(AtomicRMWInst::BinOp l) {
 	switch(l) {
-#define ENUM_CASE(x) case AtomicRMWInst::x: return LLVMAtomicRMWBinOp_ ## x;
+#define ENUM_CASE(x) case AtomicRMWInst::x: return LLVMAtomicRMWBinOp ## x;
 LLVM_HS_FOR_EACH_RMW_OPERATION(ENUM_CASE)
 #undef ENUM_CASE
-	default: return LLVMAtomicRMWBinOp_(0);
+	default: return LLVMAtomicRMWBinOp(0);
 	}
 }
 
@@ -197,7 +197,7 @@ LLVMBool LLVM_Hs_GetInBounds(LLVMValueRef i) {
 	return unwrap<GEPOperator>(i)->isInBounds();
 }
 
-LLVMAtomicRMWBinOp_ LLVM_Hs_GetAtomicRMWBinOp(LLVMValueRef i) {
+LLVMAtomicRMWBinOp LLVM_Hs_GetAtomicRMWBinOp(LLVMValueRef i) {
 	return wrap(unwrap<AtomicRMWInst>(i)->getOperation());
 }
 

--- a/llvm-hs/src/LLVM/Internal/FFI/LLVMCTypes.hsc
+++ b/llvm-hs/src/LLVM/Internal/FFI/LLVMCTypes.hsc
@@ -16,20 +16,20 @@ import LLVM.Prelude
 #include "llvm-c/OrcBindings.h"
 #include "llvm-c/Target.h"
 #include "llvm-c/TargetMachine.h"
-#include "LLVM/Internal/FFI/Analysis.h"
 #include "LLVM/Internal/FFI/Attribute.h"
-#include "LLVM/Internal/FFI/CallingConvention.h"
-#include "LLVM/Internal/FFI/Constant.h"
-#include "LLVM/Internal/FFI/GlobalValue.h"
-#include "LLVM/Internal/FFI/InlineAssembly.h"
 #include "LLVM/Internal/FFI/Instruction.h"
-#include "LLVM/Internal/FFI/LibFunc.h"
-#include "LLVM/Internal/FFI/Metadata.h"
-#include "LLVM/Internal/FFI/OrcJIT.h"
-#include "LLVM/Internal/FFI/SMDiagnostic.h"
-#include "LLVM/Internal/FFI/Target.h"
-#include "LLVM/Internal/FFI/Type.h"
 #include "LLVM/Internal/FFI/Value.h"
+#include "LLVM/Internal/FFI/SMDiagnostic.h"
+#include "LLVM/Internal/FFI/InlineAssembly.h"
+#include "LLVM/Internal/FFI/Target.h"
+#include "LLVM/Internal/FFI/CallingConvention.h"
+#include "LLVM/Internal/FFI/GlobalValue.h"
+#include "LLVM/Internal/FFI/Type.h"
+#include "LLVM/Internal/FFI/Constant.h"
+#include "LLVM/Internal/FFI/Analysis.h"
+#include "LLVM/Internal/FFI/LibFunc.h"
+#include "LLVM/Internal/FFI/OrcJIT.h"
+#include "LLVM/Internal/FFI/Metadata.h"
 
 import Language.Haskell.TH.Quote
 
@@ -225,7 +225,7 @@ newtype AsmDialect = AsmDialect CUInt
 
 newtype RMWOperation = RMWOperation CUInt
   deriving (Eq, Read, Show, Typeable, Data, Generic)
-#define RMWOp_Rec(n) { #n, LLVMAtomicRMWBinOp_ ## n },
+#define RMWOp_Rec(n) { #n, LLVMAtomicRMWBinOp ## n },
 #{inject RMW_OPERATION, RMWOperation, RMWOperation, rmwOperation, RMWOp_Rec}
 
 newtype RelocModel = RelocModel CUInt

--- a/llvm-hs/src/LLVM/Internal/RMWOperation.hs
+++ b/llvm-hs/src/LLVM/Internal/RMWOperation.hs
@@ -21,8 +21,5 @@ genCodingInstance [t| RMWOperation |] ''FFI.RMWOperation [
   (FFI.rmwOperationMax, Max),
   (FFI.rmwOperationMin, Min),
   (FFI.rmwOperationUMax, UMax),
-  (FFI.rmwOperationUMin, UMin),
-  (FFI.rmwOperationFAdd, FAdd),
-  (FFI.rmwOperationFSub, FSub)
+  (FFI.rmwOperationUMin, UMin)
  ]
-


### PR DESCRIPTION
This reverts commit 5eac40827f256f40fe5a13b70635ef1aff3f0f6f.

This functionality is not in LLVM 9 and so shouldn't be on this branch