### PR TITLE
Add INLINE annotations to monadic typeclasses

### DIFF
--- a/llvm-hs/src/Control/Monad/AnyCont.hs
+++ b/llvm-hs/src/Control/Monad/AnyCont.hs
@@ -22,9 +22,13 @@ import Control.Monad.Error.Class
 
 instance MonadState s m => MonadState s (AnyContT m) where
   get = lift get
+  {-# INLINE get #-}
   put = lift . put
+  {-# INLINE put #-}
   state = lift . state
+  {-# INLINE state #-}
 
 instance MonadError e m => MonadError e (AnyContT m) where
   throwError = lift . throwError
+  {-# INLINE throwError #-}
   x `catchError` h = anyContT $ \f -> (runAnyContT x f) `catchError` (\e -> runAnyContT (h e) f)

--- a/llvm-hs/src/Control/Monad/AnyCont/Class.hs
+++ b/llvm-hs/src/Control/Monad/AnyCont/Class.hs
@@ -22,30 +22,37 @@ class MonadAnyCont b m where
 
 instance MonadTransAnyCont b m => MonadAnyCont b (AnyContT m) where
   anyContToM c = AnyCont.anyContT (liftAnyCont c)
+  {-# INLINE anyContToM #-}
 
 instance Monad m => ScopeAnyCont (AnyContT m) where
   scopeAnyCont = lift . AnyCont.runAnyContT' return
+  {-# INLINE scopeAnyCont #-}
 
 
 instance (Monad m, MonadAnyCont b m) => MonadAnyCont b (StateT s m) where
   anyContToM x = lift $ anyContToM x
+  {-# INLINE anyContToM #-}
 
 instance ScopeAnyCont m => ScopeAnyCont (StateT s m) where
   scopeAnyCont = StateT . (scopeAnyCont .) . runStateT
+  {-# INLINE scopeAnyCont #-}
 
 
 instance (Monad m, MonadAnyCont b m) => MonadAnyCont b (ExceptT e m) where
   anyContToM x = lift $ anyContToM x
-
+  {-# INLINE anyContToM #-}
 
 instance ScopeAnyCont m => ScopeAnyCont (ExceptT e m) where
   scopeAnyCont = mapExceptT scopeAnyCont
+  {-# INLINE scopeAnyCont #-}
+
 
 class MonadTransAnyCont b m where
   liftAnyCont :: (forall r . (a -> b r) -> b r) -> (forall r . (a -> m r) -> m r)
 
 instance MonadTransAnyCont b b where
   liftAnyCont c = c
+  {-# INLINE liftAnyCont #-}
 
 instance MonadTransAnyCont b m => MonadTransAnyCont b (StateT s m) where
   liftAnyCont c = (\c q -> StateT $ \s -> c $ ($ s) . runStateT . q) (liftAnyCont c)

--- a/llvm-hs/src/Control/Monad/Trans/AnyCont.hs
+++ b/llvm-hs/src/Control/Monad/Trans/AnyCont.hs
@@ -13,42 +13,56 @@ newtype AnyContT m a = AnyContT { unAnyContT :: forall r . ContT r m a }
 
 instance Functor (AnyContT m) where
   fmap f p = AnyContT $ fmap f (unAnyContT p)
+  {-# INLINE fmap #-}
 
 instance Applicative (AnyContT m) where
   pure a = AnyContT $ pure a
+  {-# INLINE pure #-}
   f <*> v = AnyContT $ unAnyContT f <*> unAnyContT v
+  {-# INLINE (<*>) #-}
 
 instance Monad m => Monad (AnyContT m) where
   AnyContT f >>= k = AnyContT $ f >>= \x -> unAnyContT (k x)
+  {-# INLINE (>>=) #-}
   return a = AnyContT $ return a
+  {-# INLINE return #-}
 #if !(MIN_VERSION_base(4,13,0))
   fail s = AnyContT (ContT (\_ -> Cont.fail s))
+  {-# INLINE fail #-}
 #endif
 
 instance MonadFail m => MonadFail (AnyContT m) where
   fail s = AnyContT (ContT (\_ -> Fail.fail s))
+  {-# INLINE fail #-}
 
 instance MonadIO m => MonadIO (AnyContT m) where
   liftIO = lift . liftIO
+  {-# INLINE liftIO #-}
 
 instance MonadTrans AnyContT where
   lift ma = AnyContT (lift ma)
+  {-# INLINE lift #-}
 
 instance MonadThrow m => MonadThrow (AnyContT m) where
   throwM = lift . throwM
+  {-# INLINE throwM #-}
 
 runAnyContT :: AnyContT m a -> forall r . (a -> m r) -> m r
 runAnyContT k = runContT (unAnyContT k)
+{-# INLINE runAnyContT #-}
 
 runAnyContT' :: (a -> m r) -> AnyContT m a -> m r
 runAnyContT' f k = runContT (unAnyContT k) f
+{-# INLINE runAnyContT' #-}
 
 anyContT :: (forall r . (a -> m r) -> m r) -> AnyContT m a
 anyContT f = AnyContT (ContT f)
+{-# INLINE anyContT #-}
 
 withAnyContT :: (forall r . (b -> m r) -> (a -> m r)) -> AnyContT m a -> AnyContT m b
 withAnyContT f m = anyContT $ runAnyContT m . f
+{-# INLINE withAnyContT #-}
 
 mapAnyContT :: (forall r . m r -> m r) -> AnyContT m a -> AnyContT m a
 mapAnyContT f m = anyContT $ f . runAnyContT m
-
+{-# INLINE mapAnyContT #-}


### PR DESCRIPTION
Those are generally tiny functions that we should encourage GHC to
inline. The same approach is taken e.g. by the transformers library.