### PR TITLE
IR-builder: Use only first terminator when generating LLVM IR

### DIFF
--- a/llvm-hs-pure/CHANGELOG.md
+++ b/llvm-hs-pure/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.1.0 (UNRELEASED)
+
+* IRBuilder: first emitted terminator (`br`, `condBr`, `ret`, ...) is only
+  generated in final IR. This allows for greater composition of IR (and matches
+  with LLVM semantics, since later instructions are unreachable).
+
 ## 9.0.0 (2019-09-06)
 
 * The functions in `LLVM.IRBuilder.Constant` no longer return a

--- a/llvm-hs-pure/CHANGELOG.md
+++ b/llvm-hs-pure/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 9.1.0 (2021-09-XX)
+## 9.1.0 (2021-10-XX)
 
 * Eliminate hard-coded assumption of 32-bit `size_t`
 * Add a runtime variant of the `LLVM.AST.Constant.sizeof` utility in `LLVM.IRBuilder.Instruction.sizeof`. The size of opaque structure types is unknown until link-time and therefore cannot be computed as a constant.

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
@@ -31,6 +31,7 @@ import Control.Monad.Trans.Identity
 #endif
 
 import Data.Bifunctor
+import Data.Monoid (First(..))
 import Data.String
 import Data.Map.Strict(Map)
 import qualified Data.Map.Strict as M
@@ -69,11 +70,11 @@ instance Monad m => MonadIRBuilder (IRBuilderT m) where
 data PartialBlock = PartialBlock
   { partialBlockName :: !Name
   , partialBlockInstrs :: SnocList (Named Instruction)
-  , partialBlockTerm :: Maybe (Named Terminator)
+  , partialBlockTerm :: First (Named Terminator)
   }
 
 emptyPartialBlock :: Name -> PartialBlock
-emptyPartialBlock nm = PartialBlock nm mempty Nothing
+emptyPartialBlock nm = PartialBlock nm mempty (First Nothing)
 
 -- | Builder monad state
 data IRBuilderState = IRBuilderState
@@ -199,7 +200,7 @@ emitTerm
   => Terminator
   -> m ()
 emitTerm term = modifyBlock $ \bb -> bb
-  { partialBlockTerm = Just (Do term)
+  { partialBlockTerm = partialBlockTerm bb <> First (Just (Do term))
   }
 
 -- | Starts a new block labelled using the given name and ends the previous
@@ -215,7 +216,7 @@ emitBlockStart nm = do
     Just bb -> do
       let
         instrs = getSnocList $ partialBlockInstrs bb
-        newBb = case partialBlockTerm bb of
+        newBb = case getFirst (partialBlockTerm bb) of
           Nothing   -> BasicBlock (partialBlockName bb) instrs (Do (Ret Nothing []))
           Just term -> BasicBlock (partialBlockName bb) instrs term
       liftIRState $ modify $ \s -> s
@@ -271,7 +272,7 @@ hasTerminator = do
   current <- liftIRState $ gets builderBlock
   case current of
     Nothing    -> error "Called hasTerminator when no block was active"
-    Just blk -> case partialBlockTerm blk of
+    Just blk -> case getFirst (partialBlockTerm blk) of
       Nothing  -> return False
       Just _   -> return True
 

--- a/llvm-hs-pure/test/LLVM/Test/IRBuilder.hs
+++ b/llvm-hs-pure/test/LLVM/Test/IRBuilder.hs
@@ -52,7 +52,8 @@ tests =
         }
       , testCase "calls constant globals" callWorksWithConstantGlobals
       , testCase "supports recursive function calls" recursiveFunctionCalls
-      , testCase "resolves typefes" resolvesTypeDefs
+      , testCase "resolves typedefs" resolvesTypeDefs
+      , testCase "handling of terminator" terminatorHandling
       , testCase "builds the example" $ do
         let f10 = ConstantOperand (C.Float (F.Double 10))
             fadd a b = FAdd { operand0 = a, operand1 = b, fastMathFlags = noFastMathFlags, metadata = [] }
@@ -299,6 +300,78 @@ resolvesTypeDefs = do
                 ]
               }
             ]}
+
+terminatorHandling :: Assertion
+terminatorHandling = do
+  firstTerminatorWins @?= firstWinsAst
+  terminatorsCompose @?= terminatorsComposeAst
+  where
+    firstTerminatorWins = buildModule "firstTerminatorWinsModule" $ mdo
+      function "f" [(AST.i32, "a"), (AST.i32, "b")] AST.i32 $ \[a, b] -> mdo
+
+        entry <- block `named` "entry"; do
+          c <- add a b
+          d <- add a c
+          ret c
+          ret d
+    terminatorsCompose = buildModule "terminatorsComposeModule" $ mdo
+      function "f" [(AST.i1, "a")] AST.i1 $ \[a] -> mdo
+
+        entry <- block `named` "entry"; do
+          if' a $ do
+            ret (bit 0)
+
+          ret (bit 1)
+    if' cond asm = mdo
+      condBr cond ifBlock end
+      ifBlock <- block `named` "if.begin"
+      asm
+      end <- block `named` "if.end"
+      return ()
+
+    firstWinsAst = defaultModule
+      { moduleName = "firstTerminatorWinsModule"
+      , moduleDefinitions =
+        [ GlobalDefinition functionDefaults
+          { name = "f"
+          , parameters = ([ Parameter AST.i32 "a_0" [], Parameter AST.i32 "b_0" []], False)
+          , returnType = AST.i32
+          , basicBlocks =
+            [ BasicBlock (Name "entry_0")
+              [ UnName 0 := Add { nsw = False, nuw = False, metadata = []
+                                , operand0 = LocalReference (IntegerType {typeBits = 32}) (Name "a_0")
+                                , operand1 = LocalReference (IntegerType {typeBits = 32}) (Name "b_0")
+                                }
+              , UnName 1 := Add { nsw = False, nuw = False, metadata = []
+                                , operand0 = LocalReference (IntegerType {typeBits = 32}) (Name "a_0")
+                                , operand1 = LocalReference (IntegerType {typeBits = 32}) (UnName 0)
+                                }
+              ]
+              (Do (Ret {returnOperand = Just (LocalReference (IntegerType {typeBits = 32}) (UnName 0)), metadata' = []}))]
+          }
+        ]}
+    terminatorsComposeAst = defaultModule
+      { moduleName = "terminatorsComposeModule"
+      , moduleDefinitions =
+        [ GlobalDefinition functionDefaults
+          { name = "f"
+          , parameters = ([ Parameter AST.i1 "a_0" []], False)
+          , returnType = AST.i1
+          , basicBlocks =
+            [ BasicBlock (Name "entry_0")
+              []
+              (Do (CondBr {condition = LocalReference (IntegerType {typeBits = 1}) (Name "a_0")
+                          , trueDest = Name "if.begin_0"
+                          , falseDest = Name "if.end_0", metadata' = []}))
+                          , BasicBlock (Name "if.begin_0")
+                            []
+                            (Do (Ret {returnOperand = Just (ConstantOperand (C.Int {C.integerBits = 1, C.integerValue = 0})), metadata' = []}))
+                          , BasicBlock (Name "if.end_0")
+                            []
+                            (Do (Ret {returnOperand = Just (ConstantOperand (C.Int {C.integerBits = 1, C.integerValue = 1})), metadata' = []}))]
+          }
+        ]}
+
 
 simple :: Module
 simple = buildModule "exampleModule" $ mdo


### PR DESCRIPTION
Resolves #366.

Note that this branched off from llvm-9 branch (where I need the feature), but it should also be merged into master/latest branch.