### PR TITLE
Cherry-pick fixes from the llvm-9 branch

### DIFF
--- a/llvm-hs-pure/CHANGELOG.md
+++ b/llvm-hs-pure/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 12.0.0 (2021-03-19)
 
 * Update to LLVM 12.0
+* Eliminate hard-coded assumption of 32-bit `size_t`
+* Add a runtime variant of the `LLVM.AST.Constant.sizeof` utility in `LLVM.IRBuilder.Instruction.sizeof`. The size of opaque structure types is unknown until link-time and therefore cannot be computed as a constant.
+* Handle type resolution through `NamedTypeReference` correctly: type resolution in LLVM depends on module state by design
+* Support the LLVM `NoFree` attribute
+* Add support for some more DWARF operators: `DW_OP_bregx` and `DW_OP_push_object_address`
 
 ## 9.0.0 (2019-09-06)
 

--- a/llvm-hs-pure/src/LLVM/AST/Operand.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Operand.hs
@@ -61,27 +61,29 @@ data DWOpFragment = DW_OP_LLVM_Fragment
 
 -- | <https://llvm.org/docs/LangRef.html#diexpression>
 data DWOp
-  = DwOpFragment DWOpFragment -- ^ Must appear at the end
-  | DW_OP_StackValue -- ^ Must be the last one or followed by a DW_OP_LLVM_Fragment
-  | DW_OP_Swap
+  = DW_OP_And
+  | DW_OP_Bregx
   | DW_OP_ConstU Word64
-  | DW_OP_Lit0
-  | DW_OP_PlusUConst Word64
-  | DW_OP_Plus
-  | DW_OP_Minus
-  | DW_OP_Mul
+  | DW_OP_Deref
   | DW_OP_Div
+  | DW_OP_Dup
+  | DwOpFragment DWOpFragment -- ^ Must appear at the end
+  | DW_OP_Lit0
+  | DW_OP_Minus
   | DW_OP_Mod
+  | DW_OP_Mul
   | DW_OP_Not
   | DW_OP_Or
-  | DW_OP_Xor
-  | DW_OP_And
+  | DW_OP_Plus
+  | DW_OP_PlusUConst Word64
+  | DW_OP_PushObjectAddress
+  | DW_OP_Shl
   | DW_OP_Shr
   | DW_OP_Shra
-  | DW_OP_Shl
-  | DW_OP_Dup
-  | DW_OP_Deref
+  | DW_OP_StackValue -- ^ Must be the last one or followed by a DW_OP_LLVM_Fragment
+  | DW_OP_Swap
   | DW_OP_XDeref
+  | DW_OP_Xor
   deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
 
 -- | <http://llvm.org/docs/LangRef.html#metadata>

--- a/llvm-hs-pure/src/LLVM/AST/Typed.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Typed.hs
@@ -53,7 +53,7 @@ instance Typed C.Constant where
                                return $ VectorType (fromIntegral $ length memberValues) t
 
   typeOf (C.Undef t)     = return t
-  typeOf (C.BlockAddress {..})   = return $ ptr i8
+  typeOf (C.BlockAddress {}) = return $ ptr i8
   typeOf (C.GlobalReference t _) = return t
   typeOf (C.Add {..})     = typeOf operand0
   typeOf (C.FAdd {..})    = typeOf operand0

