### PR TITLE
llvm-hs-pure: work with bytestring 0.11.x

### DIFF
--- a/llvm-hs-pure/llvm-hs-pure.cabal
+++ b/llvm-hs-pure/llvm-hs-pure.cabal
@@ -30,7 +30,7 @@ library
   build-depends:
     base >= 4.9 && < 5,
     attoparsec >= 0.13,
-    bytestring >= 0.10 && < 0.11,
+    bytestring >= 0.10 && < 0.12,
     fail,
     transformers >= 0.3 && < 0.6,
     mtl >= 2.1,

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -34,7 +34,8 @@ import Control.Monad.Fail (MonadFail)
 #endif
 
 import Data.Bifunctor
-import Data.ByteString.Short as BS
+import qualified Data.ByteString.Short as BS
+import Data.ByteString.Short (ShortByteString)
 import Data.Char
 import Data.Data
 import Data.Foldable

--- a/llvm-hs-pure/src/LLVM/Triple.hs
+++ b/llvm-hs-pure/src/LLVM/Triple.hs
@@ -14,7 +14,7 @@ import Control.Monad.Trans.Except
 import Data.Attoparsec.ByteString
 import Data.Attoparsec.ByteString.Char8
 import Data.ByteString.Char8 as ByteString hiding (map, foldr)
-import Data.ByteString.Short hiding (pack)
+import Data.ByteString.Short (toShort, fromShort)
 
 import Data.Map (Map, (!))
 import qualified Data.Map as Map


### PR DESCRIPTION
This patch:

- Relaxes the version bound on bytestring for llvm-hs-pure
- Fixes a couple trivial build errors due to ambiguous symbol
  resoltions; bytestring 0.11 added some functions called snoc,
  foldr and such.

---

It would probably make sense to do the same for llvm-hs, but I am having trouble getting it to build against my local version of llvm, so decided to punt for now; for my own project I may end up just shelling out to `llc` rather than try to link against the library.