### PR TITLE
Add -Wno-init-list-lifetime options to cc-options

### DIFF
--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -239,7 +239,7 @@ library
     src/LLVM/Internal/FFI/TypeC.cpp
     src/LLVM/Internal/FFI/ValueC.cpp
 
-  cc-options: -std=c++11 -Wno-stringop-overflow
+  cc-options: -std=c++11 -Wno-stringop-overflow -Wno-init-list-lifetime
 
   if flag(debug)
     cc-options: -g


### PR DESCRIPTION
This silences many warnings we can't do anything about, generated by code in the LLVM release/9.x branch