### PR TITLE
Transition to opaque pointers

### DIFF
--- a/llvm-hs-pure/src/LLVM/AST/Constant.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Constant.hs
@@ -32,7 +32,7 @@ data Constant
     | Vector { memberValues :: [ Constant ] }
     | Undef { constantType :: Type }
     | BlockAddress { blockAddressFunction :: Name, blockAddressBlock :: Name }
-    | GlobalReference Type Name
+    | GlobalReference Name
     | TokenNone
     | Add {
         nsw :: Bool,
@@ -120,6 +120,7 @@ data Constant
       }
     | GetElementPtr {
         inBounds :: Bool,
+        type' :: Type,
         address :: Constant,
         indices :: [Constant]
       }
@@ -242,6 +243,6 @@ unsignedIntegerValue _ = error "unsignedIntegerValue is only defined for Int"
 sizeof :: Word32 -> Type -> Constant
 sizeof szBits t = PtrToInt szPtr (IntegerType szBits)
   where
-     ptrType = PointerType t (AddrSpace 0)
+     ptrType = PointerType (AddrSpace 0)
      nullPtr = IntToPtr (Int szBits 0) ptrType
-     szPtr   = GetElementPtr True nullPtr [Int szBits 1]
+     szPtr   = GetElementPtr True t nullPtr [Int szBits 1]

--- a/llvm-hs-pure/src/LLVM/AST/Instruction.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Instruction.hs
@@ -51,6 +51,7 @@ data Terminator
   | Invoke {
       callingConvention' :: CallingConvention,
       returnAttributes' :: [PA.ParameterAttribute],
+      type'' :: Type,
       function' :: CallableOperand,
       arguments' :: [(Operand, [PA.ParameterAttribute])],
       functionAttributes' :: [Either FA.GroupID FA.FunctionAttribute],
@@ -266,6 +267,7 @@ data Instruction
     }
   | Load {
       volatile :: Bool,
+      type' :: Type,
       address :: Operand,
       maybeAtomicity :: Maybe Atomicity,
       alignment :: Word32,
@@ -281,6 +283,7 @@ data Instruction
     }
   | GetElementPtr {
       inBounds :: Bool,
+      type' :: Type,
       address :: Operand,
       indices :: [Operand],
       metadata :: InstructionMetadata
@@ -405,6 +408,7 @@ data Instruction
       tailCallKind :: Maybe TailCallKind,
       callingConvention :: CallingConvention,
       returnAttributes :: [PA.ParameterAttribute],
+      type' :: Type,
       function :: CallableOperand,
       arguments :: [(Operand, [PA.ParameterAttribute])],
       functionAttributes :: [Either FA.GroupID FA.FunctionAttribute],

--- a/llvm-hs-pure/src/LLVM/AST/Type.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Type.hs
@@ -23,7 +23,7 @@ data Type
   -- | <http://llvm.org/docs/LangRef.html#integer-type>
   | IntegerType { typeBits :: Word32 }
   -- | <http://llvm.org/docs/LangRef.html#pointer-type>
-  | PointerType { pointerReferent :: Type, pointerAddrSpace :: AddrSpace }
+  | PointerType { pointerAddrSpace :: AddrSpace }
   -- | <http://llvm.org/docs/LangRef.html#floating-point-types>
   | FloatingPointType { floatingPointType :: FloatingPointType }
   -- | <http://llvm.org/docs/LangRef.html#function-type>
@@ -72,9 +72,9 @@ i64 = IntegerType 64
 i128 :: Type
 i128 = IntegerType 128
 
--- | An abbreviation for 'PointerType' t ('AddrSpace' 0)
-ptr :: Type -> Type
-ptr t = PointerType t (AddrSpace 0)
+-- | An abbreviation for 'PointerType' ('AddrSpace' 0)
+ptr :: Type
+ptr = PointerType (AddrSpace 0)
 
 -- | An abbreviation for 'FloatingPointType' 'HalfFP'
 half :: Type

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -147,9 +147,8 @@ function label argtys retty body = do
       , returnType  = retty
       , basicBlocks = blocks
       }
-    funty = ptr $ FunctionType retty (fst <$> argtys) False
   emitDefn def
-  pure $ ConstantOperand $ C.GlobalReference funty label
+  pure $ ConstantOperand $ C.GlobalReference label
 
 -- | An external function definition
 extern
@@ -165,8 +164,7 @@ extern nm argtys retty = do
     , parameters  = ([Parameter ty (mkName "") [] | ty <- argtys], False)
     , returnType  = retty
     }
-  let funty = ptr $ FunctionType retty argtys False
-  pure $ ConstantOperand $ C.GlobalReference funty nm
+  pure $ ConstantOperand $ C.GlobalReference nm
 
 -- | An external variadic argument function definition
 externVarArgs
@@ -182,8 +180,7 @@ externVarArgs nm argtys retty = do
     , parameters  = ([Parameter ty (mkName "") [] | ty <- argtys], True)
     , returnType  = retty
     }
-  let funty = ptr $ FunctionType retty argtys True
-  pure $ ConstantOperand $ C.GlobalReference funty nm
+  pure $ ConstantOperand $ C.GlobalReference nm
 
 -- | A global variable definition
 global
@@ -199,7 +196,7 @@ global nm ty initVal = do
     , linkage               = External
     , initializer           = Just initVal
     }
-  pure $ ConstantOperand $ C.GlobalReference (ptr ty) nm
+  pure $ ConstantOperand $ C.GlobalReference nm
 
 -- | A named type definition
 typedef

--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -241,6 +241,7 @@ library
     src/LLVM/Internal/FFI/BuilderC.cpp
     src/LLVM/Internal/FFI/CallingConventionC.cpp
     src/LLVM/Internal/FFI/ConstantC.cpp
