### PR TITLE
Update to LLVM HEAD

### DIFF
--- a/llvm-hs-pure/src/LLVM/AST/Constant.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Constant.hs
@@ -64,16 +64,6 @@ data Constant
         operand0 :: Constant,
         operand1 :: Constant
       }
-    | UDiv {
-        exact :: Bool,
-        operand0 :: Constant,
-        operand1 :: Constant
-      }
-    | SDiv {
-        exact :: Bool,
-        operand0 :: Constant,
-        operand1 :: Constant
-      }
     | FDiv {
         operand0 :: Constant,
         operand1 :: Constant
@@ -204,15 +194,6 @@ data Constant
         operand0 :: Constant,
         operand1 :: Constant,
         mask :: Constant
-      }
-    | ExtractValue {
-        aggregate :: Constant,
-        indices' :: [Word32]
-      }
-    | InsertValue {
-        aggregate :: Constant,
-        element :: Constant,
-        indices' :: [Word32]
       }
     deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
 

--- a/llvm-hs-pure/src/LLVM/AST/Typed.hs
+++ b/llvm-hs-pure/src/LLVM/AST/Typed.hs
@@ -70,8 +70,6 @@ instance Typed C.Constant where
   typeOf (C.FSub {..})    = typeOf operand0
   typeOf (C.Mul {..})     = typeOf operand0
   typeOf (C.FMul {..})    = typeOf operand0
-  typeOf (C.UDiv {..})    = typeOf operand0
-  typeOf (C.SDiv {..})    = typeOf operand0
   typeOf (C.URem {..})    = typeOf operand0
   typeOf (C.SRem {..})    = typeOf operand0
   typeOf (C.Shl {..})     = typeOf operand0
@@ -119,12 +117,6 @@ instance Typed C.Constant where
     case (t0, tm) of
       (Right (VectorType _ t), Right (VectorType m _)) -> return $ Right $ VectorType m t
       _ -> return $ Left "The first operand of an shufflevector instruction is a value of vector type. (Malformed AST)"
