### PR TITLE
Better handling of terminators in IR builder (llvm-12)

### DIFF
--- a/llvm-hs-pure/CHANGELOG.md
+++ b/llvm-hs-pure/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 ## 12.0.0 (2021-03-19)
 
 * Update to LLVM 12.0
@@ -6,6 +7,12 @@
 * Handle type resolution through `NamedTypeReference` correctly: type resolution in LLVM depends on module state by design
 * Support the LLVM `NoFree` attribute
 * Add support for some more DWARF operators: `DW_OP_bregx` and `DW_OP_push_object_address`
+
+## 9.1.0 (UNRELEASED)
+
+* IRBuilder: first emitted terminator (`br`, `condBr`, `ret`, ...) is only
+  generated in final IR. This allows for greater composition of IR (and matches
+  with LLVM semantics, since later instructions are unreachable).
 
 ## 9.0.0 (2019-09-06)
 

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
@@ -32,6 +32,7 @@ import Control.Monad.Fail (MonadFail)
 #endif
 
 import Data.Bifunctor
+import Data.Monoid (First(..))
 import Data.String
 import Data.Map.Strict(Map)
 import qualified Data.Map.Strict as M
@@ -71,11 +72,11 @@ instance Monad m => MonadIRBuilder (IRBuilderT m) where
 data PartialBlock = PartialBlock
   { partialBlockName :: !Name
   , partialBlockInstrs :: SnocList (Named Instruction)
-  , partialBlockTerm :: Maybe (Named Terminator)
+  , partialBlockTerm :: First (Named Terminator)
   }
 
 emptyPartialBlock :: Name -> PartialBlock
-emptyPartialBlock nm = PartialBlock nm mempty Nothing
+emptyPartialBlock nm = PartialBlock nm mempty (First Nothing)
 
 -- | Builder monad state
 data IRBuilderState = IRBuilderState
@@ -201,7 +202,7 @@ emitTerm
   => Terminator
   -> m ()
 emitTerm term = modifyBlock $ \bb -> bb
-  { partialBlockTerm = Just (Do term)
+  { partialBlockTerm = partialBlockTerm bb <> First (Just (Do term))
   }
 
 -- | Starts a new block labelled using the given name and ends the previous
@@ -217,7 +218,7 @@ emitBlockStart nm = do
     Just bb -> do
       let
         instrs = getSnocList $ partialBlockInstrs bb
-        newBb = case partialBlockTerm bb of
+        newBb = case getFirst (partialBlockTerm bb) of
           Nothing   -> BasicBlock (partialBlockName bb) instrs (Do (Ret Nothing []))
           Just term -> BasicBlock (partialBlockName bb) instrs term
       liftIRState $ modify $ \s -> s
@@ -273,7 +274,7 @@ hasTerminator = do
   current <- liftIRState $ gets builderBlock
   case current of
     Nothing    -> error "Called hasTerminator when no block was active"
-    Just blk -> case partialBlockTerm blk of
+    Just blk -> case getFirst (partialBlockTerm blk) of
       Nothing  -> return False
       Just _   -> return True
 


### PR DESCRIPTION
Same as #367. But for the llvm-12 branch.