### PR TITLE
Fix build under LLVM 13 because of a missing argument in the ORC ExecutionSession

### DIFF
--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp
@@ -52,7 +52,8 @@ extern "C" {
 // ExecutionSession
 
 ExecutionSession *LLVM_Hs_createExecutionSession() {
-    return new ExecutionSession();
+    // TODO: llvm-hs does not yet expose LLVM 13's executor process control API
+    return new ExecutionSession(std::make_unique<UnsupportedExecutorProcessControl>());
 }
 
 void LLVM_Hs_disposeExecutionSession(ExecutionSession *es) {


### PR DESCRIPTION
As of the LLVM 13 commit https://github.com/llvm/llvm-project/commit/2487db1f286222e2501c2fa8e8244eda13f6afc3, the executor process control API for interacting with an ORC session has been moved into the `ExecutionSession` and needs to be provided as a pointer. This `UnsupportedExecutorProcessControl` is simply an empty implementation meant as a migration path for clients that don't already use `ExecutorProcessControl`-based APIs. Ideally llvm-hs would provide its own `ExecutorProcessControl` implementation to make it possible to interact with the JIT, but I've never ORC myself so I have no idea how that's supposed to work.