### PR TITLE
llvm-hs-pure.cabal: only depend on 'fail' for ghc7

### DIFF
--- a/llvm-hs-pure/llvm-hs-pure.cabal
+++ b/llvm-hs-pure/llvm-hs-pure.cabal
@@ -31,12 +31,13 @@ library
     base >= 4.9 && < 5,
     attoparsec >= 0.13,
     bytestring >= 0.10 && < 0.11,
-    fail,
     transformers >= 0.3 && < 0.6,
     mtl >= 2.1,
     template-haskell >= 2.5.0.0,
     containers >= 0.4.2.1,
     unordered-containers >= 0.2
+  if !impl(ghc >= 8.0)
+    build-depends: fail
   hs-source-dirs: src
   default-extensions:
     NoImplicitPrelude


### PR DESCRIPTION
fail is a dummy package for ghc8+

Or does llvm-hs even still build with ghc7?
Maybe the dependency on fail can just be dropped?