+    src/LLVM/Internal/FFI/ContextC.cpp
     src/LLVM/Internal/FFI/CommandLineC.cpp
     src/LLVM/Internal/FFI/ErrorHandling.cpp
     src/LLVM/Internal/FFI/ExecutionEngineC.cpp

--- a/llvm-hs/src/LLVM/Internal/Context.hs
+++ b/llvm-hs/src/LLVM/Internal/Context.hs
@@ -14,14 +14,20 @@ import qualified LLVM.Internal.FFI.Context as FFI
 -- | Then it got packed up in this object to allow multiple threads to compile at once.
 data Context = Context (Ptr FFI.Context)
 
+contextCreate :: IO (Ptr FFI.Context)
+contextCreate = do
+  ctx <- FFI.contextCreate
+  FFI.contextSetOpaquePointers ctx
+  return ctx
+
 -- | Create a Context, run an action (to which it is provided), then destroy the Context.
 withContext :: (Context -> IO a) -> IO a
-withContext = runBound . bracket FFI.contextCreate FFI.contextDispose . (. Context)
+withContext = runBound . bracket contextCreate FFI.contextDispose . (. Context)
   where runBound = if rtsSupportsBoundThreads then runInBoundThread else id
 
 -- | Create a Context.
 createContext :: IO Context
-createContext = Context <$> FFI.contextCreate
+createContext = Context <$> contextCreate
 
 -- | Destroy a context created by 'createContext'.
 disposeContext :: Context -> IO ()

--- a/llvm-hs/src/LLVM/Internal/FFI/Builder.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Builder.hs
@@ -39,8 +39,8 @@ foreign import ccall unsafe "LLVMBuildSwitch" buildSwitch ::
 foreign import ccall unsafe "LLVMBuildIndirectBr" buildIndirectBr ::
   Ptr Builder -> Ptr Value -> CUInt -> IO (Ptr Instruction)
 
-foreign import ccall unsafe "LLVMBuildInvoke" buildInvoke ::
-  Ptr Builder -> Ptr Value -> Ptr (Ptr Value) -> CUInt
+foreign import ccall unsafe "LLVMBuildInvoke2" buildInvoke ::
+  Ptr Builder -> Ptr Type -> Ptr Value -> Ptr (Ptr Value) -> CUInt
               -> Ptr BasicBlock -> Ptr BasicBlock -> CString -> IO (Ptr Instruction)
 
 foreign import ccall unsafe "LLVMBuildResume" buildResume ::
@@ -158,10 +158,10 @@ foreign import ccall unsafe "LLVMBuildArrayAlloca" buildAlloca ::
   Ptr Builder -> Ptr Type -> Ptr Value -> CString -> IO (Ptr Instruction)
 
 foreign import ccall unsafe "LLVM_Hs_BuildLoad" buildLoad' ::
-  Ptr Builder -> LLVMBool -> Ptr Value -> MemoryOrdering -> SynchronizationScope -> CUInt -> CString -> IO (Ptr Instruction)
+  Ptr Builder -> LLVMBool -> Ptr Type -> Ptr Value -> MemoryOrdering -> SynchronizationScope -> CUInt -> CString -> IO (Ptr Instruction)
 
-buildLoad :: Ptr Builder -> LLVMBool -> Ptr Value -> (SynchronizationScope, MemoryOrdering) -> CUInt -> CString -> IO (Ptr Instruction)
-buildLoad builder vol a' (ss, mo) al s = buildLoad' builder vol a' mo ss al s
+buildLoad :: Ptr Builder -> LLVMBool -> Ptr Type -> Ptr Value -> (SynchronizationScope, MemoryOrdering) -> CUInt -> CString -> IO (Ptr Instruction)
+buildLoad builder vol ty a' (ss, mo) al s = buildLoad' builder vol ty a' mo ss al s
 
 foreign import ccall unsafe "LLVM_Hs_BuildStore" buildStore' ::
   Ptr Builder -> LLVMBool -> Ptr Value -> Ptr Value -> MemoryOrdering -> SynchronizationScope -> CUInt -> CString -> IO (Ptr Instruction)
