### PR TITLE
llvm12: add reproducible builds with nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,3 @@
+(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+  src = builtins.fetchGit ./.;
+}).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,196 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "fu": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "master",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1611672876,
+        "narHash": "sha256-qHu3uZ/o9jBHiA3MEKHJ06k7w4heOhA+4HCSIvflRxo=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "211907489e9f198594c0eb0ca9256a1949c9d412",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "hls": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1640886100,
+        "narHash": "sha256-/PKDI/GOZXbu0eWCyN9w6OchFUO05T9HNX91axEN66w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "15902b18cd952f43adc5e90bd4b52b83af0d4dcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "master",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "nf": {
+      "locked": {
+        "lastModified": 1620202920,
+        "narHash": "sha256-BOkm3eKT45Dk4NNxJT0xL9NnyYeZcF+t79zPnJkggac=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "3c9e33ed627e009428197b07216613206f06ed80",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "master",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1639357775,
+        "narHash": "sha256-mJJFCPqZi1ZO3CvgEfN2nFAYv4uAJSRnTKzLFi61+WA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c473cc8714710179df205b153f4e9fa007107ff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1640418986,
+        "narHash": "sha256-a8GGtxn2iL3WAkY5H+4E0s3Q7XJt6bTOvos9qqxT5OQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5c37ad87222cfc1ec36d6cd1364514a9efc2f7f2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "np": {
+      "locked": {
+        "lastModified": 1640822900,
+        "narHash": "sha256-H44cm4EYvJOLOzw+4aTEgoVV1R+NmZ+S/++0KSKPICc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4884725b151701282e8c539efc13cfe67dbb3add",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "haskell-updates",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1624971177,
+        "narHash": "sha256-Amf/nBj1E77RmbSSmV+hg6YOpR+rddCbbVgo5C7BS0I=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "397f0713d007250a2c7a745e555fa16c5dc8cadb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fu": "fu",
+        "hls": "hls",
+        "nf": "nf",
+        "np": "np"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -120,11 +120,11 @@
     "lhp": {
       "flake": false,
       "locked": {
-        "lastModified": 1640926554,
-        "narHash": "sha256-R3RCT+t3l9Rxo/knKFrowaDQWkk3lEGA0fBJ06iGW2w=",
+        "lastModified": 1640927191,
+        "narHash": "sha256-yjCVfvvBCUPSAYbinvl9bM4mBJc4elb6q1L8Vja9lbc=",
         "owner": "smunix",
         "repo": "llvm-hs-pretty",
-        "rev": "ace3c52ce575b1ba3a677436cc8efafb21fc10a3",
+        "rev": "2538d7bd6a58006c7a766c6346da6511d5d52264",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -101,6 +101,38 @@
         "type": "github"
       }
     },
+    "lhc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640610238,
+        "narHash": "sha256-qdUHqdqR9vJqzWgmXRmkvKJelEhlu67ubX7DmNGFJ0s=",
+        "owner": "luc-tielen",
+        "repo": "llvm-hs-combinators",
+        "rev": "5814c4f8ba3c675a059cda3c56c56e8ed558f27c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "luc-tielen",
+        "repo": "llvm-hs-combinators",
+        "type": "github"
+      }
+    },
+    "lhp": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1634299651,
+        "narHash": "sha256-EvSI03u8W3khNvh+nlHAIp/fFSCZk+jYk2b/D4hFC08=",
+        "owner": "llvm-hs",
+        "repo": "llvm-hs-pretty",
+        "rev": "990bb6981f6214d9c1bbf46fd9e9ce5596d3bf30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "llvm-hs",
+        "repo": "llvm-hs-pretty",
+        "type": "github"
+      }
+    },
     "nf": {
       "locked": {
         "lastModified": 1620202920,
@@ -186,6 +218,8 @@
       "inputs": {
         "fu": "fu",
         "hls": "hls",
+        "lhc": "lhc",
+        "lhp": "lhp",
         "nf": "nf",
         "np": "np"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -120,16 +120,16 @@
     "lhp": {
       "flake": false,
       "locked": {
-        "lastModified": 1626880009,
-        "narHash": "sha256-uuIP3gIUMbBpZ/K6Xyn0uHJWFq+EUdqM7ISL2E/wvbY=",
-        "owner": "llvm-hs",
+        "lastModified": 1640926554,
+        "narHash": "sha256-R3RCT+t3l9Rxo/knKFrowaDQWkk3lEGA0fBJ06iGW2w=",
+        "owner": "smunix",
         "repo": "llvm-hs-pretty",
-        "rev": "655ff4d47b3a584b4c9a5863f6121b954825920c",
+        "rev": "ace3c52ce575b1ba3a677436cc8efafb21fc10a3",
         "type": "github"
       },
       "original": {
-        "owner": "llvm-hs",
-        "ref": "llvm-12",
+        "owner": "smunix",
+        "ref": "pre.llvm-12",
         "repo": "llvm-hs-pretty",
         "type": "github"
       }
@@ -182,11 +182,11 @@
     },
     "np": {
       "locked": {
-        "lastModified": 1640822900,
-        "narHash": "sha256-H44cm4EYvJOLOzw+4aTEgoVV1R+NmZ+S/++0KSKPICc=",
+        "lastModified": 1640909298,
+        "narHash": "sha256-0YoyFfvPQopwzB8dwPw++DA9lRrdOBfbMgSAXYhfhlY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4884725b151701282e8c539efc13cfe67dbb3add",
+        "rev": "1537d1a8989e094415bb8825a03c5bf2cd26f063",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -120,15 +120,16 @@
     "lhp": {
       "flake": false,
       "locked": {
-        "lastModified": 1634299651,
-        "narHash": "sha256-EvSI03u8W3khNvh+nlHAIp/fFSCZk+jYk2b/D4hFC08=",
+        "lastModified": 1626880009,
+        "narHash": "sha256-uuIP3gIUMbBpZ/K6Xyn0uHJWFq+EUdqM7ISL2E/wvbY=",
         "owner": "llvm-hs",
         "repo": "llvm-hs-pretty",
-        "rev": "990bb6981f6214d9c1bbf46fd9e9ce5596d3bf30",
+        "rev": "655ff4d47b3a584b4c9a5863f6121b954825920c",
         "type": "github"
       },
       "original": {
         "owner": "llvm-hs",
+        "ref": "llvm-12",
         "repo": "llvm-hs-pretty",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -120,11 +120,11 @@
     "lhp": {
       "flake": false,
       "locked": {
-        "lastModified": 1640927191,
-        "narHash": "sha256-yjCVfvvBCUPSAYbinvl9bM4mBJc4elb6q1L8Vja9lbc=",
+        "lastModified": 1640927810,
+        "narHash": "sha256-Ht9/IbCKF04Jfe2STTwLvwkekOpkXVf4b7c3EOtdLeA=",
         "owner": "smunix",
         "repo": "llvm-hs-pretty",
-        "rev": "2538d7bd6a58006c7a766c6346da6511d5d52264",
+        "rev": "b0160ce8b4de0f4594e271cbb64f302a6f8c7fdc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "General purpose LLVM bindings";
+  inputs = {
+    np.url = "github:nixos/nixpkgs?ref=haskell-updates";
+    fu.url = "github:numtide/flake-utils?ref=master";
+    nf.url = "github:numtide/nix-filter?ref=master";
+    hls.url = "github:haskell/haskell-language-server?ref=master";
+  };
+  outputs = { self, np, fu, nf, hls }:
+    with fu.lib;
+    eachSystem [ "x86_64-linux" ] (system:
+      let
+        version = ghc:
+          with np.lib;
+          "${ghc}-${substring 0 8 self.lastModifiedDate}.${
+            self.shortRev or "dirty"
+          }";
+        config = { };
+        mkOverlay = ghc: final: _:
+          with final;
+          with haskell.packages."ghc${ghc}".extend (final: _:
+            with final;
+            with haskell.lib; {
+              llvm-hs-pure = overrideCabal (callCabal2nix "llvm-hs-pure"
+                (with nf.lib; filter { root = ./llvm-hs-pure; }) { })
+                (o: { version = "${o.version}-${version ghc}"; });
+              llvm-hs = overrideCabal (callCabal2nix "llvm-hs"
+                (with nf.lib; filter { root = ./llvm-hs; }) {
+                  inherit llvm-hs-pure;
+                  llvm-config = llvmPackages_9.llvm;
+                }) (o: { version = "${o.version}-${version ghc}"; });
+            }); {
+              "llvm-hs-pure-${ghc}" = llvm-hs;
+              "llvm-hs-${ghc}" = llvm-hs-pure;
+            };
+        mkOverlays = ghcs: map mkOverlay ghcs;
+        eachGHC = ghcs:
+          let
+            pkgs = (import np {
+              inherit config system;
+              overlays = (mkOverlays ghcs);
+            });
+          in with pkgs;
+          with builtins; rec {
+            inherit (pkgs) overlays;
+            packages = flattenTree (recurseIntoAttrs (with lib.lists;
+              foldr (ghc: s:
+                {
+                  "llvm-hs-${ghc}" = getAttr "llvm-hs-${ghc}" pkgs;
+                  "llvm-hs-pure-${ghc}" = getAttr "llvm-hs-pure-${ghc}" pkgs;
+                } // s) { } ghcs));
+          };
+      in eachGHC [ "902" "8107" ]);
+}

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
       flake = false;
     };
     lhp = {
-      url = "github:llvm-hs/llvm-hs-pretty/llvm-12";
+      url = "github:smunix/llvm-hs-pretty/pre.llvm-12";
       flake = false;
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -28,8 +28,10 @@
         mkOverlay = ghc: final: _:
           with final;
           with haskell.lib;
-          with haskell.packages."ghc${ghc}".extend (final: _:
-            with final; rec {
+          with haskell.packages."ghc${ghc}".extend (final: _: rec { }); {
+            "${ghc}" = rec {
+              # inherit (haskell.packages."ghc${ghc}")
+              #   llvm-hs llvm-hs-pure llvm-hs-pretty;
               llvm-hs-pure = overrideCabal (callCabal2nix "llvm-hs-pure"
                 (with nf.lib; filter { root = ./llvm-hs-pure; }) { })
                 (o: { version = "${o.version}-${version ghc}"; });
@@ -45,17 +47,13 @@
                   version = "${o.version}-${version ghc}";
                   patches = [ ./patches/1-llvm-hs-pretty.patch ];
                 }));
-            }); {
-              "${ghc}" = rec {
-                inherit (haskell.packages."ghc${ghc}")
-                  llvm-hs llvm-hs-pure llvm-hs-pretty;
-                llvm-hs-combinators = dontCheck (overrideCabal (addBuildTools
-                  (callCabal2nix "llvm-hs-combinators" "${lhc}" {
-                    inherit llvm-hs-pure;
-                  }) [ hpack ])
-                  (o: { version = "${o.version}-${version ghc}"; }));
-              };
+              llvm-hs-combinators = dontCheck (overrideCabal (addBuildTools
+                (callCabal2nix "llvm-hs-combinators" "${lhc}" {
+                  inherit llvm-hs-pure;
+                }) [ hpack ])
+                (o: { version = "${o.version}-${version ghc}"; }));
             };
+          };
         mkOverlays = ghcs: map mkOverlay ghcs;
         eachGHC = ghcs:
           let

--- a/flake.nix
+++ b/flake.nix
@@ -30,8 +30,6 @@
           with haskell.lib;
           with haskell.packages."ghc${ghc}".extend (final: _: rec { }); {
             "${ghc}" = rec {
-              # inherit (haskell.packages."ghc${ghc}")
-              #   llvm-hs llvm-hs-pure llvm-hs-pretty;
               llvm-hs-pure = overrideCabal (callCabal2nix "llvm-hs-pure"
                 (with nf.lib; filter { root = ./llvm-hs-pure; }) { })
                 (o: { version = "${o.version}-${version ghc}"; });
@@ -67,6 +65,22 @@
               foldr
               (ghc: s: { "ghc${ghc}" = recurseIntoAttrs (pkgs."${ghc}"); } // s)
               { } ghcs));
+            defaultPackage = packages."ghc${head ghcs}/llvm-hs";
+            devShell = with haskell.packages."ghc${head ghcs}";
+              shellFor {
+                packages = _: [
+                  packages."ghc${head ghcs}/llvm-hs"
+                  packages."ghc${head ghcs}/llvm-hs-pure"
+                  packages."ghc${head ghcs}/llvm-hs-combinators"
+                  packages."ghc${head ghcs}/llvm-hs-pretty"
+                ];
+                buildInputs = [
+                  cabal-install
+                  ghc
+                  haskell-language-server
+                  llvmPackages_9.llvm
+                ];
+              };
           };
       in eachGHC [ "902" "8107" ]);
 }

--- a/flake.nix
+++ b/flake.nix
@@ -33,11 +33,11 @@
               llvm-hs-pure = overrideCabal (callCabal2nix "llvm-hs-pure"
                 (with nf.lib; filter { root = ./llvm-hs-pure; }) { })
                 (o: { version = "${o.version}-${version ghc}"; });
-              llvm-hs = overrideCabal (callCabal2nix "llvm-hs"
+              llvm-hs = addBuildDepends (overrideCabal (callCabal2nix "llvm-hs"
                 (with nf.lib; filter { root = ./llvm-hs; }) {
                   inherit llvm-hs-pure;
-                  llvm-config = llvmPackages_9.llvm;
-                }) (o: { version = "${o.version}-${version ghc}"; });
+                }) (o: { version = "${o.version}-${version ghc}"; }))
+                [ llvmPackages_12.llvm ];
               llvm-hs-pretty = dontCheck (overrideCabal (addBuildTools
                 (callCabal2nix "llvm-hs-pretty" "${lhp}" {
                   inherit llvm-hs llvm-hs-pure;
@@ -78,7 +78,7 @@
                   cabal-install
                   ghc
                   haskell-language-server
-                  llvmPackages_9.llvm
+                  llvmPackages_12.llvm
                 ];
               };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
       flake = false;
     };
     lhp = {
-      url = "github:llvm-hs/llvm-hs-pretty";
+      url = "github:llvm-hs/llvm-hs-pretty/llvm-12";
       flake = false;
     };
   };
@@ -41,10 +41,8 @@
               llvm-hs-pretty = dontCheck (overrideCabal (addBuildTools
                 (callCabal2nix "llvm-hs-pretty" "${lhp}" {
                   inherit llvm-hs llvm-hs-pure;
-                }) [ hpack ]) (o: {
-                  version = "${o.version}-${version ghc}";
-                  patches = [ ./patches/1-llvm-hs-pretty.patch ];
-                }));
+                }) [ hpack ])
+                (o: { version = "${o.version}-${version ghc}"; }));
               llvm-hs-combinators = dontCheck (overrideCabal (addBuildTools
                 (callCabal2nix "llvm-hs-combinators" "${lhc}" {
                   inherit llvm-hs-pure;

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,13 @@
+cradle:
+  cabal:
+    - path: "./llvm-hs/src"
+      component: "lib:llvm-hs"
+
+    - path: "./llvm-hs/test"
+      component: "llvm-hs:test:test"
+
+    - path: "./llvm-hs-pure/src"
+      component: "lib:llvm-hs-pure"
+
+    - path: "./llvm-hs-pure/test"
+      component: "llvm-hs-pure:test:test"

--- a/patches/1-llvm-hs-pretty.patch
+++ b/patches/1-llvm-hs-pretty.patch
@@ -1,0 +1,13 @@
+diff --git a/llvm-hs-pretty.cabal b/llvm-hs-pretty.cabal
+index 72589ae..c982478 100644
+--- a/llvm-hs-pretty.cabal
++++ b/llvm-hs-pretty.cabal
+@@ -30,7 +30,7 @@ library
+     bytestring           >= 0.1   && < 0.11,
+     llvm-hs-pure         >= 9.0   && < 10.0,
+     text                 >= 1.2   && < 2.0,
+-    prettyprinter        >= 1.2   && < 1.6
++    prettyprinter        >= 1.2   
+ 
+ Test-suite test
+   type:                exitcode-stdio-1.0


### PR DESCRIPTION
Adding nix support to make it easy to build and integrate llvm-hs.

```sh
~/P/h/l/llvm-hs (pre.llvm-12) ∫ n flake show --allow-import-from-derivation                                                                                                                      [22:58:46] 
git+file:///home/smunix/Programming/haskell/llvm/llvm-hs?ref=pre.llvm-12&rev=59e39e249bf2636cd252fbb960b88467260305e1
├───defaultPackage
│   └───x86_64-linux: package 'llvm-hs-12.0.0-902-20211231.59e39e2'
├───devShell
│   └───x86_64-linux: development environment 'ghc-shell-for-packages-0'
├───overlays
│   └───x86_64-linux: Nixpkgs overlay
└───packages
    └───x86_64-linux
        ├───"ghc8107/llvm-hs": package 'llvm-hs-12.0.0-8107-20211231.59e39e2'
        ├───"ghc8107/llvm-hs-combinators": package 'llvm-hs-combinators-0.1.0.0-8107-20211231.59e39e2'
        ├───"ghc8107/llvm-hs-pretty": package 'llvm-hs-pretty-0.9.0.0-8107-20211231.59e39e2'
        ├───"ghc8107/llvm-hs-pure": package 'llvm-hs-pure-12.0.0-8107-20211231.59e39e2'
        ├───"ghc902/llvm-hs": package 'llvm-hs-12.0.0-902-20211231.59e39e2'
        ├───"ghc902/llvm-hs-combinators": package 'llvm-hs-combinators-0.1.0.0-902-20211231.59e39e2'
        ├───"ghc902/llvm-hs-pretty": package 'llvm-hs-pretty-0.9.0.0-902-20211231.59e39e2'
        └───"ghc902/llvm-hs-pure": package 'llvm-hs-pure-12.0.0-902-20211231.59e39e2'
```