--- a/llvm-hs-pure/src/LLVM/AST/Typed.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Typed.hs
@@ -10,43 +10,51 @@ module LLVM.AST.Typed (
 
 import LLVM.Prelude
 
+import Control.Monad.State (gets)
+import qualified Data.Map.Lazy as Map
 import GHC.Stack
 
 import LLVM.AST
 import LLVM.AST.Global
 import LLVM.AST.Type
 
+import LLVM.IRBuilder.Module
+
 import qualified LLVM.AST.Constant as C
 import qualified LLVM.AST.Float as F
 
 class Typed a where
-    typeOf :: HasCallStack => a -> Type
+    typeOf :: (HasCallStack, MonadModuleBuilder m) => a -> m Type
 
 instance Typed Operand where
-  typeOf (LocalReference t _) = t
+  typeOf (LocalReference t _) = return t
   typeOf (ConstantOperand c)  = typeOf c
-  typeOf _                    = MetadataType
+  typeOf _                    = return MetadataType
 
 instance Typed CallableOperand where
   typeOf (Right op) = typeOf op
   typeOf (Left _) = error "typeOf inline assembler is not defined. (Malformed AST)"
 
 instance Typed C.Constant where
-  typeOf (C.Int bits _)  = IntegerType bits
+  typeOf (C.Int bits _)  = return $ IntegerType bits
   typeOf (C.Float t) = typeOf t
-  typeOf (C.Null t)      = t
-  typeOf (C.AggregateZero t) = t
+  typeOf (C.Null t)      = return t
+  typeOf (C.AggregateZero t) = return t
   typeOf (C.Struct {..}) = case structName of
-                             Nothing -> StructureType isPacked (map typeOf memberValues)
-                             Just sn -> NamedTypeReference sn
-  typeOf (C.Array {..})  = ArrayType (fromIntegral $ length memberValues) memberType
-  typeOf (C.Vector {..}) = VectorType (fromIntegral $ length memberValues) $
-                              case memberValues of
-                                  []    -> error "Vectors of size zero are not allowed. (Malformed AST)"
-                                  (x:_) -> typeOf x
-  typeOf (C.Undef t)     = t
-  typeOf (C.BlockAddress {..})   = ptr i8
-  typeOf (C.GlobalReference t _) = t
+                             Nothing -> do
+                               mvtys <- mapM typeOf memberValues
+                               return $ StructureType isPacked mvtys
+                             Just sn -> return $ NamedTypeReference sn
+  typeOf (C.Array {..})  = return $ ArrayType (fromIntegral $ length memberValues) memberType
+  typeOf (C.Vector {..}) = case memberValues of
+                             []    -> error "Vectors of size zero are not allowed. (Malformed AST)"
+                             (x:_) -> do
+                               t <- typeOf x
+                               return $ VectorType (fromIntegral $ length memberValues) t
+
+  typeOf (C.Undef t)     = return t
+  typeOf (C.BlockAddress {..})   = return $ ptr i8
+  typeOf (C.GlobalReference t _) = return t
   typeOf (C.Add {..})     = typeOf operand0
   typeOf (C.FAdd {..})    = typeOf operand0
   typeOf (C.FDiv {..})    = typeOf operand0
@@ -65,53 +73,73 @@ instance Typed C.Constant where
   typeOf (C.And {..})     = typeOf operand0
   typeOf (C.Or  {..})     = typeOf operand0
   typeOf (C.Xor {..})     = typeOf operand0
-  typeOf (C.GetElementPtr {..}) = getElementPtrType (typeOf address) indices
-  typeOf (C.Trunc {..})   = type'
-  typeOf (C.ZExt {..})    = type'
-  typeOf (C.SExt {..})    = type'
-  typeOf (C.FPToUI {..})  = type'
-  typeOf (C.FPToSI {..})  = type'
-  typeOf (C.UIToFP {..})  = type'
-  typeOf (C.SIToFP {..})  = type'
-  typeOf (C.FPTrunc {..}) = type'
-  typeOf (C.FPExt {..})   = type'
-  typeOf (C.PtrToInt {..}) = type'
-  typeOf (C.IntToPtr {..}) = type'
-  typeOf (C.BitCast {..})  = type'
-  typeOf (C.ICmp {..})    = case (typeOf operand0) of
-                              (VectorType n _) -> VectorType n i1
-                              _ -> i1
-  typeOf (C.FCmp {..})    = case (typeOf operand0) of
-                              (VectorType n _) -> VectorType n i1
-                              _ -> i1
+  typeOf (C.GetElementPtr {..}) = do
+    aty <- typeOf address
+    getElementPtrType aty indices
+  typeOf (C.Trunc {..})   = return type'
+  typeOf (C.ZExt {..})    = return type'
+  typeOf (C.SExt {..})    = return type'
+  typeOf (C.FPToUI {..})  = return type'
+  typeOf (C.FPToSI {..})  = return type'
+  typeOf (C.UIToFP {..})  = return type'
+  typeOf (C.SIToFP {..})  = return type'
+  typeOf (C.FPTrunc {..}) = return type'
+  typeOf (C.FPExt {..})   = return type'
+  typeOf (C.PtrToInt {..}) = return type'
+  typeOf (C.IntToPtr {..}) = return type'
+  typeOf (C.BitCast {..})  = return type'
+  typeOf (C.ICmp {..})    = do
+    t <- typeOf operand0
+    case t of
+      (VectorType n _) -> return $ VectorType n i1
+      _ -> return i1
+  typeOf (C.FCmp {..})    = do
+    t <- typeOf operand0
+    case t of
+      (VectorType n _) -> return $ VectorType n i1
+      _ -> return i1
   typeOf (C.Select {..})  = typeOf trueValue
-  typeOf (C.ExtractElement {..})  = case typeOf vector of
-                                      (VectorType _ t) -> t
-                                      _ -> error "The first operand of an extractelement instruction is a value of vector type. (Malformed AST)"
+  typeOf (C.ExtractElement {..})  = do
+    t <- typeOf vector
+    case t of
+      (VectorType _ t') -> return t'
+      _ -> error "The first operand of an extractelement instruction is a value of vector type. (Malformed AST)"
   typeOf (C.InsertElement {..})   = typeOf vector
-  typeOf (C.ShuffleVector {..})   = case (typeOf operand0, typeOf mask) of
-                                      (VectorType _ t, VectorType m _) -> VectorType m t
-                                      _ -> error "The first operand of an shufflevector instruction is a value of vector type. (Malformed AST)"
-  typeOf (C.ExtractValue {..})    = extractValueType indices' (typeOf aggregate)
-  typeOf (C.InsertValue {..})     = typeOf aggregate
-  typeOf (C.TokenNone)          = TokenType
-  typeOf (C.AddrSpaceCast {..}) = type'
+  typeOf (C.ShuffleVector {..})   = do
+    t0 <- typeOf operand0
+    tm <- typeOf mask
+    case (t0, tm) of
+      (VectorType _ t, VectorType m _) -> return $ VectorType m t
+      _ -> error "The first operand of an shufflevector instruction is a value of vector type. (Malformed AST)"
+  typeOf (C.ExtractValue {..})    = do
+    t <- typeOf aggregate
+    extractValueType indices' t
+  typeOf (C.InsertValue {..})   = typeOf aggregate
+  typeOf (C.TokenNone)          = return TokenType
+  typeOf (C.AddrSpaceCast {..}) = return type'
 
-getElementPtrType :: Type -> [C.Constant] -> Type
-getElementPtrType ty [] = ptr ty
+getElementPtrType :: (HasCallStack, MonadModuleBuilder m) => Type -> [C.Constant] -> m Type
+getElementPtrType ty [] = return $ ptr ty
 getElementPtrType (PointerType ty _) (_:is) = getElementPtrType ty is
 getElementPtrType (StructureType _ elTys) (C.Int 32 val:is) =
   getElementPtrType (elTys !! fromIntegral val) is
+getElementPtrType (StructureType _ _) (_:_) =
+  error "Indices into structures should be 32-bit constants. (Malformed AST)"
 getElementPtrType (VectorType _ elTy) (_:is) = getElementPtrType elTy is
 getElementPtrType (ArrayType _ elTy) (_:is) = getElementPtrType elTy is
+getElementPtrType (NamedTypeReference n) (_:is) = do
+  mayTy <- liftModuleState (gets (Map.lookup n . builderTypeDefs))
+  case mayTy of
+    Nothing -> error $ "Couldn’t resolve typedef for: " ++ show n
+    Just ty -> getElementPtrType ty is
 getElementPtrType ty@_ _ = error $ "Expecting aggregate type but saw " ++ show ty ++ " (Malformed AST)"
 
 getElementType :: Type -> Type
 getElementType (PointerType t _) = t
 getElementType ty@_ = error $ "Expecting pointer type but saw " ++ show ty ++ " (Malformed AST)"
 
-extractValueType :: [Word32] -> Type -> Type
-extractValueType [] ty = ty
+extractValueType :: (HasCallStack, MonadModuleBuilder m) => [Word32] -> Type -> m Type
+extractValueType [] ty = return ty
 extractValueType (i : is) (ArrayType numEls elTy)
   | fromIntegral i < numEls = extractValueType is elTy
   | fromIntegral i >= numEls = error "Expecting valid index into array type. (Malformed AST)"
@@ -121,20 +149,23 @@ extractValueType (i : is) (StructureType _ elTys)
 extractValueType _ _ = error "Expecting vector type. (Malformed AST)"
 
 instance Typed F.SomeFloat where
-  typeOf (F.Half _)          = FloatingPointType HalfFP
-  typeOf (F.Single _)        = FloatingPointType FloatFP
-  typeOf (F.Double _)        = FloatingPointType DoubleFP
-  typeOf (F.Quadruple _ _)   = FloatingPointType FP128FP
-  typeOf (F.X86_FP80 _ _)    = FloatingPointType X86_FP80FP
-  typeOf (F.PPC_FP128 _ _)   = FloatingPointType PPC_FP128FP
+  typeOf (F.Half _)          = return $ FloatingPointType HalfFP
+  typeOf (F.Single _)        = return $ FloatingPointType FloatFP
+  typeOf (F.Double _)        = return $ FloatingPointType DoubleFP
+  typeOf (F.Quadruple _ _)   = return $ FloatingPointType FP128FP
+  typeOf (F.X86_FP80 _ _)    = return $ FloatingPointType X86_FP80FP
+  typeOf (F.PPC_FP128 _ _)   = return $ FloatingPointType PPC_FP128FP
 
 instance Typed Global where
-  typeOf (GlobalVariable {..}) = type'
-  typeOf (GlobalAlias {..})    = type'
-  typeOf (Function {..})       = let (params, isVarArg) = parameters
-                                   in FunctionType returnType (map typeOf params) isVarArg
+  typeOf (GlobalVariable {..}) = return $ type'
+  typeOf (GlobalAlias {..})    = return $ type'
+  typeOf (Function {..})       = do
+    let (params, isVarArg) = parameters
+    ptys <- mapM typeOf params
+    return $ FunctionType returnType ptys isVarArg
+
 instance Typed Parameter where
-  typeOf (Parameter t _ _) = t
+  typeOf (Parameter t _ _) = return t
 
 instance Typed [Int32] where
-  typeOf mask = VectorType (fromIntegral $ length mask) i32
+  typeOf mask = return $ VectorType (fromIntegral $ length mask) i32

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Constant.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Constant.hs
@@ -6,6 +6,7 @@ import           LLVM.AST.Typed
 
 import           LLVM.AST.Constant
 import           LLVM.AST.Float
+import           LLVM.IRBuilder.Module
 
 int64 :: Integer -> Operand
 int64 = ConstantOperand . Int 64
@@ -28,5 +29,7 @@ half = ConstantOperand . Float . Half
 struct :: Maybe Name -> Bool -> [Constant] -> Operand
 struct nm packing members = ConstantOperand $ Struct nm packing members
 
-array :: [Constant] -> Operand
-array members = ConstantOperand $ Array (typeOf $ head members) members
+array :: MonadModuleBuilder m => [Constant] -> m Operand
+array members = do
+  thm <- typeOf $ head members
+  return $ ConstantOperand $ Array thm members

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Instruction.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Instruction.hs
@@ -28,7 +28,7 @@ import LLVM.IRBuilder.Monad
 import LLVM.IRBuilder.Module
 
 -- | See <https://llvm.org/docs/LangRef.html#fneg-instruction reference>.
-fneg :: MonadIRBuilder m => Operand -> m Operand
+fneg :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> m Operand
 fneg a = do
   ta <- typeOf a
   emitInstr ta $ FNeg noFastMathFlags a []
@@ -262,7 +262,7 @@ insertElement v e i = do
   emitInstr tv $ InsertElement v e i []
 
 -- | See <https://llvm.org/docs/LangRef.html#shufflevector-instruction reference>.
-shuffleVector :: (HasCallStack, MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> C.Constant -> m Operand
+shuffleVector :: (HasCallStack, MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> [Int32] -> m Operand
 shuffleVector a b m = do
   ta <- typeOf a
   tm <- typeOf m

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Instruction.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Instruction.hs
@@ -29,91 +29,130 @@ import LLVM.IRBuilder.Module
 
 -- | See <https://llvm.org/docs/LangRef.html#fneg-instruction reference>.
 fneg :: MonadIRBuilder m => Operand -> m Operand
-fneg a = emitInstr (typeOf a) $ FNeg noFastMathFlags a []
+fneg a = do
+  ta <- typeOf a
+  emitInstr ta $ FNeg noFastMathFlags a []
 
 -- | See <https://llvm.org/docs/LangRef.html#fadd-instruction reference>.
-fadd :: MonadIRBuilder m => Operand -> Operand -> m Operand
-fadd a b = emitInstr (typeOf a) $ FAdd noFastMathFlags a b []
+fadd :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+fadd a b = do
+  ta <- typeOf a
+  emitInstr ta $ FAdd noFastMathFlags a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#fmul-instruction reference>.
-fmul :: MonadIRBuilder m => Operand -> Operand -> m Operand
-fmul a b = emitInstr (typeOf a) $ FMul noFastMathFlags a b []
+fmul :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+fmul a b = do
+  ta <- typeOf a
+  emitInstr ta $ FMul noFastMathFlags a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#fsub-instruction reference>.
-fsub :: MonadIRBuilder m => Operand -> Operand -> m Operand
-fsub a b = emitInstr (typeOf a) $ FSub noFastMathFlags a b []
+fsub :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+fsub a b = do
+  ta <- typeOf a
+  emitInstr ta $ FSub noFastMathFlags a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#fdiv-instruction reference>.
-fdiv :: MonadIRBuilder m => Operand -> Operand -> m Operand
-fdiv a b = emitInstr (typeOf a) $ FDiv noFastMathFlags a b []
+fdiv :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+fdiv a b = do
+  ta <- typeOf a
+  emitInstr ta $ FDiv noFastMathFlags a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#frem-instruction reference>.
-frem :: MonadIRBuilder m => Operand -> Operand -> m Operand
-frem a b = emitInstr (typeOf a) $ FRem noFastMathFlags a b []
+frem :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+frem a b = do
+  ta <- typeOf a
+  emitInstr ta $ FRem noFastMathFlags a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#add-instruction reference>.
-add :: MonadIRBuilder m => Operand -> Operand -> m Operand
-add a b = emitInstr (typeOf a) $ Add False False a b []
+add :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+add a b = do
+  ta <- typeOf a
+  emitInstr ta $ Add False False a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#mul-instruction reference>.
-mul :: MonadIRBuilder m => Operand -> Operand -> m Operand
-mul a b = emitInstr (typeOf a) $ Mul False False a b []
+mul :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+mul a b = do
+  ta <- typeOf a
+  emitInstr ta $ Mul False False a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#sub-instruction reference>.
-sub :: MonadIRBuilder m => Operand -> Operand -> m Operand
-sub a b = emitInstr (typeOf a) $ Sub False False a b []
+sub :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+sub a b = do
+  ta <- typeOf a
+  emitInstr ta $ Sub False False a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#udiv-instruction reference>.
-udiv :: MonadIRBuilder m => Operand -> Operand -> m Operand
-udiv a b = emitInstr (typeOf a) $ UDiv False a b []
+udiv :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+udiv a b = do
+  ta <- typeOf a
+  emitInstr ta $ UDiv False a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#sdiv-instruction reference>.
-sdiv :: MonadIRBuilder m => Operand -> Operand -> m Operand
-sdiv a b = emitInstr (typeOf a) $ SDiv False a b []
+sdiv :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+sdiv a b = do
+  ta <- typeOf a
+  emitInstr ta $ SDiv False a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#urem-instruction reference>.
-urem :: MonadIRBuilder m => Operand -> Operand -> m Operand
-urem a b = emitInstr (typeOf a) $ URem a b []
+urem :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+urem a b = do
+  ta <- typeOf a
+  emitInstr ta $ URem a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#srem-instruction reference>.
-srem :: MonadIRBuilder m => Operand -> Operand -> m Operand
-srem a b = emitInstr (typeOf a) $ SRem a b []
+srem :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+srem a b = do
+  ta <- typeOf a
+  emitInstr ta $ SRem a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#shl-instruction reference>.
-shl :: MonadIRBuilder m => Operand -> Operand -> m Operand
-shl a b = emitInstr (typeOf a) $ Shl False False a b []
+shl :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+shl a b = do
+  ta <- typeOf a
+  emitInstr ta $ Shl False False a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#lshl-instruction reference>.
-lshr :: MonadIRBuilder m => Operand -> Operand -> m Operand
-lshr a b = emitInstr (typeOf a) $ LShr True a b []
+lshr :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+lshr a b = do
+  ta <- typeOf a
+  emitInstr ta $ LShr True a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#ashl-instruction reference>.
-ashr :: MonadIRBuilder m => Operand -> Operand -> m Operand
-ashr a b = emitInstr (typeOf a) $ AShr True a b []
+ashr :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+ashr a b = do
+  ta <- typeOf a
+  emitInstr ta $ AShr True a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#and-instruction reference>.
-and :: MonadIRBuilder m => Operand -> Operand -> m Operand
-and a b = emitInstr (typeOf a) $ And a b []
+and :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+and a b = do
+  ta <- typeOf a
+  emitInstr ta $ And a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#or-instruction reference>.
-or :: MonadIRBuilder m => Operand -> Operand -> m Operand
-or a b = emitInstr (typeOf a) $ Or a b []
+or :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+or a b = do
+  ta <- typeOf a
+  emitInstr ta $ Or a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#xor-instruction reference>.
-xor :: MonadIRBuilder m => Operand -> Operand -> m Operand
-xor a b = emitInstr (typeOf a) $ Xor a b []
+xor :: (MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+xor a b = do
+  ta <- typeOf a
+  emitInstr ta $ Xor a b []
 
 -- | See <https://llvm.org/docs/LangRef.html#alloca-instruction reference>.
 alloca :: MonadIRBuilder m => Type -> Maybe Operand -> Word32 -> m Operand
 alloca ty count align = emitInstr (ptr ty) $ Alloca ty count align []
 
 -- | See <https://llvm.org/docs/LangRef.html#load-instruction reference>.
-load :: HasCallStack => MonadIRBuilder m => Operand -> Word32 -> m Operand
-load a align = emitInstr retty $ Load False a Nothing align []
-  where
-    retty = case typeOf a of
-      PointerType ty _ -> ty
-      _ -> error "Cannot load non-pointer (Malformed AST)."
+load :: (HasCallStack, MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Word32 -> m Operand
+load a align = do
+  ta <- typeOf a
+  let retty = case ta of
+                PointerType ty _ -> ty
+                _ -> error "Cannot load non-pointer (Malformed AST)."
+  emitInstr retty $ Load False a Nothing align []
 
 -- | See <https://llvm.org/docs/LangRef.html#store-instruction reference>.
 store :: MonadIRBuilder m => Operand -> Word32 -> Operand -> m ()
@@ -121,13 +160,14 @@ store addr align val = emitInstrVoid $ Store False addr val Nothing align []
 
 -- | Emit the @getelementptr@ instruction.
 -- See <https://llvm.org/docs/LangRef.html#getelementptr-instruction reference>.
-gep :: (MonadIRBuilder m, MonadModuleBuilder m, HasCallStack) => Operand -> [Operand] -> m Operand
+gep :: (HasCallStack, MonadIRBuilder m, MonadModuleBuilder m) => Operand -> [Operand] -> m Operand
 gep addr is = do
-  ty <- ptr <$> gepType "gep" (typeOf addr) is
+  ta <- typeOf addr
+  ty <- ptr <$> gepType "gep" ta is
   emitInstr ty (GetElementPtr False addr is [])
 
 -- TODO: Perhaps use the function from llvm-hs-pretty (https://github.com/llvm-hs/llvm-hs-pretty/blob/master/src/LLVM/Typed.hs)
-gepType :: (MonadModuleBuilder m, HasCallStack) => String -> Type -> [Operand] -> m Type
+gepType :: (HasCallStack, MonadModuleBuilder m) => String -> Type -> [Operand] -> m Type
 gepType caller = go
   where
     msg m = caller ++ ": " ++ m
@@ -207,41 +247,47 @@ bitcast :: MonadIRBuilder m => Operand -> Type -> m Operand
 bitcast a to = emitInstr to $ BitCast a to []
 
 -- | See <https://llvm.org/docs/LangRef.html#extractelement-instruction reference>.
-extractElement :: (MonadIRBuilder m, HasCallStack) => Operand -> Operand -> m Operand
-extractElement v i = emitInstr elemTyp $ ExtractElement v i []
-  where elemTyp =
-          case typeOf v of
-            VectorType _ typ -> typ
-            _ -> error "extractElement: Expected a vector type (malformed AST)."
+extractElement :: (HasCallStack, MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> m Operand
+extractElement v i = do
+  tv <- typeOf v
+  let elemTyp = case tv of
+                  VectorType _ typ -> typ
+                  _ -> error "extractElement: Expected a vector type (malformed AST)."
+  emitInstr elemTyp $ ExtractElement v i []
 
 -- | See <https://llvm.org/docs/LangRef.html#insertelement-instruction reference>.
-insertElement :: MonadIRBuilder m => Operand -> Operand -> Operand -> m Operand
-insertElement v e i = emitInstr (typeOf v) $ InsertElement v e i []
+insertElement :: (HasCallStack, MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> Operand -> m Operand
+insertElement v e i = do
+  tv <- typeOf v
+  emitInstr tv $ InsertElement v e i []
 
 -- | See <https://llvm.org/docs/LangRef.html#shufflevector-instruction reference>.
-shuffleVector :: (MonadIRBuilder m, HasCallStack) => Operand -> Operand -> [Int32] -> m Operand
-shuffleVector a b m = emitInstr retType $ ShuffleVector a b m []
-  where retType =
-          case typeOf a of
-            VectorType _ elemTyp -> VectorType (fromIntegral (length m)) elemTyp
-            _ -> error "shuffleVector: Expected two vectors and a vector mask"
+shuffleVector :: (HasCallStack, MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> C.Constant -> m Operand
+shuffleVector a b m = do
+  ta <- typeOf a
+  tm <- typeOf m
+  let retType = case (ta, tm) of
+                  (VectorType _ elemTyp, VectorType maskLength _) -> VectorType maskLength elemTyp
+                  _ -> error "shuffleVector: Expected two vectors and a vector mask"
+  emitInstr retType $ ShuffleVector a b m []
 
 -- | See <https://llvm.org/docs/LangRef.html#extractvalue-instruction reference>.
-extractValue :: (MonadIRBuilder m, MonadModuleBuilder m, HasCallStack) => Operand -> [Word32] -> m Operand
+extractValue :: (HasCallStack, MonadIRBuilder m, MonadModuleBuilder m) => Operand -> [Word32] -> m Operand
 extractValue a i = do
+  ta <- typeOf a
+  let aggType = case ta of
+                  typ@ArrayType{} -> typ
+                  typ@NamedTypeReference{} -> typ
+                  typ@StructureType{} -> typ
+                  _ -> error "extractValue: Expecting structure or array type. (Malformed AST)"
   retType <- gepType "extractValue" aggType (map (ConstantOperand . C.Int 32 . fromIntegral) i)
   emitInstr retType $ ExtractValue a i []
-  where
-    aggType =
-      case typeOf a of
-        typ@ArrayType{} -> typ
-        typ@NamedTypeReference{} -> typ
-        typ@StructureType{} -> typ
-        _ -> error "extractValue: Expecting structure or array type. (Malformed AST)"
 
 -- | See <https://llvm.org/docs/LangRef.html#insertvalue-instruction reference>.
-insertValue :: MonadIRBuilder m => Operand -> Operand -> [Word32] -> m Operand
-insertValue a e i = emitInstr (typeOf a) $ InsertValue a e i []
+insertValue :: (HasCallStack, MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> [Word32] -> m Operand
+insertValue a e i = do
+  ta <- typeOf a
+  emitInstr ta $ InsertValue a e i []
 
 -- | See <https://llvm.org/docs/LangRef.html#icmp-instruction reference>.
 icmp :: MonadIRBuilder m => IP.IntegerPredicate -> Operand -> Operand -> m Operand
@@ -258,11 +304,11 @@ br :: MonadIRBuilder m => Name -> m ()
 br val = emitTerm (Br val [])
 
 -- | See <https://llvm.org/docs/LangRef.html#phi-instruction reference>.
-phi :: MonadIRBuilder m => [(Operand, Name)] -> m Operand
+phi :: (HasCallStack, MonadIRBuilder m, MonadModuleBuilder m) => [(Operand, Name)] -> m Operand
 phi [] = emitInstr AST.void $ Phi AST.void [] []
-phi incoming@(i:_) = emitInstr ty $ Phi ty incoming []
-  where
-    ty = typeOf (fst i) -- result type
+phi incoming@(i:_) = do
+  ty <- typeOf (fst i)
+  emitInstr ty $ Phi ty incoming []
 
 -- | Emit a @ret void@ instruction.
 -- See <https://llvm.org/docs/LangRef.html#ret-instruction reference>.
@@ -270,7 +316,7 @@ retVoid :: MonadIRBuilder m => m ()
 retVoid = emitTerm (Ret Nothing [])
 
 -- | See <https://llvm.org/docs/LangRef.html#call-instruction reference>.
-call :: (MonadIRBuilder m, HasCallStack) => Operand -> [(Operand, [ParameterAttribute])] -> m Operand
+call :: (HasCallStack, MonadIRBuilder m, MonadModuleBuilder m) => Operand -> [(Operand, [ParameterAttribute])] -> m Operand
 call fun args = do
   let instr = Call {
     AST.tailCallKind = Nothing
@@ -281,7 +327,8 @@ call fun args = do
   , AST.functionAttributes = []
   , AST.metadata = []
   }
-  case typeOf fun of
+  tf <- typeOf fun
+  case tf of
       FunctionType r _ _ -> case r of
         VoidType -> emitInstrVoid instr >> (pure (ConstantOperand (C.Undef void)))
         _        -> emitInstr r instr
@@ -299,8 +346,10 @@ switch :: MonadIRBuilder m => Operand -> Name -> [(C.Constant, Name)] -> m ()
 switch val def dests = emitTerm $ Switch val def dests []
 
 -- | See <https://llvm.org/docs/LangRef.html#select-instruction reference>.
-select :: MonadIRBuilder m => Operand -> Operand -> Operand -> m Operand
-select cond t f = emitInstr (typeOf t) $ Select cond t f []
+select :: (HasCallStack, MonadIRBuilder m, MonadModuleBuilder m) => Operand -> Operand -> Operand -> m Operand
+select cond t f = do
+  tt <- typeOf t
+  emitInstr tt $ Select cond t f []
 
 -- | Conditional branch (see 'br' for unconditional instructions).
 -- See <https://llvm.org/docs/LangRef.html#br-instruction reference>.
@@ -314,7 +363,7 @@ unreachable = emitTerm $ Unreachable []
 -- | Creates a series of instructions to generate a pointer to a string
 -- constant. Useful for making format strings to pass to @printf@, for example
 globalStringPtr
-  :: (MonadModuleBuilder m)
+  :: (HasCallStack, MonadIRBuilder m, MonadModuleBuilder m)
   => String       -- ^ The string to generate
   -> Name         -- ^ Variable name of the pointer
   -> m C.Constant
@@ -323,7 +372,7 @@ globalStringPtr str nm = do
       llvmVals  = map (C.Int 8) (asciiVals ++ [0]) -- append null terminator
       char      = IntegerType 8
       charArray = C.Array char llvmVals
-      ty        = LLVM.AST.Typed.typeOf charArray
+  ty <- LLVM.AST.Typed.typeOf charArray
   emitDefn $ GlobalDefinition globalVariableDefaults
     { name                  = nm
     , LLVM.AST.Global.type' = ty
@@ -336,7 +385,7 @@ globalStringPtr str nm = do
                            (C.GlobalReference (ptr ty) nm)
                            [(C.Int 32 0), (C.Int 32 0)]
 
-sizeof :: (MonadModuleBuilder m, MonadIRBuilder m) => Word32 -> Type -> m Operand
+sizeof :: (HasCallStack, MonadIRBuilder m, MonadModuleBuilder m) => Word32 -> Type -> m Operand
 sizeof szBits ty = do
   tyNullPtr <- inttoptr (ConstantOperand $ C.Int szBits 0) (ptr ty)
   tySzPtr <- gep tyNullPtr [ConstantOperand $ C.Int szBits 1]

--- a/llvm-hs-pure/test/LLVM/Test/IRBuilder.hs
+++ b/llvm-hs-pure/test/LLVM/Test/IRBuilder.hs
@@ -10,7 +10,8 @@ import           Test.Tasty.HUnit
 import           LLVM.AST hiding (function)
 import qualified LLVM.AST.Constant as C
 import qualified LLVM.AST.Float as F
-import           LLVM.AST.Global (basicBlocks, name, parameters, returnType)
+import qualified LLVM.AST.Global
+import           LLVM.AST.Linkage (Linkage(..))
 import qualified LLVM.AST.Type as AST
 import qualified LLVM.AST.CallingConvention as CC
 import qualified LLVM.AST.Instruction as I (function)
@@ -26,15 +27,15 @@ tests =
           moduleName = "exampleModule",
           moduleDefinitions =
             [ GlobalDefinition functionDefaults {
-                name = "add",
-                parameters =
+                LLVM.AST.Global.name = "add",
+                LLVM.AST.Global.parameters =
                   ( [ Parameter AST.i32 "a_0" []
                     , Parameter AST.i32 "b_0" []
                     ]
                   , False
                   ),
-                returnType = AST.i32,
-                basicBlocks =
+                LLVM.AST.Global.returnType = AST.i32,
+                LLVM.AST.Global.basicBlocks =
                   [ BasicBlock
                       "entry_0"
                       [ UnName 0 := Add {
@@ -53,6 +54,7 @@ tests =
       , testCase "calls constant globals" callWorksWithConstantGlobals
       , testCase "supports recursive function calls" recursiveFunctionCalls
       , testCase "resolves typedefs" resolvesTypeDefs
+      , testCase "resolves constant typedefs" resolvesConstantTypeDefs
       , testCase "builds the example" $ do
         let f10 = ConstantOperand (C.Float (F.Double 10))
             fadd a b = FAdd { operand0 = a, operand1 = b, fastMathFlags = noFastMathFlags, metadata = [] }
@@ -62,9 +64,9 @@ tests =
             moduleName = "exampleModule",
             moduleDefinitions =
               [ GlobalDefinition functionDefaults {
-                  name = "foo",
-                  returnType = AST.double,
-                  basicBlocks =
+                  LLVM.AST.Global.name = "foo",
+                  LLVM.AST.Global.returnType = AST.double,
+                  LLVM.AST.Global.basicBlocks =
                     [ BasicBlock (UnName 0) [ "xxx_0" := fadd f10 f10]
                         (Do (Ret Nothing []))
                     , BasicBlock
@@ -97,9 +99,9 @@ tests =
                     ]
                 }
               , GlobalDefinition functionDefaults {
-                  name = "bar",
-                  returnType = AST.double,
-                  basicBlocks =
+                  LLVM.AST.Global.name = "bar",
+                  LLVM.AST.Global.returnType = AST.double,
+                  LLVM.AST.Global.basicBlocks =
                     [ BasicBlock
                        (UnName 0)
                        [ UnName 1 := fadd f10 f10
@@ -109,15 +111,15 @@ tests =
                     ]
                 }
               , GlobalDefinition functionDefaults {
-                  name = "baz",
-                  parameters =
+                  LLVM.AST.Global.name = "baz",
+                  LLVM.AST.Global.parameters =
                     ( [ Parameter AST.i32 (UnName 0) []
                       , Parameter AST.double "arg_0" []
                       , Parameter AST.i32 (UnName 1) []
                       , Parameter AST.double "arg_1" []]
                     , False),
-                  returnType = AST.double,
-                  basicBlocks =
+                  LLVM.AST.Global.returnType = AST.double,
+                  LLVM.AST.Global.basicBlocks =
                     [ BasicBlock
                         (UnName 2)
                         []
@@ -175,10 +177,10 @@ recursiveFunctionCalls = do
     { moduleName = "exampleModule"
     , moduleDefinitions =
       [ GlobalDefinition functionDefaults
-          { returnType = AST.i32
-          , name = Name "f"
-          , parameters = ([Parameter AST.i32 "a_0" []], False)
-          , basicBlocks =
+          { LLVM.AST.Global.returnType = AST.i32
+          , LLVM.AST.Global.name = Name "f"
+          , LLVM.AST.Global.parameters = ([Parameter AST.i32 "a_0" []], False)
+          , LLVM.AST.Global.basicBlocks =
               [ BasicBlock (Name "entry_0")
                  [ UnName 0 := Call
                     { tailCallKind = Nothing
@@ -210,16 +212,16 @@ callWorksWithConstantGlobals = do
     { moduleName = "exampleModule"
     , moduleDefinitions =
       [ GlobalDefinition functionDefaults {
-          returnType = AST.ptr AST.i8,
-          name = Name "malloc",
-          parameters = ([Parameter (IntegerType {typeBits = 64}) (Name "") []],False),
-          basicBlocks = []
+          LLVM.AST.Global.returnType = AST.ptr AST.i8,
+          LLVM.AST.Global.name = Name "malloc",
+          LLVM.AST.Global.parameters = ([Parameter (IntegerType {typeBits = 64}) (Name "") []],False),
+          LLVM.AST.Global.basicBlocks = []
         }
       , GlobalDefinition functionDefaults {
-          returnType = VoidType,
-          name = Name "omg",
-          parameters = ([],False),
-          basicBlocks = [
+          LLVM.AST.Global.returnType = VoidType,
+          LLVM.AST.Global.name = Name "omg",
+          LLVM.AST.Global.parameters = ([],False),
+          LLVM.AST.Global.basicBlocks = [
             BasicBlock (UnName 0) [
               UnName 1 := Call { tailCallKind = Nothing
                 , I.function = Right (
@@ -263,13 +265,13 @@ resolvesTypeDefs = do
           , moduleDefinitions =
             [ TypeDefinition "pair" (Just (StructureType False [AST.i32, AST.i32]))
             , GlobalDefinition functionDefaults
-              { name = "f"
-              , parameters = ( [ Parameter (AST.ptr (NamedTypeReference "pair")) "ptr_0" []
+              { LLVM.AST.Global.name = "f"
+              , LLVM.AST.Global.parameters = ( [ Parameter (AST.ptr (NamedTypeReference "pair")) "ptr_0" []
                                , Parameter AST.i32 "x_0" []
                                , Parameter AST.i32 "y_0" []]
                              , False)
-              , returnType = AST.void
-              , basicBlocks =
+              , LLVM.AST.Global.returnType = AST.void
+              , LLVM.AST.Global.basicBlocks =
                 [ BasicBlock (UnName 0)
                   [ UnName 1 := GetElementPtr
                       { inBounds = False
@@ -304,11 +306,11 @@ resolvesTypeDefs = do
                 ]
               }
             , GlobalDefinition functionDefaults
-              { name = "g"
-              , parameters = ( [Parameter (NamedTypeReference "pair") "pair_0" []]
+              { LLVM.AST.Global.name = "g"
+              , LLVM.AST.Global.parameters = ( [Parameter (NamedTypeReference "pair") "pair_0" []]
                              , False)
-              , returnType = AST.i32
-              , basicBlocks =
+              , LLVM.AST.Global.returnType = AST.i32
+              , LLVM.AST.Global.basicBlocks =
                 [ BasicBlock (UnName 0)
                   [ UnName 1 := ExtractValue
                       { aggregate = LocalReference (NamedTypeReference "pair") "pair_0"
@@ -329,6 +331,111 @@ resolvesTypeDefs = do
                       }
                   ]
                   (Do (Ret (Just (LocalReference AST.i32 (UnName 3))) []))
+                ]
+              }
+            ]}
+
+resolvesConstantTypeDefs :: Assertion
+resolvesConstantTypeDefs = do
+  buildModule "<string>" builder @?= ast
+  where builder = mdo
+          pairTy <- typedef "pair" (Just (StructureType False [AST.i32, AST.i32]))
+          globalPair <- global "gpair" pairTy (C.AggregateZero pairTy)
+          function "f" [(AST.i32, "x"), (AST.i32, "y")] AST.void $ \[x, y] -> do
+            let ptr = ConstantOperand $ C.GlobalReference (AST.ptr pairTy) "gpair"
+            xPtr <- gep ptr [ConstantOperand (C.Int 32 0), ConstantOperand (C.Int 32 0)]
+            yPtr <- gep ptr [ConstantOperand (C.Int 32 0), ConstantOperand (C.Int 32 1)]
+            store xPtr 0 x
+            store yPtr 0 y
+          function "g" [] AST.i32 $ \[] -> do
+            pair <- load (ConstantOperand $ C.GlobalReference (AST.ptr pairTy) "gpair") 0
+            x <- extractValue pair [0]
+            y <- extractValue pair [1]
+            z <- add x y
+            ret z
+          pure ()
+        ast = defaultModule
+          { moduleName = "<string>"
+          , moduleDefinitions =
+            [ TypeDefinition "pair" (Just (StructureType False [AST.i32, AST.i32]))
+            , GlobalDefinition globalVariableDefaults
+              { LLVM.AST.Global.name = "gpair"
+              , LLVM.AST.Global.type' = NamedTypeReference "pair"
+              , LLVM.AST.Global.linkage = External
+              , LLVM.AST.Global.initializer = Just (C.AggregateZero (NamedTypeReference "pair"))
+              }
+            , GlobalDefinition functionDefaults
+              { LLVM.AST.Global.name = "f"
+              , LLVM.AST.Global.parameters = ( [ Parameter AST.i32 "x_0" []
+                                               , Parameter AST.i32 "y_0" []]
+                             , False)
+              , LLVM.AST.Global.returnType = AST.void
+              , LLVM.AST.Global.basicBlocks =
+                [ BasicBlock (UnName 0)
+                  [ UnName 1 := GetElementPtr
+                      { inBounds = False
+                      , address = ConstantOperand (C.GlobalReference (AST.ptr (NamedTypeReference "pair")) "gpair")
+                      , indices = [ConstantOperand (C.Int 32 0), ConstantOperand (C.Int 32 0)]
+                      , metadata = []
+                      }
+                  , UnName 2 := GetElementPtr
+                      { inBounds = False
+                      , address = ConstantOperand (C.GlobalReference (AST.ptr (NamedTypeReference "pair")) "gpair")
+                      , indices = [ConstantOperand (C.Int 32 0), ConstantOperand (C.Int 32 1)]
+                      , metadata = []
+                      }
+                  , Do $ Store
+                      { volatile = False
+                      , address = LocalReference (AST.ptr AST.i32) (UnName 1)
+                      , value = LocalReference AST.i32 "x_0"
+                      , maybeAtomicity = Nothing
+                      , alignment = 0
+                      , metadata = []
+                      }
+                  , Do $ Store
+                      { volatile = False
+                      , address = LocalReference (AST.ptr AST.i32) (UnName 2)
+                      , value = LocalReference AST.i32 "y_0"
+                      , maybeAtomicity = Nothing
+                      , alignment = 0
+                      , metadata = []
+                      }
+                  ]
+                  (Do (Ret Nothing []))
+                ]
+              }
+            , GlobalDefinition functionDefaults
+              { LLVM.AST.Global.name = "g"
+              , LLVM.AST.Global.parameters = ([], False)
+              , LLVM.AST.Global.returnType = AST.i32
+              , LLVM.AST.Global.basicBlocks =
+                [ BasicBlock (UnName 0)
+                  [ UnName 1 := Load
+                      { volatile = False,
+                        address = ConstantOperand (C.GlobalReference (AST.ptr (NamedTypeReference "pair")) "gpair"),
+                        maybeAtomicity = Nothing,
+                        alignment = 0,
+                        metadata = []
+                      }
+                  , UnName 2 := ExtractValue
+                      { aggregate = LocalReference (NamedTypeReference "pair") (UnName 1)
+                      , indices' = [0]
+                      , metadata = []
+                      }
+                  , UnName 3 := ExtractValue
+                      { aggregate = LocalReference (NamedTypeReference "pair") (UnName 1)
+                      , indices' = [1]
+                      , metadata = []
+                      }
+                  , UnName 4 := Add
+                      { nsw = False
+                      , nuw = False
+                      , operand0 = LocalReference AST.i32 (UnName 2)
+                      , operand1 = LocalReference AST.i32 (UnName 3)
+                      , metadata = []
+                      }
+                  ]
+                  (Do (Ret (Just (LocalReference AST.i32 (UnName 4))) []))
                 ]
               }
             ]}

--- a/llvm-hs/src/LLVM/Internal/FFI/Metadata.h
+++ b/llvm-hs/src/LLVM/Internal/FFI/Metadata.h
@@ -47,27 +47,29 @@ enum LLVM_Hs_DwOp {
 };
 
 #define LLVM_HS_FOR_EACH_DW_OP(macro) \
-    macro(LLVM_fragment)              \
-    macro(stack_value)                \
-    macro(swap)                       \
+    macro(and)                        \
+    macro(bregx)                      \
     macro(constu)                     \
-    macro(lit0)                       \
-    macro(plus_uconst)                \
-    macro(plus)                       \
-    macro(minus)                      \
-    macro(mul)                        \
+    macro(deref)                      \
     macro(div)                        \
+    macro(dup)                        \
+    macro(lit0)                       \
+    macro(LLVM_fragment)              \
+    macro(minus)                      \
     macro(mod)                        \
+    macro(mul)                        \
     macro(not)                        \
     macro(or)                         \
-    macro(xor)                        \
-    macro(and)                        \
+    macro(plus)                       \
+    macro(plus_uconst)                \
+    macro(push_object_address)        \
+    macro(shl)                        \
     macro(shr)                        \
     macro(shra)                       \
-    macro(shl)                        \
-    macro(dup)                        \
-    macro(deref)                      \
-    macro(xderef)
+    macro(stack_value)                \
+    macro(swap)                       \
+    macro(xderef)                     \
+    macro(xor)
 
 enum LLVM_Hs_DwAtE {
 #define HANDLE_DW_ATE(ID, NAME, VERSION, VENDOR) LLVM_Hs_DwAtE_##NAME = ID,

--- a/llvm-hs/src/LLVM/Internal/Operand.hs
+++ b/llvm-hs/src/LLVM/Internal/Operand.hs
@@ -194,6 +194,18 @@ instance DecodeM DecodeAST A.DINode (Ptr FFI.DINode) where
       [mdSubclassIdP|DITemplateTypeParameter|]  -> A.DITemplateParameter <$> decodeM (castPtr diN :: Ptr FFI.DITemplateParameter)
       [mdSubclassIdP|DITemplateValueParameter|] -> A.DITemplateParameter <$> decodeM (castPtr diN :: Ptr FFI.DITemplateParameter)
 
+      [mdSubclassIdP|MDString|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (MDString)"))
+      [mdSubclassIdP|ConstantAsMetadata|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (ConstantAsMetadata)"))
+      [mdSubclassIdP|LocalAsMetadata|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (LocalAsMetadata)"))
+      [mdSubclassIdP|DistinctMDOperandPlaceholder|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DistinctMDOperandPlaceholder)"))
+      [mdSubclassIdP|MDTuple|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (MDTuple)"))
+      [mdSubclassIdP|DILocation|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DILocation)"))
+      [mdSubclassIdP|DIExpression|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DIExpression)"))
+      [mdSubclassIdP|DIGlobalVariableExpression|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DIGlobalVariableExpression)"))
+      [mdSubclassIdP|GenericDINode|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (GenericDINode)"))
+      [mdSubclassIdP|DIMacro|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DIMacro)"))
+      [mdSubclassIdP|DIMacroFile|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DIMacroFile)"))
+
       _ -> throwM (DecodeException ("Unknown subclass id for DINode: " <> show sId))
 
 instance EncodeM EncodeAST A.DICount (Ptr FFI.Metadata) where

--- a/llvm-hs/src/LLVM/Internal/Operand.hs
+++ b/llvm-hs/src/LLVM/Internal/Operand.hs
@@ -167,44 +167,44 @@ instance DecodeM DecodeAST A.Metadata (Ptr FFI.Metadata) where
               else do
                 throwM (DecodeException "Metadata was not one of [MDString, MDValue, MDNode]")
 
-instance DecodeM DecodeAST A.DINode (Ptr FFI.DINode) where
+instance DecodeM DecodeAST (Either String A.DINode) (Ptr FFI.DINode) where
   decodeM diN = do
     sId <- liftIO $ FFI.getMetadataClassId (FFI.upCast diN)
     case sId of
       [mdSubclassIdP|DIEnumerator|] ->
-        A.DIEnumerator <$> decodeM (castPtr diN :: Ptr FFI.DIEnumerator)
-      [mdSubclassIdP|DIBasicType|]        -> A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
-      [mdSubclassIdP|DICompileUnit|]      -> A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
-      [mdSubclassIdP|DICompositeType|]    -> A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
-      [mdSubclassIdP|DIDerivedType|]      -> A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
-      [mdSubclassIdP|DIFile|]             -> A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
-      [mdSubclassIdP|DIImportedEntity|] -> A.DIImportedEntity <$> decodeM (castPtr diN :: Ptr FFI.DIImportedEntity)
-      [mdSubclassIdP|DILexicalBlock|]     -> A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
-      [mdSubclassIdP|DILexicalBlockFile|] -> A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
-      [mdSubclassIdP|DIModule|]           -> A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
-      [mdSubclassIdP|DINamespace|]        -> A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
-      [mdSubclassIdP|DIObjCProperty|]   -> A.DIObjCProperty <$> decodeM (castPtr diN :: Ptr FFI.DIObjCProperty)
-      [mdSubclassIdP|DISubprogram|]       -> A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
-      [mdSubclassIdP|DISubrange|]       -> A.DISubrange <$> decodeM (castPtr diN :: Ptr FFI.DISubrange)
-      [mdSubclassIdP|DISubroutineType|]   -> A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
+        liftM Right $ A.DIEnumerator <$> decodeM (castPtr diN :: Ptr FFI.DIEnumerator)
+      [mdSubclassIdP|DIImportedEntity|]   -> liftM Right $ A.DIImportedEntity <$> decodeM (castPtr diN :: Ptr FFI.DIImportedEntity)
+      [mdSubclassIdP|DIObjCProperty|]     -> liftM Right $ A.DIObjCProperty <$> decodeM (castPtr diN :: Ptr FFI.DIObjCProperty)
+      [mdSubclassIdP|DISubrange|]         -> liftM Right $ A.DISubrange <$> decodeM (castPtr diN :: Ptr FFI.DISubrange)
+      [mdSubclassIdP|DIBasicType|]        -> liftM Right $ A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
+      [mdSubclassIdP|DICompositeType|]    -> liftM Right $ A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
+      [mdSubclassIdP|DIDerivedType|]      -> liftM Right $ A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
+      [mdSubclassIdP|DISubroutineType|]   -> liftM Right $ A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
+      [mdSubclassIdP|DILexicalBlock|]     -> liftM Right $ A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
+      [mdSubclassIdP|DILexicalBlockFile|] -> liftM Right $ A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
+      [mdSubclassIdP|DIFile|]             -> liftM Right $ A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
+      [mdSubclassIdP|DINamespace|]        -> liftM Right $ A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
+      [mdSubclassIdP|DISubprogram|]       -> liftM Right $ A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
+      [mdSubclassIdP|DICompileUnit|]      -> liftM Right $ A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
+      [mdSubclassIdP|DIModule|]           -> liftM Right $ A.DIScope <$> decodeM (castPtr diN :: Ptr FFI.DIScope)
 
-      [mdSubclassIdP|DIGlobalVariable|] -> A.DIVariable <$> decodeM (castPtr diN :: Ptr FFI.DIVariable)
-      [mdSubclassIdP|DILocalVariable|]  -> A.DIVariable <$> decodeM (castPtr diN :: Ptr FFI.DIVariable)
+      [mdSubclassIdP|DIGlobalVariable|]   -> liftM Right $ A.DIVariable <$> decodeM (castPtr diN :: Ptr FFI.DIVariable)
+      [mdSubclassIdP|DILocalVariable|]    -> liftM Right $ A.DIVariable <$> decodeM (castPtr diN :: Ptr FFI.DIVariable)
 
-      [mdSubclassIdP|DITemplateTypeParameter|]  -> A.DITemplateParameter <$> decodeM (castPtr diN :: Ptr FFI.DITemplateParameter)
-      [mdSubclassIdP|DITemplateValueParameter|] -> A.DITemplateParameter <$> decodeM (castPtr diN :: Ptr FFI.DITemplateParameter)
+      [mdSubclassIdP|DITemplateTypeParameter|]  -> liftM Right $ A.DITemplateParameter <$> decodeM (castPtr diN :: Ptr FFI.DITemplateParameter)
+      [mdSubclassIdP|DITemplateValueParameter|] -> liftM Right $ A.DITemplateParameter <$> decodeM (castPtr diN :: Ptr FFI.DITemplateParameter)
 
-      [mdSubclassIdP|MDString|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (MDString)"))
-      [mdSubclassIdP|ConstantAsMetadata|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (ConstantAsMetadata)"))
-      [mdSubclassIdP|LocalAsMetadata|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (LocalAsMetadata)"))
-      [mdSubclassIdP|DistinctMDOperandPlaceholder|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DistinctMDOperandPlaceholder)"))
-      [mdSubclassIdP|MDTuple|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (MDTuple)"))
-      [mdSubclassIdP|DILocation|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DILocation)"))
-      [mdSubclassIdP|DIExpression|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DIExpression)"))
-      [mdSubclassIdP|DIGlobalVariableExpression|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DIGlobalVariableExpression)"))
-      [mdSubclassIdP|GenericDINode|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (GenericDINode)"))
-      [mdSubclassIdP|DIMacro|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DIMacro)"))
-      [mdSubclassIdP|DIMacroFile|] -> throwM (DecodeException ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DIMacroFile)"))
+      [mdSubclassIdP|MDString|] -> liftM Left $ pure ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (MDString)")
+      [mdSubclassIdP|ConstantAsMetadata|] -> liftM Left $ pure ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (ConstantAsMetadata)")
+      [mdSubclassIdP|LocalAsMetadata|] -> liftM Left $ pure ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (LocalAsMetadata)")
+      [mdSubclassIdP|DistinctMDOperandPlaceholder|] -> liftM Left $ pure ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DistinctMDOperandPlaceholder)")
+      [mdSubclassIdP|MDTuple|] -> liftM Left $ pure ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (MDTuple)")
+      [mdSubclassIdP|DILocation|] -> liftM Left $ pure ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DILocation)")
+      [mdSubclassIdP|DIExpression|] -> liftM Left $ pure ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DIExpression)")
+      [mdSubclassIdP|DIGlobalVariableExpression|] -> liftM Left $ pure ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DIGlobalVariableExpression)")
+      [mdSubclassIdP|GenericDINode|] -> liftM Left $ pure ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (GenericDINode)")
+      [mdSubclassIdP|DIMacro|] -> liftM Left $ pure ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DIMacro)")
+      [mdSubclassIdP|DIMacroFile|] -> liftM Left $ pure ("Lifting to Haskell not implemented for toplevel DINode kind: " <> show sId <> " (DIMacroFile)")
 
       _ -> throwM (DecodeException ("Unknown subclass id for DINode: " <> show sId))
 
@@ -1100,19 +1100,23 @@ instance DecodeM DecodeAST A.Metadata (Ptr FFI.MetadataAsVal) where
 
 genCodingInstance [t|A.DIMacroInfo|] ''FFI.Macinfo [ (FFI.DW_Macinfo_Define, A.Define), (FFI.DW_Macinfo_Undef, A.Undef) ]
 
-decodeMDNode :: Ptr FFI.MDNode -> DecodeAST A.MDNode
+decodeMDNode :: Ptr FFI.MDNode -> DecodeAST (Either String A.MDNode)
 decodeMDNode p = scopeAnyCont $ do
   sId <- liftIO $ FFI.getMetadataClassId p
   case sId of
-      [mdSubclassIdP|MDTuple|] -> A.MDTuple <$> decodeM p
+      [mdSubclassIdP|MDTuple|] -> liftM Right $ A.MDTuple <$> decodeM p
       [mdSubclassIdP|DIExpression|] ->
-        A.DIExpression <$> decodeM (castPtr p :: Ptr FFI.DIExpression)
+        liftM Right $ A.DIExpression <$> decodeM (castPtr p :: Ptr FFI.DIExpression)
       [mdSubclassIdP|DIGlobalVariableExpression|] ->
-        A.DIGlobalVariableExpression <$> decodeM (castPtr p :: Ptr FFI.DIGlobalVariableExpression)
-      [mdSubclassIdP|DILocation|] -> A.DILocation <$> decodeM (castPtr p :: Ptr FFI.DILocation)
-      [mdSubclassIdP|DIMacro|] -> A.DIMacroNode <$> decodeM (castPtr p :: Ptr FFI.DIMacroNode)
-      [mdSubclassIdP|DIMacroFile|] -> A.DIMacroNode <$> decodeM (castPtr p :: Ptr FFI.DIMacroNode)
-      _ -> A.DINode <$> decodeM (castPtr p :: Ptr FFI.DINode)
+        liftM Right $ A.DIGlobalVariableExpression <$> decodeM (castPtr p :: Ptr FFI.DIGlobalVariableExpression)
+      [mdSubclassIdP|DILocation|] -> liftM Right $ A.DILocation <$> decodeM (castPtr p :: Ptr FFI.DILocation)
+      [mdSubclassIdP|DIMacro|] -> liftM Right $ A.DIMacroNode <$> decodeM (castPtr p :: Ptr FFI.DIMacroNode)
+      [mdSubclassIdP|DIMacroFile|] -> liftM Right $ A.DIMacroNode <$> decodeM (castPtr p :: Ptr FFI.DIMacroNode)
+      _ -> do
+        decoded <- decodeM (castPtr p :: Ptr FFI.DINode)
+        case decoded of
+          (Right din) -> liftM Right $ pure $ A.DINode din
+          (Left err) -> pure $ Left err
 
 instance DecodeM DecodeAST A.DIMacroNode (Ptr FFI.DIMacroNode) where
   decodeM p = do
@@ -1232,11 +1236,13 @@ instance DecodeM DecodeAST A.DIImportedEntity (Ptr FFI.DIImportedEntity) where
   decodeM e = do
     tag <- decodeM =<< liftIO (FFI.getTag (FFI.upCast e))
     scope <- decodeM =<< liftIO (FFI.getDIImportedEntityScope e)
-    entity <- decodeM =<< liftIO (FFI.getDIImportedEntityEntity e)
+    entity :: Either String A.DINode <- decodeM =<< liftIO (FFI.getDIImportedEntityEntity e)
     file <- decodeM =<< liftIO (FFI.getDIImportedEntityFile e)
     name <- decodeM =<< liftIO (FFI.getDIImportedEntityName e)
     line <- liftIO (FFI.getDIImportedEntityLine e)
-    pure (A.ImportedEntity tag name scope entity file line)
+    case entity of
+      (Right din) -> pure (A.ImportedEntity tag name scope (Just $ A.MDInline din) file line)
+      (Left _) -> pure (A.ImportedEntity tag name scope Nothing file line)
 
 instance EncodeM EncodeAST A.DIObjCProperty (Ptr FFI.DIObjCProperty) where
   encodeM A.ObjCProperty {..} = do
@@ -1279,7 +1285,11 @@ getMetadataDefinitions = fix $ \continue -> do
   mdntd <- takeMetadataNodeToDefine
   case mdntd of
     Nothing -> pure []
-    Just (mid, p) ->
-      (:)
-        <$> (A.MetadataNodeDefinition mid <$> decodeMDNode p)
-        <*> continue
+    Just (mid, p) -> do
+      decoded <- decodeMDNode p
+      case decoded of
+        (Right mdn) ->
+          (:)
+            <$> (pure $ A.MetadataNodeDefinition mid mdn)
+            <*> continue
+        (Left _) -> continue

--- a/llvm-hs/src/LLVM/Internal/Operand.hs
+++ b/llvm-hs/src/LLVM/Internal/Operand.hs
@@ -1053,27 +1053,29 @@ instance (MonadIO m, MonadAnyCont IO m, DecodeM m a (Ptr a')) => DecodeM m [a] (
 encodeDWOp :: A.DWOp -> [Word64]
 encodeDWOp op =
   case op of
-    A.DwOpFragment (A.DW_OP_LLVM_Fragment offset size) -> [FFI.DwOp_LLVM_fragment, offset, size]
-    A.DW_OP_StackValue -> [FFI.DwOp_stack_value]
-    A.DW_OP_Swap -> [FFI.DwOp_swap]
+    A.DW_OP_And -> [FFI.DwOp_and]
+    A.DW_OP_Bregx -> [FFI.DwOp_bregx]
     A.DW_OP_ConstU arg -> [FFI.DwOp_constu, arg]
-    A.DW_OP_Lit0 -> [FFI.DwOp_lit0]
-    A.DW_OP_PlusUConst arg -> [FFI.DwOp_plus_uconst, arg]
-    A.DW_OP_Plus -> [FFI.DwOp_plus]
-    A.DW_OP_Minus -> [FFI.DwOp_minus]
-    A.DW_OP_Mul -> [FFI.DwOp_mul]
+    A.DW_OP_Deref -> [FFI.DwOp_deref]
     A.DW_OP_Div -> [FFI.DwOp_div]
+    A.DW_OP_Dup -> [FFI.DwOp_dup]
+    A.DwOpFragment (A.DW_OP_LLVM_Fragment offset size) -> [FFI.DwOp_LLVM_fragment, offset, size]
+    A.DW_OP_Lit0 -> [FFI.DwOp_lit0]
+    A.DW_OP_Minus -> [FFI.DwOp_minus]
     A.DW_OP_Mod -> [FFI.DwOp_mod]
+    A.DW_OP_Mul -> [FFI.DwOp_mul]
     A.DW_OP_Not -> [FFI.DwOp_not]
     A.DW_OP_Or -> [FFI.DwOp_or]
-    A.DW_OP_Xor -> [FFI.DwOp_xor]
-    A.DW_OP_And -> [FFI.DwOp_and]
-    A.DW_OP_Shr -> [FFI.DwOp_shr]
-    A.DW_OP_Shra -> [FFI.DwOp_shra]
+    A.DW_OP_Plus -> [FFI.DwOp_plus]
+    A.DW_OP_PlusUConst arg -> [FFI.DwOp_plus_uconst, arg]
+    A.DW_OP_PushObjectAddress -> [FFI.DwOp_push_object_address]
     A.DW_OP_Shl -> [FFI.DwOp_shl]
-    A.DW_OP_Dup -> [FFI.DwOp_dup]
-    A.DW_OP_Deref -> [FFI.DwOp_deref]
+    A.DW_OP_Shra -> [FFI.DwOp_shra]
+    A.DW_OP_Shr -> [FFI.DwOp_shr]
+    A.DW_OP_StackValue -> [FFI.DwOp_stack_value]
+    A.DW_OP_Swap -> [FFI.DwOp_swap]
     A.DW_OP_XDeref -> [FFI.DwOp_xderef]
+    A.DW_OP_Xor -> [FFI.DwOp_xor]
 
 instance DecodeM DecodeAST [Maybe A.Metadata] (Ptr FFI.MDNode) where
   decodeM p = decodeArray FFI.getMDNodeNumOperands FFI.getMDNodeOperand p
@@ -1177,6 +1179,8 @@ instance DecodeM DecodeAST A.DIExpression (Ptr FFI.DIExpression) where
                 FFI.DwOp_dup -> (A.DW_OP_Dup :) <$> go (i + 1)
                 FFI.DwOp_deref -> (A.DW_OP_Deref :) <$> go (i + 1)
                 FFI.DwOp_xderef -> (A.DW_OP_XDeref :) <$> go (i + 1)
+                FFI.DwOp_bregx -> (A.DW_OP_Bregx :) <$> go (i + 1)
+                FFI.DwOp_push_object_address -> (A.DW_OP_PushObjectAddress :) <$> go (i + 1)
                 _ -> throwM (DecodeException ("Unknown DW_OP " <> show op))
         expectElems name i n =
           when (i + n >= numElems)

--- a/llvm-hs/test/LLVM/Test/Metadata.hs
+++ b/llvm-hs/test/LLVM/Test/Metadata.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module LLVM.Test.Metadata where
 
 import LLVM.Prelude
@@ -350,8 +351,8 @@ roundtripDINode :: TestTree
 roundtripDINode = testProperty "roundtrip DINode" $ \diNode -> ioProperty $
   withContext $ \context -> runEncodeAST context $ do
     encodedDINode <- encodeM (diNode :: DINode)
-    decodedDINode <- liftIO (runDecodeAST (decodeM (encodedDINode :: Ptr FFI.DINode)))
-    pure (decodedDINode === diNode)
+    decodedDINode :: Either String DINode <- liftIO (runDecodeAST (decodeM (encodedDINode :: Ptr FFI.DINode)))
+    pure (decodedDINode === (Right diNode))
 
 roundtripDICompileUnit :: TestTree
 roundtripDICompileUnit = testProperty "roundtrip DICompileUnit" $ \diFile retainedType ->


### PR DESCRIPTION
There were a selection of fixes and improvements on the llvm-9 branch which should be merged onto the llvm-12 branch. The reason I cherry-picked these instead of doing a rebase is that there are some fixes which apply to the old OrcJIT interface; these would be defunct since that interface is gone on the llvm-12 branch.

The largest difference introduced by this changeset is that the typeclass `Typed` now actually deals with named type references properly. Previously, if you did `typedef foo <some struct type>`, `typeOf` would choke when computing the type of a field of `foo`. Now it works properly, but it carries an additional `MonadModuleBuilder` constraint to provide access to the context holding those type definitions, which is the module builder state.