@@ -170,15 +170,15 @@ buildStore :: Ptr Builder -> LLVMBool -> Ptr Value -> Ptr Value -> (Synchronizat
 buildStore builder vol a' v' (ss, mo) al s = buildStore' builder vol a' v' mo ss al s
 
 foreign import ccall unsafe "LLVM_Hs_BuildGEP" buildGetElementPtr' ::
-  Ptr Builder -> Ptr Value -> Ptr (Ptr Value) -> CUInt -> CString -> IO (Ptr Instruction)
+  Ptr Builder -> Ptr Type -> Ptr Value -> Ptr (Ptr Value) -> CUInt -> CString -> IO (Ptr Instruction)
 
 foreign import ccall unsafe "LLVM_Hs_BuildInBoundsGEP" buildInBoundsGetElementPtr' ::
-  Ptr Builder -> Ptr Value -> Ptr (Ptr Value) -> CUInt -> CString -> IO (Ptr Instruction)
+  Ptr Builder -> Ptr Type -> Ptr Value -> Ptr (Ptr Value) -> CUInt -> CString -> IO (Ptr Instruction)
 
-buildGetElementPtr :: HasCallStack => Ptr Builder -> LLVMBool -> Ptr Value -> (CUInt, Ptr (Ptr Value)) -> CString -> IO (Ptr Instruction)
-buildGetElementPtr builder (LLVMBool 1) a (n, is) s = buildInBoundsGetElementPtr' builder a is n s
-buildGetElementPtr builder (LLVMBool 0) a (n, is) s = buildGetElementPtr' builder a is n s
-buildGetElementPtr _ (LLVMBool i) _ _ _ = error ("LLVMBool should be 0 or 1 but is " <> show i)
+buildGetElementPtr :: HasCallStack => Ptr Builder -> LLVMBool -> Ptr Type -> Ptr Value -> (CUInt, Ptr (Ptr Value)) -> CString -> IO (Ptr Instruction)
+buildGetElementPtr builder (LLVMBool 1) ty a (n, is) s = buildInBoundsGetElementPtr' builder ty a is n s
+buildGetElementPtr builder (LLVMBool 0) ty a (n, is) s = buildGetElementPtr' builder ty a is n s
+buildGetElementPtr _ (LLVMBool i) _ _ _ _ = error ("LLVMBool should be 0 or 1 but is " <> show i)
 
 foreign import ccall unsafe "LLVM_Hs_BuildFence" buildFence' ::
   Ptr Builder -> MemoryOrdering -> SynchronizationScope -> CString -> IO (Ptr Instruction)
@@ -207,8 +207,8 @@ foreign import ccall unsafe "LLVMBuildFCmp" buildFCmp ::
 foreign import ccall unsafe "LLVMBuildPhi" buildPhi ::
   Ptr Builder -> Ptr Type -> CString -> IO (Ptr Instruction)
 
-foreign import ccall unsafe "LLVMBuildCall" buildCall ::
-  Ptr Builder -> Ptr Value -> Ptr (Ptr Value) -> CUInt -> CString -> IO (Ptr Instruction)
+foreign import ccall unsafe "LLVMBuildCall2" buildCall ::
+  Ptr Builder -> Ptr Type -> Ptr Value -> Ptr (Ptr Value) -> CUInt -> CString -> IO (Ptr Instruction)
 
 foreign import ccall unsafe "LLVMBuildFreeze" buildFreeze ::
   Ptr Builder -> Ptr Value -> Ptr Type -> IO (Ptr Instruction)

--- a/llvm-hs/src/LLVM/Internal/FFI/Constant.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Constant.hs
@@ -107,19 +107,22 @@ $(do
        foreignDecl (prefix ++ "Const" ++ name) ("constant" ++ name) (map typeMapping fieldTypes) [t| Ptr Constant |]
   )
 
-foreign import ccall unsafe "LLVMConstGEP" constantGetElementPtr' ::
-  Ptr Constant -> Ptr (Ptr Constant) -> CUInt -> IO (Ptr Constant)
+foreign import ccall unsafe "LLVMConstGEP2" constantGetElementPtr' ::
+  Ptr Type -> Ptr Constant -> Ptr (Ptr Constant) -> CUInt -> IO (Ptr Constant)
 
-foreign import ccall unsafe "LLVMConstInBoundsGEP" constantInBoundsGetElementPtr' ::
-  Ptr Constant -> Ptr (Ptr Constant) -> CUInt -> IO (Ptr Constant)
+foreign import ccall unsafe "LLVMConstInBoundsGEP2" constantInBoundsGetElementPtr' ::
+  Ptr Type -> Ptr Constant -> Ptr (Ptr Constant) -> CUInt -> IO (Ptr Constant)
 
-constantGetElementPtr :: LLVMBool -> Ptr Constant -> (CUInt, Ptr (Ptr Constant)) -> IO (Ptr Constant)
-constantGetElementPtr (LLVMBool ib) a (n, is) =
+constantGetElementPtr :: LLVMBool -> Ptr Type -> Ptr Constant -> (CUInt, Ptr (Ptr Constant)) -> IO (Ptr Constant)
+constantGetElementPtr (LLVMBool ib) ty a (n, is) =
   (case ib of
      0 -> constantGetElementPtr'
      1 -> constantInBoundsGetElementPtr'
      _ -> error ("LLVMBool should be 0 or 1 but is " <> show ib)
-  ) a is n
+  ) ty a is n
+
+foreign import ccall unsafe "LLVM_Hs_GetConstGEPSourceType" getConstantGEPSourceType ::
+  Ptr Constant -> IO (Ptr Type)
 
 foreign import ccall unsafe "LLVM_Hs_GetConstCPPOpcode" getConstantCPPOpcode ::
   Ptr Constant -> IO CPPOpcode

--- a/llvm-hs/src/LLVM/Internal/FFI/ConstantC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/ConstantC.cpp
@@ -2,6 +2,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
+#include "llvm/IR/Operator.h"
 
 #include "llvm-c/Core.h"
 #include "LLVM/Internal/FFI/Value.h"
@@ -127,5 +128,8 @@ LLVMValueRef LLVM_Hs_GetConstTokenNone(LLVMContextRef context) {
     return wrap(ConstantTokenNone::get(*unwrap(context)));
 }
 
+LLVMTypeRef LLVM_Hs_GetConstGEPSourceType(LLVMValueRef v) {
+    return wrap(unwrap<GEPOperator>(v)->getSourceElementType());
+}
 
 }

--- a/llvm-hs/src/LLVM/Internal/FFI/Context.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Context.hs
@@ -23,6 +23,9 @@ foreign import ccall unsafe "LLVMContextCreate" contextCreate ::
 foreign import ccall unsafe "LLVMGetGlobalContext" getGlobalContext ::
     IO (Ptr Context)
 
+foreign import ccall unsafe "LLVM_Hs_SetOpaquePointers" contextSetOpaquePointers ::
+    Ptr Context -> IO ()
+
 -- | <http://llvm.org/doxygen/group__LLVMCCoreContext.html#ga9cf8b0fb4a546d4cdb6f64b8055f5f57>
 foreign import ccall unsafe "LLVMContextDispose" contextDispose ::
     Ptr Context -> IO ()

--- a/llvm-hs/src/LLVM/Internal/FFI/ContextC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/ContextC.cpp
@@ -1,0 +1,13 @@
+#define __STDC_LIMIT_MACROS
+#include "llvm-c/Core.h"
+#include "llvm/IR/LLVMContext.h"
+
+using namespace llvm;
+
+extern "C" {
+
+void LLVM_Hs_SetOpaquePointers(LLVMContextRef context) {
+  unwrap(context)->setOpaquePointers(true);
+}
+
+}

