### PR TITLE
Add int16 helper function

### DIFF
--- a/llvm-hs-pure/src/LLVM/IRBuilder/Constant.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Constant.hs
@@ -14,6 +14,8 @@ int64 :: Integer -> Operand
 int64 = ConstantOperand . Int 64
 int32 :: Integer -> Operand
 int32 = ConstantOperand . Int 32
+int16 :: Integer -> Operand
+int16 = ConstantOperand . Int 16
 int8 :: Integer -> Operand
 int8  = ConstantOperand . Int 8
 bit :: Integer -> Operand


### PR DESCRIPTION
This adds support for 16-bit integers (`short` in C and C++). 
Do tests need to be added for something as simple as this?