-  typeOf (C.ExtractValue {..})    = do
-    t <- typeOf aggregate
-    case t of
-      (Left _) -> return t
-      (Right t') -> extractValueType indices' t'
-  typeOf (C.InsertValue {..})   = typeOf aggregate
   typeOf (C.TokenNone)          = return $ Right TokenType
   typeOf (C.AddrSpaceCast {..}) = return $ Right type'
 

--- a/llvm-hs/src/LLVM/Internal/Constant.hs
+++ b/llvm-hs/src/LLVM/Internal/Constant.hs
@@ -284,14 +284,6 @@ instance DecodeM DecodeAST A.Constant (Ptr FFI.Constant) where
                                                       "nuw" -> return [| liftIO $ decodeM =<< FFI.hasNoUnsignedWrap v |]
                                                       x -> error $ "constant bool field " ++ show x ++ " not handled yet"
                                  TH.AppT TH.ListT (TH.ConT h)
-                                   | h == ''Word32 ->
-                                      return [|
-                                            do
-                                              np <- alloca
-                                              isp <- liftIO $ FFI.getConstantIndices c np
-                                              n <- peek np
-                                              decodeM (n, isp)
-                                            |]
                                    | h == ''A.Constant &&
                                      TH.nameBase fn == "indices" -> do
                                        operandNumber <- get

--- a/llvm-hs/src/LLVM/Internal/FFI/Attribute.h
+++ b/llvm-hs/src/LLVM/Internal/FFI/Attribute.h
@@ -14,6 +14,7 @@
   macro(Cold,F,F,T)                                 \
   macro(Convergent,F,F,T)                           \
   macro(DisableSanitizerInstrumentation,F,F,T)      \
+  macro(FnRetThunkExtern,F,F,T)                     \
   macro(Hot,F,F,T)                                  \
   macro(ImmArg,T,F,F)                               \
   macro(InReg,T,T,F)                                \
@@ -50,6 +51,7 @@
   macro(OptForFuzzing,F,F,T)                        \
   macro(OptimizeForSize,F,F,T)                      \
   macro(OptimizeNone,F,F,T)                         \
+  macro(PresplitCoroutine,F,F,T)                    \
   macro(ReadNone,T,F,T)                             \
   macro(ReadOnly,T,F,T)                             \
   macro(Returned,T,F,F)                             \
@@ -81,6 +83,7 @@
   macro(Preallocated,F,F,T)                         \
   macro(StructRet,T,F,F)                            \
   macro(Alignment,T,T,F)                            \
+  macro(AllocKind,F,F,T)                            \
   macro(AllocSize,F,F,T)                            \
   macro(Dereferenceable,T,T,F)                      \
   macro(DereferenceableOrNull,T,T,F)                \

--- a/llvm-hs/src/LLVM/Internal/FFI/Constant.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Constant.hs
@@ -133,9 +133,6 @@ foreign import ccall unsafe "LLVM_Hs_GetConstPredicate" getConstantICmpPredicate
 foreign import ccall unsafe "LLVM_Hs_GetConstPredicate" getConstantFCmpPredicate ::
   Ptr Constant -> IO FCmpPredicate
 
-foreign import ccall unsafe "LLVM_Hs_GetConstIndices" getConstantIndices ::
-  Ptr Constant -> Ptr CUInt -> IO (Ptr CUInt)
-
 foreign import ccall unsafe "LLVMGetUndef" constantUndef ::
   Ptr Type -> IO (Ptr Constant)
 

--- a/llvm-hs/src/LLVM/Internal/FFI/ConstantC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/ConstantC.cpp
@@ -69,14 +69,6 @@ LLVMValueRef LLVM_Hs_ConstSub(unsigned nsw, unsigned nuw, LLVMValueRef o0, LLVMV
     return wrap(ConstantExpr::getSub(unwrap<Constant>(o0), unwrap<Constant>(o1), nuw != 0, nsw != 0));
 }
 
-LLVMValueRef LLVM_Hs_ConstUDiv(unsigned isExact, LLVMValueRef o0, LLVMValueRef o1) {
-    return wrap(ConstantExpr::getUDiv(unwrap<Constant>(o0), unwrap<Constant>(o1), isExact != 0));
-}
-
-LLVMValueRef LLVM_Hs_ConstSDiv(unsigned isExact, LLVMValueRef o0, LLVMValueRef o1) {
-    return wrap(ConstantExpr::getSDiv(unwrap<Constant>(o0), unwrap<Constant>(o1), isExact != 0));
-}
-
 LLVMValueRef LLVM_Hs_ConstLShr(unsigned isExact, LLVMValueRef o0, LLVMValueRef o1) {
     return wrap(ConstantExpr::getLShr(unwrap<Constant>(o0), unwrap<Constant>(o1), isExact != 0));
 }
@@ -91,12 +83,6 @@ unsigned LLVM_Hs_GetConstCPPOpcode(LLVMValueRef v) {
 
 unsigned LLVM_Hs_GetConstPredicate(LLVMValueRef v) {
     return unwrap<ConstantExpr>(v)->getPredicate();
-}
-
-const unsigned *LLVM_Hs_GetConstIndices(LLVMValueRef v, unsigned *n) {
-    ArrayRef<unsigned> r = unwrap<ConstantExpr>(v)->getIndices();
-    *n = r.size();
-    return r.data();
 }
 
 const uint64_t *LLVM_Hs_GetConstantIntWords(LLVMValueRef v, unsigned *n) {

--- a/llvm-hs/src/LLVM/Internal/FFI/Target.h
+++ b/llvm-hs/src/LLVM/Internal/FFI/Target.h
@@ -89,7 +89,6 @@ typedef enum {
 
 #define LLVM_HS_FOR_EACH_DEBUG_COMPRESSION_TYPE(macro) \
     macro(None) \
-    macro(GNU) \
     macro(Z)
 
 typedef enum {

--- a/llvm-hs/src/LLVM/Internal/Target.hs
+++ b/llvm-hs/src/LLVM/Internal/Target.hs
@@ -79,7 +79,6 @@ genCodingInstance [t| TO.FloatingPointOperationFusionMode |] ''FFI.FPOpFusionMod
 
 genCodingInstance[t| TO.DebugCompressionType |] ''FFI.DebugCompressionType [
   (FFI.debugCompressionTypeNone, TO.CompressNone),
-  (FFI.debugCompressionTypeGNU, TO.CompressGNU),
   (FFI.debugCompressionTypeZ, TO.CompressZ)
   ]
 

--- a/llvm-hs/src/LLVM/Target/Options.hs
+++ b/llvm-hs/src/LLVM/Target/Options.hs
@@ -20,7 +20,6 @@ data FloatingPointOperationFusionMode
 -- | <https://llvm.org/doxygen/namespacellvm.html#aa100a124c9d33561b0950011928aae00>
 data DebugCompressionType
   = CompressNone -- ^ No compression
-  | CompressGNU -- ^ zlib-gnu style compression
   | CompressZ -- ^ zlib style compression
   deriving (Eq, Ord, Read, Show, Enum, Bounded, Typeable, Data, Generic)
 

--- a/llvm-hs/test/LLVM/Test/FunctionAttribute.hs
+++ b/llvm-hs/test/LLVM/Test/FunctionAttribute.hs
@@ -78,7 +78,7 @@ instance Arbitrary FunctionAttribute where
     , StackAlignment <$> elements (map (2^) [0..8 :: Int])
     , StringAttribute <$> (B.pack <$> arbitrary) <*> (B.pack <$> arbitrary)
     , suchThat (AllocSize <$> arbitrary <*> arbitrary) (/= AllocSize 0 (Just 0))
-    , suchThat (VScaleRange <$> arbitrary <*> arbitrary) (\(VScaleRange l h) -> l <= h)
+    , suchThat (VScaleRange <$> arbitrary <*> arbitrary) (\(VScaleRange l h) -> l <= h && h /= 0)
     ]
 
   shrink = \case

--- a/llvm-hs/test/LLVM/Test/Target.hs
+++ b/llvm-hs/test/LLVM/Test/Target.hs
@@ -104,7 +104,7 @@ instance Arbitrary MachineCodeOptions where
     return MachineCodeOptions { .. }
 
 instance Arbitrary DebugCompressionType where
-  arbitrary = elements [CompressNone, CompressGNU, CompressZ]
+  arbitrary = elements [CompressNone, CompressZ]
 
 arbitraryASCIIString :: Gen String
 #if MIN_VERSION_QuickCheck(2,10,0)


### PR DESCRIPTION
Most notably, a bunch of constant expressions have been removed.

Also, don't create trivial VScaleRange function attributes in tests to fix a flaky test.