--- a/llvm-hs/src/LLVM/Internal/FFI/GlobalValue.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/GlobalValue.hs
@@ -13,11 +13,18 @@ import Foreign.C
 
 import LLVM.Internal.FFI.PtrHierarchy
 import LLVM.Internal.FFI.LLVMCTypes
+import LLVM.Internal.FFI.Type
 
 data COMDAT
 
 foreign import ccall unsafe "LLVMIsAGlobalValue" isAGlobalValue ::
   Ptr Value -> IO (Ptr GlobalValue)
+
+foreign import ccall unsafe "LLVM_Hs_GetGlobalValueType" getGlobalValueType ::
+  Ptr GlobalValue -> IO (Ptr Type)
+
+foreign import ccall unsafe "LLVM_Hs_GetGlobalValueAddressSpace" getGlobalValueAddressSpace ::
+  Ptr GlobalValue -> IO AddrSpace
 
 foreign import ccall unsafe "LLVMGetLinkage" getLinkage ::
   Ptr GlobalValue -> IO Linkage

--- a/llvm-hs/src/LLVM/Internal/FFI/GlobalValueC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/GlobalValueC.cpp
@@ -1,5 +1,6 @@
 #define __STDC_LIMIT_MACROS
 #include "llvm/IR/Comdat.h"
+#include "llvm/IR/Type.h"
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/IR/GlobalObject.h"
 #include "llvm/IR/Metadata.h"
@@ -76,6 +77,14 @@ void LLVM_Hs_GlobalObject_GetAllMetadata(GlobalObject* obj, unsigned *kinds, LLV
 
 void LLVM_Hs_GlobalObject_SetMetadata(GlobalObject* obj, unsigned kind, MDNode* node) {
     obj->setMetadata(kind, node);
+}
+
+LLVMTypeRef LLVM_Hs_GetGlobalValueType(LLVMValueRef v) {
+  return wrap(unwrap<GlobalValue>(v)->getValueType());
+}
+
+unsigned LLVM_Hs_GetGlobalValueAddressSpace(LLVMValueRef v) {
+  return unwrap<GlobalValue>(v)->getAddressSpace();
 }
 
 }

--- a/llvm-hs/src/LLVM/Internal/FFI/InlineAssembly.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/InlineAssembly.hs
@@ -33,3 +33,5 @@ foreign import ccall unsafe "LLVM_Hs_InlineAsmIsAlignStack" inlineAsmIsAlignStac
 foreign import ccall unsafe "LLVM_Hs_GetInlineAsmDialect" getInlineAsmDialect ::
   Ptr InlineAsm -> IO AsmDialect
 
+foreign import ccall unsafe "LLVM_Hs_GetInlineAsmFunctionType" getInlineAsmFunctionType ::
+  Ptr InlineAsm -> IO (Ptr Type)

