### PR TITLE
Fix a bug when writing LLVM assembly to an existing file

### DIFF
--- a/llvm-hs/src/LLVM/Internal/FFI/RawOStream.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/RawOStream.hs
@@ -19,11 +19,15 @@ foreign import ccall "wrapper" wrapRawPWriteStreamCallback ::
   RawPWriteStreamCallback -> IO (FunPtr RawPWriteStreamCallback)
 
 foreign import ccall safe "LLVM_Hs_WithFileRawPWriteStream" withFileRawPWriteStream' ::
-  CString -> LLVMBool -> LLVMBool -> Ptr (OwnerTransfered CString) -> FunPtr RawPWriteStreamCallback -> IO LLVMBool
+  CString -> LLVMBool -> Ptr (OwnerTransfered CString) -> FunPtr RawPWriteStreamCallback -> IO LLVMBool
 
-withFileRawPWriteStream :: CString -> LLVMBool -> LLVMBool -> Ptr (OwnerTransfered CString) -> RawPWriteStreamCallback -> IO LLVMBool
-withFileRawPWriteStream p ex bin err c =
-  bracket (wrapRawPWriteStreamCallback c) freeHaskellFunPtr (withFileRawPWriteStream' p ex bin err)
+withFileRawPWriteStream
+  :: CString -- ^ path
+  -> LLVMBool -- ^ open in binary or text mode? ('True' = text)
+  -> Ptr (OwnerTransfered CString)
+  -> RawPWriteStreamCallback -> IO LLVMBool
+withFileRawPWriteStream p text err c =
+  bracket (wrapRawPWriteStreamCallback c) freeHaskellFunPtr (withFileRawPWriteStream' p text err)
 
 foreign import ccall safe "LLVM_Hs_WithBufferRawPWriteStream" withBufferRawPWriteStream' ::
   FunPtr ByteRangeCallback -> FunPtr RawPWriteStreamCallback -> IO ()

--- a/llvm-hs/src/LLVM/Internal/FFI/RawOStreamC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/RawOStreamC.cpp
@@ -8,12 +8,12 @@ using namespace llvm;
 extern "C" {
 
 LLVMBool
-LLVM_Hs_WithFileRawPWriteStream(const char *filename, LLVMBool excl,
+LLVM_Hs_WithFileRawPWriteStream(const char *filename,
                                 LLVMBool text, char **error,
                                 void (&callback)(raw_pwrite_stream &ostream)) {
     std::error_code e;
     raw_fd_ostream os(filename, e,
-                      excl ? sys::fs::CD_CreateNew : sys::fs::CD_OpenAlways,
+                      sys::fs::CD_CreateAlways,
                       sys::fs::FA_Write,
                       text ? sys::fs::OF_Text : sys::fs::OF_None);
     if (e) {

--- a/llvm-hs/src/LLVM/Internal/Module.hs
+++ b/llvm-hs/src/LLVM/Internal/Module.hs
@@ -155,7 +155,7 @@ moduleLLVMAssembly m = do
 writeLLVMAssemblyToFile :: File -> Module -> IO ()
 writeLLVMAssemblyToFile (File path) m = flip runAnyContT return $ do
   m' <- readModule m
-  withFileRawOStream path False True $ FFI.writeLLVMAssembly m'
+  withFileRawOStream path True $ FFI.writeLLVMAssembly m'
 
 class BitcodeInput b where
   bitcodeMemoryBuffer :: (MonadThrow m, MonadIO m, MonadAnyCont IO m)
@@ -187,7 +187,7 @@ moduleBitcode m = do
 writeBitcodeToFile :: File -> Module -> IO ()
 writeBitcodeToFile (File path) m = flip runAnyContT return $ do
   m' <- readModule m
-  withFileRawOStream path False False $ FFI.writeBitcode m'
+  withFileRawOStream path False $ FFI.writeBitcode m'
 
 -- | May throw 'TargetMachineEmitException'.
 targetMachineEmit :: FFI.CodeGenFileType -> TargetMachine -> Module -> Ptr FFI.RawPWriteStream -> IO ()
@@ -200,7 +200,7 @@ targetMachineEmit fileType (TargetMachine tm) m os = flip runAnyContT return $ d
 -- | May throw 'FdStreamException' and 'TargetMachineEmitException'.
 emitToFile :: FFI.CodeGenFileType -> TargetMachine -> File -> Module -> IO ()
 emitToFile fileType tm (File path) m = flip runAnyContT return $ do
-  withFileRawPWriteStream path False False $ targetMachineEmit fileType tm m
+  withFileRawPWriteStream path False $ targetMachineEmit fileType tm m
 
 -- | May throw 'TargetMachineEmitException'.
 emitToByteString :: FFI.CodeGenFileType -> TargetMachine -> Module -> IO BS.ByteString

--- a/llvm-hs/src/LLVM/Internal/RawOStream.hs
+++ b/llvm-hs/src/LLVM/Internal/RawOStream.hs
@@ -23,26 +23,23 @@ withFileRawOStream ::
   (MonadThrow m, MonadIO m, MonadAnyCont IO m)
   => String
   -> Bool
-  -> Bool
   -> (Ptr FFI.RawOStream -> IO ())
   -> m ()
-withFileRawOStream path excl text c =
-  withFileRawPWriteStream path excl text (c . FFI.upCast)
+withFileRawOStream path text c =
+  withFileRawPWriteStream path text (c . FFI.upCast)
 
 -- May throw 'FdStreamException'.
 withFileRawPWriteStream ::
   (MonadThrow m, MonadIO m, MonadAnyCont IO m)
   => String
   -> Bool
-  -> Bool
   -> (Ptr FFI.RawPWriteStream -> IO ())
   -> m ()
-withFileRawPWriteStream path excl text c = do
+withFileRawPWriteStream path text c = do
   path <- encodeM path
-  excl <- encodeM excl
   text <- encodeM text
   msgPtr <- alloca
-  succeeded <- decodeM =<< (liftIO $ FFI.withFileRawPWriteStream path excl text msgPtr c)
+  succeeded <- decodeM =<< (liftIO $ FFI.withFileRawPWriteStream path text msgPtr c)
   unless succeeded $ do
     s <- decodeM msgPtr
     throwM $ FdStreamException s

--- a/llvm-hs/test/LLVM/Test/Optimization.hs
+++ b/llvm-hs/test/LLVM/Test/Optimization.hs
@@ -282,7 +282,6 @@ tests = testGroup "Optimization" [
              ]
            }
       mOut <- do
-        initializeAllTargets
         let triple = "x86_64"
         (target, _) <- lookupTarget Nothing triple
         withTargetOptions $ \targetOptions -> do

--- a/llvm-hs/test/Test.hs
+++ b/llvm-hs/test/Test.hs
@@ -1,6 +1,9 @@
 import Test.Tasty
 import qualified LLVM.Test.Tests as LLVM
 import LLVM.CommandLine
+import LLVM.Target (initializeAllTargets)
 
 main :: IO ()
-main = defaultMain LLVM.tests
+main = do
+  initializeAllTargets
+  defaultMain LLVM.tests


### PR DESCRIPTION
Previously, writeLLVMAssemblyToFile and other similar functions would not truncate an existing file when writing to it.

This means that when there are two calls to writeLLVMAssemblyToFile, and the second one results in a smaller file, there would be remainings of the first module at the end of the file, making it invalid.

This PR fixes that and removes the excl boolean argument to file-writing functions, as there's no use for it in the code base. It would have to be applied to other branches too (I checked that the issue is still present on the llvm-12 branch).