### PR TITLE
Update to match LLVM head

### DIFF
--- a/llvm-hs/src/LLVM/Internal/FFI/Attribute.h
+++ b/llvm-hs/src/LLVM/Internal/FFI/Attribute.h
@@ -35,6 +35,7 @@
   macro(NoRecurse,F,F,T)                            \
   macro(NoRedZone,F,F,T)                            \
   macro(NoReturn,F,F,T)                             \
+  macro(NoSanitizeCoverage,F,F,T)                   \
   macro(NoSync,F,F,T)                               \
   macro(NoUndef,F,F,T)                              \
   macro(NoUnwind,F,F,T)                             \
@@ -62,6 +63,7 @@
   macro(StackProtectReq,F,F,T)                      \
   macro(StackProtectStrong,F,F,T)                   \
   macro(StrictFP,F,F,T)                             \
+  macro(SwiftAsync,T,F,F)                           \
   macro(SwiftError,T,F,F)                           \
   macro(SwiftSelf,T,F,F)                            \
   macro(UWTable,F,F,T)                              \

--- a/llvm-hs/src/LLVM/Internal/FFI/Target.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Target.hs
@@ -47,12 +47,6 @@ foreign import ccall unsafe "LLVM_Hs_GetCompressDebugSections" getCompressDebugS
 foreign import ccall unsafe "LLVM_Hs_SetCompressDebugSections" setCompressDebugSections ::
   Ptr TargetOptions -> DebugCompressionType -> IO ()
 
-foreign import ccall unsafe "LLVM_Hs_SetStackAlignmentOverride" setStackAlignmentOverride ::
-  Ptr TargetOptions -> CUInt -> IO ()
-
-foreign import ccall unsafe "LLVM_Hs_GetStackAlignmentOverride" getStackAlignmentOverride ::
-  Ptr TargetOptions -> IO CUInt
-
 foreign import ccall unsafe "LLVM_Hs_SetFloatABIType" setFloatABIType ::
   Ptr TargetOptions -> FloatABIType -> IO ()
 

--- a/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/TargetC.cpp
@@ -349,14 +349,6 @@ unsigned LLVM_Hs_GetMCTargetOptionFlag(MCTargetOptions *to,
     }
 }
 
-void LLVM_Hs_SetStackAlignmentOverride(TargetOptions *to, unsigned v) {
-    to->StackAlignmentOverride = v;
-}
-
-unsigned LLVM_Hs_GetStackAlignmentOverride(TargetOptions *to) {
-    return to->StackAlignmentOverride;
-}
-
 void LLVM_Hs_SetFloatABIType(TargetOptions *to, LLVM_Hs_FloatABI v) {
     to->FloatABIType = unwrap(v);
 }

--- a/llvm-hs/src/LLVM/Internal/Target.hs
+++ b/llvm-hs/src/LLVM/Internal/Target.hs
@@ -188,7 +188,6 @@ pokeTargetOptions hOpts opts@(TargetOptions cOpts) = do
     (FFI.targetOptionFlagEmulatedTLS, TO.emulatedThreadLocalStorage),
     (FFI.targetOptionFlagEnableIPRA, TO.enableInterProceduralRegisterAllocation)
    ]
-  FFI.setStackAlignmentOverride cOpts =<< encodeM (TO.stackAlignmentOverride hOpts)
   FFI.setFloatABIType cOpts =<< encodeM (TO.floatABIType hOpts)
   FFI.setAllowFPOpFusion cOpts =<< encodeM (TO.allowFloatingPointOperationFusion hOpts)
   FFI.setCompressDebugSections cOpts =<< encodeM (TO.compressDebugSections hOpts)
@@ -259,7 +258,6 @@ peekTargetOptions opts@(TargetOptions tOpts) = do
     <- gof FFI.targetOptionFlagEmulatedTLS
   enableInterProceduralRegisterAllocation
     <- gof FFI.targetOptionFlagEnableIPRA
-  stackAlignmentOverride <- decodeM =<< FFI.getStackAlignmentOverride tOpts
   floatABIType <- decodeM =<< FFI.getFloatABIType tOpts
   allowFloatingPointOperationFusion <- decodeM =<< FFI.getAllowFPOpFusion tOpts
   threadModel <- decodeM =<< FFI.getThreadModel tOpts