--- a/llvm-hs/src/LLVM/Internal/FFI/InlineAssemblyC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/InlineAssemblyC.cpp
@@ -39,7 +39,7 @@ LLVMValueRef LLVM_Hs_CreateInlineAsm(
 ) {
 	return wrap(
 		InlineAsm::get(
-			unwrap<FunctionType>(t), 
+			unwrap<FunctionType>(t),
 			asmStr,
 			constraintsStr,
 			hasSideEffects,
@@ -69,5 +69,8 @@ LLVMAsmDialect LLVM_Hs_GetInlineAsmDialect(LLVMValueRef v) {
 	return wrap(unwrap<InlineAsm>(v)->getDialect());
 }
 
+LLVMTypeRef LLVM_Hs_GetInlineAsmFunctionType(LLVMValueRef v) {
+  return wrap(unwrap<InlineAsm>(v)->getFunctionType());
 }
 
+}

--- a/llvm-hs/src/LLVM/Internal/FFI/Instruction.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Instruction.hs
@@ -49,6 +49,12 @@ foreign import ccall unsafe "LLVM_Hs_SetTailCallKind" setTailCallKind ::
 foreign import ccall unsafe "LLVMGetCalledValue" getCallSiteCalledValue ::
   Ptr Instruction -> IO (Ptr Value)
 
+foreign import ccall unsafe "LLVMGetCalledFunctionType" getCalledFunctionType ::
+  Ptr Instruction -> IO (Ptr Type)
+
+foreign import ccall unsafe "LLVMGetGEPSourceElementType" getGEPSourceElementType ::
+  Ptr Instruction -> IO (Ptr Type)
+
 foreign import ccall unsafe "LLVMGetNumArgOperands" getCallSiteNumArgOperands ::
   Ptr Instruction -> IO CUInt
 

--- a/llvm-hs/src/LLVM/Internal/FFI/PassesC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/PassesC.cpp
@@ -72,6 +72,7 @@ void LLVM_Hs_AddAlwaysInlinePass(ModulePassManager* mpm, int insert_lifetimes) {
 
 void LLVM_Hs_AddInternalizeFunctionsPass(ModulePassManager* mpm, int num_exports, char** exports) {
   std::vector<std::string> owned_exports;
+  owned_exports.reserve(num_exports);
   for (int i = 0; i < num_exports; ++i) {
     owned_exports.push_back(std::string(exports[i]));
   }

--- a/llvm-hs/src/LLVM/Internal/FFI/Type.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Type.hs
@@ -57,6 +57,12 @@ newtype AddrSpace = AddrSpace CUInt
 foreign import ccall unsafe "LLVMPointerType" pointerType ::
   Ptr Type -> AddrSpace -> IO (Ptr Type)
 
+foreign import ccall unsafe "LLVM_Hs_OpaquePointerType" opaquePointerType ::
+  Ptr Context -> AddrSpace -> IO (Ptr Type)
+
+foreign import ccall unsafe "LLVM_Hs_IsOpaquePointerType" isOpaquePointerType ::
+  Ptr Type -> IO LLVMBool
+
 -- | <http://llvm.org/doxygen/group__LLVMCCoreTypeSequential.html#ga124b162b69b5def41dde2fda3668cbd9>
 foreign import ccall unsafe "LLVMGetPointerAddressSpace" getPointerAddressSpace ::
   Ptr Type -> IO AddrSpace

--- a/llvm-hs/src/LLVM/Internal/FFI/TypeC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/TypeC.cpp
@@ -24,6 +24,14 @@ LLVMTypeRef LLVM_Hs_ArrayType(LLVMTypeRef ElementType, uint64_t ElementCount) {
     return wrap(ArrayType::get(unwrap(ElementType), ElementCount));
 }
 
+LLVMTypeRef LLVM_Hs_OpaquePointerType(LLVMContextRef C, unsigned AddrSpace) {
+    return wrap(PointerType::get(*unwrap(C), AddrSpace));
+}
+
+LLVMBool LLVM_Hs_IsOpaquePointerType(LLVMTypeRef type) {
+    return unwrap(type)->isOpaquePointerTy();
+}
+
 uint64_t LLVM_Hs_GetArrayLength(LLVMTypeRef ArrayTy) {
     return unwrap<ArrayType>(ArrayTy)->getNumElements();
 }

--- a/llvm-hs/src/LLVM/Internal/FFI/Value.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Value.hs
@@ -27,7 +27,7 @@ foreign import ccall unsafe "LLVMSetValueName" setValueName ::
   Ptr Value -> CString -> IO ()
 
 -- | This function exposes the ID returned by llvm::Value::getValueID()
--- | <http://llvm.org/doxygen/classllvm_1_1Value.html#a2983b7b4998ef5b9f51b18c01588af3c>. 
+-- | <http://llvm.org/doxygen/classllvm_1_1Value.html#a2983b7b4998ef5b9f51b18c01588af3c>.
 foreign import ccall unsafe "LLVM_Hs_GetValueSubclassId" getValueSubclassId ::
   Ptr Value -> IO ValueSubclassId
 

--- a/llvm-hs/src/LLVM/Internal/Global.hs
+++ b/llvm-hs/src/LLVM/Internal/Global.hs
@@ -19,6 +19,7 @@ import qualified LLVM.Internal.FFI.GlobalValue as FFI
 import LLVM.Internal.Coding
 import LLVM.Internal.DecodeAST
 import LLVM.Internal.EncodeAST
+import LLVM.Internal.Type ()
 
 import qualified LLVM.AST.Linkage as A.L
 import qualified LLVM.AST.Visibility as A.V
@@ -26,6 +27,7 @@ import qualified LLVM.AST.COMDAT as A.COMDAT
 import qualified LLVM.AST.DLL as A.DLL
 import qualified LLVM.AST.ThreadLocalStorage as A.TLS
 import qualified LLVM.AST.Global as A.G
+import qualified LLVM.AST.Type as A.T
 
 genCodingInstance [t| A.L.Linkage |] ''FFI.Linkage [
   (FFI.linkageExternal, A.L.External),
@@ -46,7 +48,7 @@ getLinkage g = liftIO $ decodeM =<< FFI.getLinkage (FFI.upCast g)
 
 setLinkage :: FFI.DescendentOf FFI.GlobalValue v => Ptr v -> A.L.Linkage -> EncodeAST ()
 setLinkage g l = liftIO . FFI.setLinkage (FFI.upCast g) =<< encodeM l
-                                                                       
+
 genCodingInstance [t| A.V.Visibility |] ''FFI.Visibility [
   (FFI.visibilityDefault, A.V.Default),
   (FFI.visibilityHidden, A.V.Hidden),
@@ -146,3 +148,6 @@ genCodingInstance [t| Maybe A.G.UnnamedAddr |] ''FFI.UnnamedAddr [
   (FFI.unnamedAddrLocal, Just A.G.LocalAddr),
   (FFI.unnamedAddrGlobal, Just A.G.GlobalAddr)
  ]
+
+typeOfGlobal :: FFI.DescendentOf FFI.GlobalValue v => Ptr v -> DecodeAST A.T.Type
+typeOfGlobal = decodeM <=< liftIO . FFI.getGlobalValueType . FFI.upCast

--- a/llvm-hs/src/LLVM/Internal/InlineAssembly.hs
+++ b/llvm-hs/src/LLVM/Internal/InlineAssembly.hs
@@ -4,7 +4,7 @@
   OverloadedStrings
   #-}
 module LLVM.Internal.InlineAssembly where
- 
+
 import LLVM.Prelude
 
 import Control.Monad.IO.Class
@@ -21,12 +21,11 @@ import qualified LLVM.Internal.FFI.PtrHierarchy as FFI
 
 import qualified LLVM.AST as A (Definition(..))
 import qualified LLVM.AST.InlineAssembly as A
-import qualified LLVM.AST.Type as A
 
-import LLVM.Internal.Coding 
+import LLVM.Internal.Coding
 import LLVM.Internal.EncodeAST
 import LLVM.Internal.DecodeAST
-import LLVM.Internal.Value
+import LLVM.Internal.Type ()
 
 genCodingInstance [t| A.Dialect |] ''FFI.AsmDialect [
    (FFI.asmDialectATT, A.ATTDialect),
@@ -53,7 +52,7 @@ instance EncodeM EncodeAST A.InlineAssembly (Ptr FFI.InlineAsm) where
 instance DecodeM DecodeAST A.InlineAssembly (Ptr FFI.InlineAsm) where
   decodeM p = do
     return A.InlineAssembly
-      `ap` (liftM (\(A.PointerType f _) -> f) (typeOf p))
+      `ap` (decodeM =<< liftIO (FFI.getInlineAsmFunctionType p))
       `ap` (decodeM =<< liftIO (FFI.getInlineAsmAssemblyString p))
       `ap` (decodeM =<< liftIO (FFI.getInlineAsmConstraintString p))
       `ap` (decodeM =<< liftIO (FFI.inlineAsmHasSideEffects p))

--- a/llvm-hs/src/LLVM/Internal/Value.hs
+++ b/llvm-hs/src/LLVM/Internal/Value.hs
@@ -14,10 +14,9 @@ import qualified LLVM.Internal.FFI.Value as FFI
 
 import LLVM.Internal.Coding
 import LLVM.Internal.DecodeAST
-import LLVM.Internal.Type () 
+import LLVM.Internal.Type ()
 
 import qualified LLVM.AST.Type as A
 
 typeOf :: FFI.DescendentOf FFI.Value v => Ptr v -> DecodeAST A.Type
 typeOf = decodeM <=< liftIO . FFI.typeOf . FFI.upCast
-

--- a/llvm-hs/test/LLVM/Test/Analysis.hs
+++ b/llvm-hs/test/LLVM/Test/Analysis.hs
@@ -38,8 +38,8 @@ tests = testGroup "Analysis" [
             GlobalDefinition $ Function L.External V.Default CC.C [] A.T.void (Name "foo") ([
                 Parameter i32 (Name "x") []
                ],False)
-             [] 
-             Nothing 0 Nothing         
+             []
+             Nothing 0 Nothing
              [
               BasicBlock (UnName 0) [
                 UnName 1 := Call {
@@ -71,31 +71,33 @@ tests = testGroup "Analysis" [
        let str = "; ModuleID = '<string>'\n\
                  \source_filename = \"<string>\"\n\
                  \\n\
-                 \define double @my_function2(double* %input_0) {\n\
+                 \define double @my_function2(ptr %input_0) {\n\
                  \foo:\n\
-                 \  %tmp_input_w0 = getelementptr inbounds double, double* %input_0, i64 0\n\
-                 \  %0 = load double, double* %tmp_input_w0, align 8\n\
+                 \  %tmp_input_w0 = getelementptr inbounds double, ptr %input_0, i64 0\n\
+                 \  %0 = load double, ptr %tmp_input_w0, align 8\n\
                  \  ret double %0\n\
                  \}\n"
-           ast = 
+           ast =
              Module "<string>" "<string>" Nothing Nothing [
                GlobalDefinition $ functionDefaults {
                  G.returnType = double,
                  G.name = Name "my_function2",
                  G.parameters = ([
-                   Parameter (ptr double) (Name "input_0") []
+                   Parameter ptr (Name "input_0") []
                   ],False),
                  G.basicBlocks = [
-                   BasicBlock (Name "foo") [ 
+                   BasicBlock (Name "foo") [
                     Name "tmp_input_w0" := GetElementPtr {
                       inBounds = True,
-                      address = LocalReference (ptr double) (Name "input_0"),
+                      type' = double,
+                      address = LocalReference ptr (Name "input_0"),
                       indices = [ConstantOperand (C.Int 64 0)],
                       metadata = []
                     },
                     UnName 0 := Load {
                       volatile = False,
-                      address = LocalReference (ptr double) (Name "tmp_input_w0"),
+                      type' = double,
+                      address = LocalReference ptr (Name "tmp_input_w0"),
                       maybeAtomicity = Nothing,
                       alignment = 8,
                       metadata = []

--- a/llvm-hs/test/LLVM/Test/Attribute.hs
+++ b/llvm-hs/test/LLVM/Test/Attribute.hs
@@ -49,17 +49,16 @@ moduleAst =
                      { tailCallKind = Nothing
                      , callingConvention = C
                      , returnAttributes = []
+                     , type' =
+                         FunctionType
+                           { resultType = i32
+                           , argumentTypes = []
+                           , isVarArg = False
+                           }
                      , function =
                          Right
                            (ConstantOperand
-                              (GlobalReference
-                                 (ptr
-                                    (FunctionType
-                                     { resultType = i32
-                                     , argumentTypes = []
-                                     , isVarArg = False
-                                     }))
-                                 ("f")))
+                              (GlobalReference "f"))
                      , arguments = []
                      , functionAttributes = [Left (GroupID 0)]
                      , metadata = []

--- a/llvm-hs/test/LLVM/Test/Constants.hs
+++ b/llvm-hs/test/LLVM/Test/Constants.hs
@@ -117,44 +117,44 @@ tests = testGroup "Constants" [
     ), (
       "binop/cast",
       i64,
-      C.Add False False (C.PtrToInt (C.GlobalReference (ptr i32) (UnName 1)) i64) (C.Int 64 2),
-      "global i64 add (i64 ptrtoint (i32* @1 to i64), i64 2)"
+      C.Add False False (C.PtrToInt (C.GlobalReference (UnName 1)) i64) (C.Int 64 2),
+      "global i64 add (i64 ptrtoint (ptr @1 to i64), i64 2)"
     ), (
       "binop/cast nsw",
       i64,
-      C.Add True False (C.PtrToInt (C.GlobalReference (ptr i32) (UnName 1)) i64) (C.Int 64 2),
-      "global i64 add nsw (i64 ptrtoint (i32* @1 to i64), i64 2)"
+      C.Add True False (C.PtrToInt (C.GlobalReference (UnName 1)) i64) (C.Int 64 2),
+      "global i64 add nsw (i64 ptrtoint (ptr @1 to i64), i64 2)"
     ), (
       "icmp",
       i1,
-      C.ICmp IPred.SGE (C.GlobalReference (ptr i32) (UnName 1)) (C.GlobalReference (ptr i32) (UnName 2)),
-      "global i1 icmp sge (i32* @1, i32* @2)"
+      C.ICmp IPred.SGE (C.GlobalReference (UnName 1)) (C.GlobalReference (UnName 2)),
+      "global i1 icmp sge (ptr @1, ptr @2)"
     ), (
       "getelementptr",
-      ptr i32,
-      C.GetElementPtr True (C.GlobalReference (ptr i32) (UnName 1)) [C.Int 64 27],
-      "global i32* getelementptr inbounds (i32, i32* @1, i64 27)"
+      ptr,
+      C.GetElementPtr True i32 (C.GlobalReference (UnName 1)) [C.Int 64 27],
+      "global ptr getelementptr inbounds (i32, ptr @1, i64 27)"
     ), (
       "selectvalue",
       i32,
-      C.Select (C.PtrToInt (C.GlobalReference (ptr i32) (UnName 1)) i1)
+      C.Select (C.PtrToInt (C.GlobalReference (UnName 1)) i1)
          (C.Int 32 1)
          (C.Int 32 2),
-      "global i32 select (i1 ptrtoint (i32* @1 to i1), i32 1, i32 2)"
+      "global i32 select (i1 ptrtoint (ptr @1 to i1), i32 1, i32 2)"
     ), (
       "extractelement",
       i32,
       C.ExtractElement
          (C.BitCast
-             (C.PtrToInt (C.GlobalReference (ptr i32) (UnName 1)) i64)
+             (C.PtrToInt (C.GlobalReference (UnName 1)) i64)
              (VectorType 2 i32))
          (C.Int 32 1),
-      "global i32 extractelement (<2 x i32> bitcast (i64 ptrtoint (i32* @1 to i64) to <2 x i32>), i32 1)"
+      "global i32 extractelement (<2 x i32> bitcast (i64 ptrtoint (ptr @1 to i64) to <2 x i32>), i32 1)"
     ), (
      "addrspacecast",
-     (PointerType i32 (AddrSpace 1)),
-     C.AddrSpaceCast (C.GlobalReference (ptr i32) (UnName 1)) (PointerType i32 (AddrSpace 1)),
-     "global i32 addrspace(1)* addrspacecast (i32* @1 to i32 addrspace(1)*)"
+     (PointerType (AddrSpace 1)),
+     C.AddrSpaceCast (C.GlobalReference (UnName 1)) (PointerType (AddrSpace 1)),
+     "global ptr addrspace(1) addrspacecast (ptr @1 to ptr addrspace(1))"
 {-    ), (
 -- This test fails since LLVM 3.2!
 -- LLVM parses the extractValue instruction from a file via llvm-as properly, but it does not here.

--- a/llvm-hs/test/LLVM/Test/InlineAssembly.hs
+++ b/llvm-hs/test/LLVM/Test/InlineAssembly.hs
@@ -21,7 +21,7 @@ import qualified LLVM.AST.Global as G
 tests = testGroup "InlineAssembly" [
   testCase "expression" $ do
     let ast = Module "<string>" "<string>" Nothing Nothing [
-                GlobalDefinition $ 
+                GlobalDefinition $
                   functionDefaults {
                     G.returnType = i32,
                     G.name = Name "foo",
@@ -32,6 +32,7 @@ tests = testGroup "InlineAssembly" [
                           tailCallKind = Nothing,
                           callingConvention = CC.C,
                           returnAttributes = [],
+                          LLVM.AST.type' = FunctionType i32 [i32] False,
                           function = Left $ InlineAssembly {
                                        IA.type' = FunctionType i32 [i32] False,
                                        assembly = "bswap $0",

--- a/llvm-hs/test/LLVM/Test/Instrumentation.hs
+++ b/llvm-hs/test/LLVM/Test/Instrumentation.hs
@@ -117,7 +117,7 @@ ast = do
     G.name = Name "main",
     G.parameters = ([
       Parameter i32 (Name "argc") [],
-      Parameter (ptr (ptr i8)) (Name "argv") []
+      Parameter ptr (Name "argv") []
      ],False),
     G.basicBlocks = [
       BasicBlock (UnName 0) [
@@ -125,12 +125,10 @@ ast = do
           tailCallKind = Nothing,
           callingConvention = CC.C,
           returnAttributes = [],
+          type' = FunctionType i32 [i128] False,
           function = Right
             (ConstantOperand
               (C.GlobalReference
-                 (PointerType
-                    { pointerReferent = FunctionType i32 [i128] False
-                    , pointerAddrSpace = AddrSpace 0})
                  (Name "foo"))),
           arguments = [
            (ConstantOperand (C.Int 128 9491828328), [])

--- a/llvm-hs/test/LLVM/Test/Metadata.hs
+++ b/llvm-hs/test/LLVM/Test/Metadata.hs
@@ -827,7 +827,7 @@ cyclicMetadata = testGroup "cyclic" [
              },
             MetadataNodeDefinition
               (MetadataNodeID 0)
-              (MDTuple [Just $ MDValue $ ConstantOperand (C.GlobalReference (ptr (FunctionType A.T.void [] False)) (Name "foo"))])
+              (MDTuple [Just $ MDValue $ ConstantOperand (C.GlobalReference (Name "foo"))])
            ]
       let s = "; ModuleID = '<string>'\n\
               \source_filename = \"<string>\"\n\
@@ -836,7 +836,7 @@ cyclicMetadata = testGroup "cyclic" [
               \  ret void, !my-metadatum !0\n\
               \}\n\
               \\n\
-              \!0 = !{void ()* @foo}\n"
+              \!0 = !{ptr @foo}\n"
       strCheck ast s
    ]
 

--- a/llvm-hs/test/LLVM/Test/Regression.hs
+++ b/llvm-hs/test/LLVM/Test/Regression.hs
@@ -35,66 +35,11 @@ example1 =
                   , UnName 1 :=
                     Store
                       False
-                      (LocalReference (ptr i32) (UnName 0))
+                      (LocalReference ptr (UnName 0))
                       (ConstantOperand (C.Int 32 42))
                       Nothing
                       0
                       []
-                  ]
-                  (Do $ Ret Nothing [])
-              ]
-          }
-      ]
-  }
-
-example2 :: AST.Module
-example2 =
-  defaultModule
-  { moduleDefinitions =
-      [ GlobalDefinition
-          functionDefaults
-          { name = "test"
-          , returnType = void
-          , basicBlocks =
-              [ BasicBlock
-                  "entry"
-                  [ UnName 0 :=
-                    Alloca (ptr $ FunctionType void [] False) Nothing 0 []
-                  , Do $
-                    Store
-                      False
-                      (LocalReference
-                         (ptr $ ptr $ FunctionType void [] False)
-                         (UnName 0))
-                      (ConstantOperand $
-                       C.GlobalReference (FunctionType void [] False) "test")
-                      Nothing
-                      0
-                      []
-                  ]
-                  (Do $ Ret Nothing [])
-              ]
-          }
-      ]
-  }
-
-example3 :: AST.Module
-example3 =
-  defaultModule
-  { moduleDefinitions =
-      [ GlobalDefinition
-          functionDefaults
-          { name = "test"
-          , returnType = void
-          , basicBlocks =
-              [ BasicBlock
-                  "entry"
-                  [ UnName 0 := GetElementPtr {
-                      inBounds = False,
-                      address = ConstantOperand (C.Null i32),
-                      indices = [ ConstantOperand (C.Int 32 0) ],
-                      metadata = []
-                    }
                   ]
                   (Do $ Ret Nothing [])
               ]
@@ -202,15 +147,7 @@ tests =
     [ testCase
         "no named voids"
         (example1 `shouldThrowEncodeException`
-         "Instruction of type void must not have a name: UnName 1 := Store {volatile = False, address = LocalReference (PointerType {pointerReferent = IntegerType {typeBits = 32}, pointerAddrSpace = AddrSpace 0}) (UnName 0), value = ConstantOperand (Int {integerBits = 32, integerValue = 42}), maybeAtomicity = Nothing, alignment = 0, metadata = []}")
-    , testCase
-        "no implicit casts"
-        (example2 `shouldThrowEncodeException`
-         "The serialized GlobalReference Name \"test\" has type FunctionType {resultType = VoidType, argumentTypes = [], isVarArg = False} but should have type PointerType {pointerReferent = FunctionType {resultType = VoidType, argumentTypes = [], isVarArg = False}, pointerAddrSpace = AddrSpace 0}")
-    , testCase
-        "null constants must have pointer type"
-        (example3 `shouldThrowEncodeException`
-          "Null pointer constant must have pointer type but has type IntegerType {typeBits = 32}.")
+         "Instruction of type void must not have a name: UnName 1 := Store {volatile = False, address = LocalReference (PointerType {pointerAddrSpace = AddrSpace 0}) (UnName 0), value = ConstantOperand (Int {integerBits = 32, integerValue = 42}), maybeAtomicity = Nothing, alignment = 0, metadata = []}")
     , testCase
         "Duplicate definitions are not allowed"
         (duplicateDefinitions `shouldThrowEncodeException`

--- a/llvm-hs/test/LLVM/Test/Support.hs
+++ b/llvm-hs/test/LLVM/Test/Support.hs
@@ -20,6 +20,7 @@ import Text.Show.Pretty
 import LLVM.Context
 import LLVM.Module
 import LLVM.Diagnostic
+import LLVM.Target
 
 withModuleFromLLVMAssembly' :: Context -> ByteString -> (Module -> IO a) -> IO a
 withModuleFromLLVMAssembly' c s f  = withModuleFromLLVMAssembly c s f
@@ -40,3 +41,6 @@ strCheck mAST mStr = strCheckC mAST mStr mStr
 
 arbitrarySbs :: Gen ShortByteString
 arbitrarySbs = BSS.pack <$> listOf arbitrary
+
+withTargets :: TestTree -> TestTree
+withTargets = withResource initializeAllTargets return . const

--- a/llvm-hs/test/LLVM/Test/Target.hs
+++ b/llvm-hs/test/LLVM/Test/Target.hs
@@ -133,6 +133,7 @@ tests = testGroup "Target" [
                reloc = Reloc.Default
                codeModel = CodeModel.Default
                codeGenOpt = CodeGenOpt.Default
+           initializeAllTargets
            (target, _) <- lookupTarget Nothing triple
            withTargetMachine target triple cpu features to reloc codeModel codeGenOpt $ \tm -> do
              options' <- peekTargetOptions =<< targetMachineOptions tm

--- a/llvm-hs/test/LLVM/Test/Tests.hs
+++ b/llvm-hs/test/LLVM/Test/Tests.hs
@@ -22,8 +22,10 @@ import qualified LLVM.Test.OrcJIT as OrcJIT
 import qualified LLVM.Test.ParameterAttribute as ParameterAttribute
 import qualified LLVM.Test.Target as Target
 import qualified LLVM.Test.Regression as Regression
+import qualified LLVM.Test.Support as Support
 
-tests = testGroup "llvm-hs" [
+
+tests = Support.withTargets $ testGroup "llvm-hs" [
     CallingConvention.tests,
     Constants.tests,
     DataLayout.tests,


### PR DESCRIPTION
LLVM devs are currently busy at work cleaning up the typed pointer types
that have been deprecated a while back, and that are the only ones
representable in llvm-hs at the moment. This patch rewrites the whole
library to work with opaque pointers (i.e. ones that are not labeled
with the pointee type, only by their address space). They've been just
enabled by default in clang, so it seems like high time for us to make
the switch.

See the [migration guide](https://llvm.org/docs/OpaquePointers.html) for extra context.