### PR TITLE
Use cxx-sources instead of c-sources in the Cabal file

### DIFF
--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -234,7 +234,7 @@ library
     Control.Monad.Trans.AnyCont
 
   include-dirs: src
-  c-sources:
+  cxx-sources:
     src/LLVM/Internal/FFI/AssemblyC.cpp
     src/LLVM/Internal/FFI/AttributeC.cpp
     src/LLVM/Internal/FFI/BitcodeC.cpp


### PR DESCRIPTION
`cxx-flags` aren't applied to `c-sources`, causing build errors on macOS.