--- a/llvm-hs/src/LLVM/Target/Options.hs
+++ b/llvm-hs/src/LLVM/Target/Options.hs
@@ -86,7 +86,6 @@ data Options = Options {
   trapUnreachable :: Bool,
   emulatedThreadLocalStorage :: Bool,
   enableInterProceduralRegisterAllocation :: Bool,
-  stackAlignmentOverride :: Word32,
   floatABIType :: FloatABI,
   allowFloatingPointOperationFusion :: FloatingPointOperationFusionMode,
   threadModel :: ThreadModel,

--- a/llvm-hs/test/LLVM/Test/Module.hs
+++ b/llvm-hs/test/LLVM/Test/Module.hs
@@ -60,17 +60,17 @@ handString = "; ModuleID = '<string>'\n\
     \@one = thread_local(initialexec) alias i32, i32* @5\n\
     \\n\
     \define i32 @bar() prefix i32 1 {\n\
-    \  %1 = musttail call zeroext i32 @foo(i32 inreg align 16 1, i8 signext 4) #0\n\
+    \  %1 = musttail call zeroext i32 @foo(i32 inreg 1, i8 signext 4) #0\n\
     \  ret i32 %1\n\
     \}\n\
     \\n\
     \define i32 @baz() prefix i32 1 {\n\
-    \  %1 = notail call zeroext i32 @foo(i32 inreg align 16 1, i8 signext 4) #0\n\
+    \  %1 = notail call zeroext i32 @foo(i32 inreg 1, i8 signext 4) #0\n\
     \  ret i32 %1\n\
     \}\n\
     \\n\
     \; Function Attrs: nounwind readnone uwtable\n\
-    \define zeroext i32 @foo(i32 inreg align 16 %x, i8 signext %y) #0 {\n\
+    \define zeroext i32 @foo(i32 inreg %x, i8 signext %y) #0 {\n\
     \  %1 = mul nsw i32 %x, %x\n\
     \  br label %here\n\
     \\n\
@@ -169,7 +169,7 @@ handAST = Module "<string>" "<string>" Nothing Nothing [
              returnAttributes = [PA.ZeroExt],
              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType i32 [i32, i8] False)) (Name "foo"))),
              arguments = [
-              (ConstantOperand (C.Int 32 1), [PA.InReg, PA.Alignment 16]),
+              (ConstantOperand (C.Int 32 1), [PA.InReg]),
               (ConstantOperand (C.Int 8 4), [PA.SignExt])
              ],
              functionAttributes = [Left (FA.GroupID 0)],
@@ -192,7 +192,7 @@ handAST = Module "<string>" "<string>" Nothing Nothing [
              returnAttributes = [PA.ZeroExt],
              function = Right (ConstantOperand (C.GlobalReference (ptr (FunctionType i32 [i32, i8] False)) (Name "foo"))),
              arguments = [
-              (ConstantOperand (C.Int 32 1), [PA.InReg, PA.Alignment 16]),
+              (ConstantOperand (C.Int 32 1), [PA.InReg]),
               (ConstantOperand (C.Int 8 4), [PA.SignExt])
              ],
              functionAttributes = [Left (FA.GroupID 0)],
@@ -208,7 +208,7 @@ handAST = Module "<string>" "<string>" Nothing Nothing [
         G.returnType = i32,
         G.name = Name "foo",
         G.parameters = ([
-          Parameter i32 (Name "x") [PA.InReg, PA.Alignment 16],
+          Parameter i32 (Name "x") [PA.InReg],
           Parameter i8 (Name "y") [PA.SignExt]
          ], False),
         G.functionAttributes = [Left (FA.GroupID 0)],

--- a/llvm-hs/test/LLVM/Test/Optimization.hs
+++ b/llvm-hs/test/LLVM/Test/Optimization.hs
@@ -143,7 +143,7 @@ tests = testGroup "Optimization" [
             )
           ]
         },
-      FunctionAttributes (A.GroupID 0) [A.NoRecurse, A.NoUnwind, A.ReadNone, A.UWTable, A.WillReturn]
+      FunctionAttributes (A.GroupID 0) [A.NoFree, A.NoRecurse, A.NoSync, A.NoUnwind, A.ReadNone, A.UWTable, A.WillReturn, A.MustProgress]
       ],
 
   testGroup "individual" [

--- a/llvm-hs/test/LLVM/Test/Target.hs
+++ b/llvm-hs/test/LLVM/Test/Target.hs
@@ -74,7 +74,6 @@ instance Arbitrary Options where
     trapUnreachable <- arbitrary
     emulatedThreadLocalStorage <- arbitrary
     enableInterProceduralRegisterAllocation <- arbitrary
-    stackAlignmentOverride <- arbitrary
     floatABIType <- arbitrary
     allowFloatingPointOperationFusion <- arbitrary
     threadModel <- arbitrary


### PR DESCRIPTION
- Add new attributes
- Remove stack alignment from target options (it is not a module attribute)
- Update curated pass tests with new inferred attributes
- Remove illegal align annotations on tail call tests