### PR TITLE
Support for GHC 9.0, 9.2 and 9.4

### DIFF
--- a/llvm-hs-pure/llvm-hs-pure.cabal
+++ b/llvm-hs-pure/llvm-hs-pure.cabal
@@ -30,7 +30,7 @@ library
   build-depends:
     base >= 4.9 && < 5,
     attoparsec >= 0.13,
-    bytestring >= 0.10 && < 0.11,
+    bytestring >= 0.10 && < 0.12,
     fail,
     transformers >= 0.3 && < 0.6,
     mtl >= 2.1,

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -31,7 +31,7 @@ import Control.Monad.Trans.Identity
 #endif
 
 import Data.Bifunctor
-import Data.ByteString.Short as BS
+import Data.ByteString.Short (ShortByteString)
 import Data.Char
 import Data.Data
 import Data.Foldable

--- a/llvm-hs/Setup.hs
+++ b/llvm-hs/Setup.hs
@@ -170,6 +170,9 @@ main = do
           newHsc buildInfo localBuildInfo =
 #endif
               PreProcessor {
+#if MIN_VERSION_Cabal(3,8,0)
+                  ppOrdering = \_ _ ms -> pure ms,
+#endif
                   platformIndependent = platformIndependent (origHsc buildInfo),
                   runPreProcessor = \inFiles outFiles verbosity -> do
                       llvmConfig <- getLLVMConfig (configFlags localBuildInfo)

--- a/llvm-hs/Setup.hs
+++ b/llvm-hs/Setup.hs
@@ -171,7 +171,7 @@ main = do
 #endif
               PreProcessor {
 #if MIN_VERSION_Cabal(3,8,0)
-                  ppOrdering = \_ _ ms -> pure ms,
+                  ppOrdering = unsorted,
 #endif
                   platformIndependent = platformIndependent (origHsc buildInfo),
                   runPreProcessor = \inFiles outFiles verbosity -> do

--- a/llvm-hs/src/Control/Monad/AnyCont.hs
+++ b/llvm-hs/src/Control/Monad/AnyCont.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE
   MultiParamTypeClasses,
-  UndecidableInstances
+  UndecidableInstances,
+  FlexibleContexts,
+  FlexibleInstances
   #-}
 module Control.Monad.AnyCont (
     MonadAnyCont(..),

--- a/llvm-hs/src/Control/Monad/AnyCont/Class.hs
+++ b/llvm-hs/src/Control/Monad/AnyCont/Class.hs
@@ -24,7 +24,7 @@ instance MonadTransAnyCont b m => MonadAnyCont b (AnyContT m) where
   anyContToM c = AnyCont.anyContT (liftAnyCont c)
 
 instance Monad m => ScopeAnyCont (AnyContT m) where
-  scopeAnyCont = lift . flip AnyCont.runAnyContT return
+  scopeAnyCont a = lift (((\cont -> AnyCont.runAnyContT cont return)) a)
 
 
 instance (Monad m, MonadAnyCont b m) => MonadAnyCont b (StateT s m) where

--- a/llvm-hs/src/LLVM/Internal/Analysis.hs
+++ b/llvm-hs/src/LLVM/Internal/Analysis.hs
@@ -17,7 +17,7 @@ import LLVM.Exception
 -- | Run basic sanity checks on a 'Module'. Note that the same checks will trigger assertions
 -- within LLVM if LLVM was built with them turned on, before this function can be is called.
 verify :: Module -> IO ()
-verify m = flip runAnyContT return $ do
+verify m = (\cont -> runAnyContT cont return) $ do
   errorPtr <- alloca
   m' <- readModule m
   result <- decodeM =<< (liftIO $ FFI.verifyModule m' FFI.verifierFailureActionReturnStatus errorPtr)

--- a/llvm-hs/src/LLVM/Internal/CommandLine.hs
+++ b/llvm-hs/src/LLVM/Internal/CommandLine.hs
@@ -17,7 +17,7 @@ import LLVM.Internal.String ()
 -- in LLVM which are accessible only as command line flags setting global state,
 -- as if the command line tools were the only use of LLVM. Very sad.
 parseCommandLineOptions :: [ShortByteString] -> Maybe ShortByteString -> IO ()
-parseCommandLineOptions args overview = flip runAnyContT return $ do
+parseCommandLineOptions args overview = (\cont -> runAnyContT cont return) $ do
   args <- encodeM args
   overview <- maybe (return nullPtr) encodeM overview
   liftIO $ FFI.parseCommandLineOptions args overview

--- a/llvm-hs/src/LLVM/Internal/DataLayout.hs
+++ b/llvm-hs/src/LLVM/Internal/DataLayout.hs
@@ -17,7 +17,7 @@ import LLVM.Internal.Coding
 import LLVM.Internal.String ()
 
 withFFIDataLayout :: DataLayout -> (Ptr FFI.DataLayout -> IO a) -> IO a
-withFFIDataLayout dl f = flip runAnyContT return $ do
+withFFIDataLayout dl f = (\cont -> runAnyContT cont return) $ do
   dls <- encodeM (dataLayoutToString dl)
   liftIO $ bracket (FFI.createDataLayout dls) FFI.disposeDataLayout f
 

--- a/llvm-hs/src/LLVM/Internal/DecodeAST.hs
+++ b/llvm-hs/src/LLVM/Internal/DecodeAST.hs
@@ -80,7 +80,7 @@ newtype DecodeAST a = DecodeAST { unDecodeAST :: AnyContT (StateT DecodeState IO
   )
 
 runDecodeAST :: DecodeAST a -> IO a
-runDecodeAST d = flip evalStateT initialDecode . flip runAnyContT return . unDecodeAST $ d
+runDecodeAST d = flip evalStateT initialDecode . (\cont -> runAnyContT cont return) . unDecodeAST $ d
 
 localScope :: DecodeAST a -> DecodeAST a
 localScope (DecodeAST x) = DecodeAST (tweak x)

--- a/llvm-hs/src/LLVM/Internal/EncodeAST.hs
+++ b/llvm-hs/src/LLVM/Internal/EncodeAST.hs
@@ -92,7 +92,7 @@ runEncodeAST context@(Context ctx) (EncodeAST a) =
               encodeStateAttributeGroups = Map.empty,
               encodeStateCOMDATs = Map.empty
             }
-      flip evalStateT initEncodeState . flip runAnyContT return $ a
+      flip evalStateT initEncodeState . (\cont -> runAnyContT cont return) $ a
 
 withName :: A.Name -> (CString -> IO a) -> IO a
 withName (A.Name n) = ShortByteString.useAsCString n

--- a/llvm-hs/src/LLVM/Internal/ExecutionEngine.hs
+++ b/llvm-hs/src/LLVM/Internal/ExecutionEngine.hs
@@ -31,7 +31,7 @@ import qualified LLVM.AST as A
 import GHC.Stack
 
 removeModule :: Ptr FFI.ExecutionEngine -> Ptr FFI.Module -> IO ()
-removeModule e m = flip runAnyContT return $ do
+removeModule e m = (\cont -> runAnyContT cont return) $ do
   d0 <- alloca
   d1 <- alloca
   r <- liftIO $ FFI.removeModule e m d0 d1
@@ -50,7 +50,7 @@ instance ExecutionEngine (Ptr FFI.ExecutionEngine) (FunPtr ()) where
   withModuleInEngine e m f = do
     m' <- readModule m
     bracket_ (FFI.addModule e m') (removeModule e m') (f (ExecutableModule e m'))
-  getFunction (ExecutableModule e m) (A.Name name) = flip runAnyContT return $ do
+  getFunction (ExecutableModule e m) (A.Name name) = (\cont -> runAnyContT cont return) $ do
     name <- encodeM name
     f <- liftIO $ FFI.getNamedFunction m name
     if f == nullPtr 
@@ -68,7 +68,7 @@ withExecutionEngine ::
   (Ptr (Ptr FFI.ExecutionEngine) -> Ptr FFI.Module -> Ptr (FFI.OwnerTransfered CString) -> IO CUInt) ->
   (Ptr FFI.ExecutionEngine -> IO a) ->
   IO a
-withExecutionEngine c m createEngine f = flip runAnyContT return $ do
+withExecutionEngine c m createEngine f = (\cont -> runAnyContT cont return) $ do
   liftIO initializeNativeTarget
   outExecutionEngine <- alloca
   outErrorCStringPtr <- alloca

--- a/llvm-hs/src/LLVM/Internal/Module.hs
+++ b/llvm-hs/src/LLVM/Internal/Module.hs
@@ -97,7 +97,7 @@ linkModules ::
      Module -- ^ The module into which to link
   -> Module -- ^ The module to link into the other (this module is destroyed)
   -> IO ()
-linkModules dest src  = flip runAnyContT return $ do
+linkModules dest src  = (\cont -> runAnyContT cont return) $ do
   dest' <- readModule dest
   src' <- readModule src
   result <- decodeM =<< liftIO (FFI.linkModules dest' src')
@@ -130,7 +130,7 @@ instance LLVMAssemblyInput File where
 -- | parse 'Module' from LLVM assembly. May throw 'ParseFailureException'.
 withModuleFromLLVMAssembly :: LLVMAssemblyInput s
                               => Context -> s -> (Module -> IO a) -> IO a
-withModuleFromLLVMAssembly (Context c) s f = flip runAnyContT return $ do
+withModuleFromLLVMAssembly (Context c) s f = (\cont -> runAnyContT cont return) $ do
   mb <- llvmAssemblyMemoryBuffer s
   msgPtr <- alloca
   m <- anyContToM $ bracket (newModule =<< FFI.parseLLVMAssembly c mb msgPtr) (FFI.disposeModule <=< readModule)
@@ -153,7 +153,7 @@ moduleLLVMAssembly m = do
 
 -- | write LLVM assembly for a 'Module' to a file
 writeLLVMAssemblyToFile :: File -> Module -> IO ()
-writeLLVMAssemblyToFile (File path) m = flip runAnyContT return $ do
+writeLLVMAssemblyToFile (File path) m = (\cont -> runAnyContT cont return) $ do
   m' <- readModule m
   withFileRawOStream path False True $ FFI.writeLLVMAssembly m'
 
@@ -169,7 +169,7 @@ instance BitcodeInput File where
 
 -- | parse 'Module' from LLVM bitcode. May throw 'ParseFailureException'.
 withModuleFromBitcode :: BitcodeInput b => Context -> b -> (Module -> IO a) -> IO a
-withModuleFromBitcode (Context c) b f = flip runAnyContT return $ do
+withModuleFromBitcode (Context c) b f = (\cont -> runAnyContT cont return) $ do
   mb <- bitcodeMemoryBuffer b
   msgPtr <- alloca
   m <- anyContToM $ bracket (newModule =<< FFI.parseBitcode c mb msgPtr) (FFI.disposeModule <=< readModule)
@@ -185,13 +185,13 @@ moduleBitcode m = do
 
 -- | write LLVM bitcode from a 'Module' into a file
 writeBitcodeToFile :: File -> Module -> IO ()
-writeBitcodeToFile (File path) m = flip runAnyContT return $ do
+writeBitcodeToFile (File path) m = (\cont -> runAnyContT cont return) $ do
   m' <- readModule m
   withFileRawOStream path False False $ FFI.writeBitcode m'
 
 -- | May throw 'TargetMachineEmitException'.
 targetMachineEmit :: FFI.CodeGenFileType -> TargetMachine -> Module -> Ptr FFI.RawPWriteStream -> IO ()
-targetMachineEmit fileType (TargetMachine tm) m os = flip runAnyContT return $ do
+targetMachineEmit fileType (TargetMachine tm) m os = (\cont -> runAnyContT cont return) $ do
   msgPtr <- alloca
   m' <- readModule m
   r <- decodeM =<< (liftIO $ FFI.targetMachineEmit tm m' os fileType msgPtr)
@@ -199,12 +199,12 @@ targetMachineEmit fileType (TargetMachine tm) m os = flip runAnyContT return $ d
 
 -- | May throw 'FdStreamException' and 'TargetMachineEmitException'.
 emitToFile :: FFI.CodeGenFileType -> TargetMachine -> File -> Module -> IO ()
-emitToFile fileType tm (File path) m = flip runAnyContT return $ do
+emitToFile fileType tm (File path) m = (\cont -> runAnyContT cont return) $ do
   withFileRawPWriteStream path False False $ targetMachineEmit fileType tm m
 
 -- | May throw 'TargetMachineEmitException'.
 emitToByteString :: FFI.CodeGenFileType -> TargetMachine -> Module -> IO BS.ByteString
-emitToByteString fileType tm m = flip runAnyContT return $ do
+emitToByteString fileType tm m = (\cont -> runAnyContT cont return) $ do
   withBufferRawPWriteStream $ targetMachineEmit fileType tm m
 
 -- | write target-specific assembly directly into a file

--- a/llvm-hs/src/LLVM/Internal/ObjectFile.hs
+++ b/llvm-hs/src/LLVM/Internal/ObjectFile.hs
@@ -24,7 +24,7 @@ disposeObjectFile (ObjectFile obj) = FFI.disposeObjectFile obj
 -- Note that the file at `path` should already be a compiled object file i.e a
 -- `.o` file. This does *not* compile source files.
 createObjectFile :: HasCallStack => FilePath -> IO ObjectFile
-createObjectFile path = flip runAnyContT return $ do
+createObjectFile path = (\cont -> runAnyContT cont return) $ do
   -- The ownership of the object file is transfered to the object
   -- file, so we need to make sure that we do not free it here.
   FFI.OwnerTransfered buf <- encodeM (File path)

--- a/llvm-hs/src/LLVM/Internal/Operand.hs
+++ b/llvm-hs/src/LLVM/Internal/Operand.hs
@@ -789,8 +789,17 @@ instance EncodeM EncodeAST A.DILocalVariable (Ptr FFI.DILocalVariable) where
 
 instance EncodeM EncodeAST A.DITemplateParameter (Ptr FFI.DITemplateParameter) where
   encodeM p = do
-    name' <- encodeM (A.name (p :: A.DITemplateParameter)) :: EncodeAST (Ptr FFI.MDString)
-    ty <- encodeM (A.type' (p :: A.DITemplateParameter))
+    -- As of GHC 9.4.1, selector names have to be entirely unambiguous (under the
+    -- usual name resolution rules)
+    -- However, this type is ambiguous for reason not yet understood.
+    -- One solution would be to use OverloadedRecordDot, using p.name and p.type',
+    -- but it requireds GHC 9.2.
+    -- The solution here is to just extract the values
+    let (name, type') = case p of
+               A.DITemplateTypeParameter{name, type'} -> (name, type')
+               A.DITemplateValueParameter{name, type'} -> (name, type')
+    name' <- encodeM name :: EncodeAST (Ptr FFI.MDString)
+    ty <- encodeM type'
     Context c <- gets encodeStateContext
     case p of
       A.DITemplateTypeParameter {} ->

--- a/llvm-hs/src/LLVM/Internal/Operand.hs
+++ b/llvm-hs/src/LLVM/Internal/Operand.hs
@@ -45,6 +45,71 @@ import qualified LLVM.AST.Operand as A
 
 import LLVM.Internal.FFI.LLVMCTypes (mdSubclassIdP)
 
+genCodingInstance [t|A.DebugNameTableKind|] ''FFI.DebugNameTableKind
+  [ (FFI.NameTableKindDefault, A.NameTableKindDefault)
+  , (FFI.NameTableKindGNU, A.NameTableKindGNU)
+  , (FFI.NameTableKindNone, A.NameTableKindNone)
+  ]
+
+genCodingInstance [t|A.Encoding|] ''FFI.Encoding
+  [ (FFI.DwAtE_address, A.AddressEncoding)
+  , (FFI.DwAtE_boolean, A.BooleanEncoding)
+  , (FFI.DwAtE_float, A.FloatEncoding)
+  , (FFI.DwAtE_signed, A.SignedEncoding)
+  , (FFI.DwAtE_signed_char, A.SignedCharEncoding)
+  , (FFI.DwAtE_unsigned, A.UnsignedEncoding)
+  , (FFI.DwAtE_unsigned_char, A.UnsignedCharEncoding)
+  , (FFI.DwAtE_UTF, A.UTFEncoding)
+  ]
+
+genCodingInstance [t|A.ChecksumKind|] ''FFI.ChecksumKind
+  [ (FFI.ChecksumKind 1, A.MD5)
+  , (FFI.ChecksumKind 2, A.SHA1)
+  ]
+
+genCodingInstance [t|A.BasicTypeTag|] ''FFI.DwTag
+  [ (FFI.DwTag_base_type, A.BaseType)
+  , (FFI.DwTag_unspecified_type, A.UnspecifiedType)
+  ]
+
+genCodingInstance [t|A.DerivedTypeTag|] ''FFI.DwTag
+  [ (FFI.DwTag_typedef, A.Typedef)
+  , (FFI.DwTag_pointer_type, A.PointerType)
+  , (FFI.DwTag_ptr_to_member_type, A.PtrToMemberType)
+  , (FFI.DwTag_reference_type, A.ReferenceType)
+  , (FFI.DwTag_rvalue_reference_type, A.RValueReferenceType)
+  , (FFI.DwTag_const_type, A.ConstType)
+  , (FFI.DwTag_volatile_type, A.VolatileType)
+  , (FFI.DwTag_restrict_type, A.RestrictType)
+  , (FFI.DwTag_atomic_type, A.AtomicType)
+  , (FFI.DwTag_member, A.Member)
+  , (FFI.DwTag_inheritance, A.Inheritance)
+  , (FFI.DwTag_friend, A.Friend)
+  ]
+
+genCodingInstance [t|A.TemplateValueParameterTag|] ''FFI.DwTag
+  [ (FFI.DwTag_template_value_parameter, A.TemplateValueParameter)
+  , (FFI.DwTag_GNU_template_template_param, A.GNUTemplateTemplateParam)
+  , (FFI.DwTag_GNU_template_parameter_pack, A.GNUTemplateParameterPack)
+  ]
+genCodingInstance [t|A.Virtuality|] ''FFI.DwVirtuality
+  [ (FFI.DwVirtuality_none, A.NoVirtuality)
+  , (FFI.DwVirtuality_virtual, A.Virtual)
+  , (FFI.DwVirtuality_pure_virtual, A.PureVirtual)
+  ]
+genCodingInstance [t|A.DIMacroInfo|] ''FFI.Macinfo [ (FFI.DW_Macinfo_Define, A.Define), (FFI.DW_Macinfo_Undef, A.Undef) ]
+
+genCodingInstance [t|A.ImportedEntityTag|] ''FFI.DwTag
+  [ (FFI.DwTag_imported_module, A.ImportedModule)
+  , (FFI.DwTag_imported_declaration, A.ImportedDeclaration)
+  ]
+
+genCodingInstance [t|A.DebugEmissionKind|] ''FFI.DebugEmissionKind
+  [ (FFI.NoDebug, A.NoDebug)
+  , (FFI.FullDebug, A.FullDebug)
+  , (FFI.LineTablesOnly, A.LineTablesOnly)
+  ]
+
 instance EncodeM EncodeAST ShortByteString (Ptr FFI.MDString) where
   encodeM s = do
     s' <- encodeM s
@@ -324,18 +389,6 @@ instance EncodeM EncodeAST A.DIModule (Ptr FFI.DIModule) where
     Context c <- gets encodeStateContext
     liftIO (FFI.getDIModule c scope name configurationMacros includePath isysRoot)
 
-genCodingInstance [t|A.DebugEmissionKind|] ''FFI.DebugEmissionKind
-  [ (FFI.NoDebug, A.NoDebug)
-  , (FFI.FullDebug, A.FullDebug)
-  , (FFI.LineTablesOnly, A.LineTablesOnly)
-  ]
-
-genCodingInstance [t|A.DebugNameTableKind|] ''FFI.DebugNameTableKind
-  [ (FFI.NameTableKindDefault, A.NameTableKindDefault)
-  , (FFI.NameTableKindGNU, A.NameTableKindGNU)
-  , (FFI.NameTableKindNone, A.NameTableKindNone)
-  ]
-
 instance DecodeM DecodeAST A.DICompileUnit (Ptr FFI.DICompileUnit) where
   decodeM p = do
     language <- decodeM =<< liftIO (FFI.getDICompileUnitLanguage p)
@@ -449,27 +502,6 @@ instance EncodeM EncodeAST (Maybe A.Encoding) FFI.Encoding where
 instance DecodeM DecodeAST (Maybe A.Encoding) FFI.Encoding where
   decodeM (FFI.Encoding 0) = pure Nothing
   decodeM e = Just <$> decodeM e
-
-genCodingInstance [t|A.Encoding|] ''FFI.Encoding
-  [ (FFI.DwAtE_address, A.AddressEncoding)
-  , (FFI.DwAtE_boolean, A.BooleanEncoding)
-  , (FFI.DwAtE_float, A.FloatEncoding)
-  , (FFI.DwAtE_signed, A.SignedEncoding)
-  , (FFI.DwAtE_signed_char, A.SignedCharEncoding)
-  , (FFI.DwAtE_unsigned, A.UnsignedEncoding)
-  , (FFI.DwAtE_unsigned_char, A.UnsignedCharEncoding)
-  , (FFI.DwAtE_UTF, A.UTFEncoding)
-  ]
-
-genCodingInstance [t|A.ChecksumKind|] ''FFI.ChecksumKind
-  [ (FFI.ChecksumKind 1, A.MD5)
-  , (FFI.ChecksumKind 2, A.SHA1)
-  ]
-
-genCodingInstance [t|A.BasicTypeTag|] ''FFI.DwTag
-  [ (FFI.DwTag_base_type, A.BaseType)
-  , (FFI.DwTag_unspecified_type, A.UnspecifiedType)
-  ]
 
 instance EncodeM EncodeAST A.DIType (Ptr FFI.DIType) where
   encodeM (A.DIBasicType t) = FFI.upCast <$> (encodeM t :: EncodeAST (Ptr FFI.DIBasicType))
@@ -664,21 +696,6 @@ instance DecodeM DecodeAST A.DIDerivedType (Ptr FFI.DIDerivedType) where
       , A.flags = flags
       }
 
-genCodingInstance [t|A.DerivedTypeTag|] ''FFI.DwTag
-  [ (FFI.DwTag_typedef, A.Typedef)
-  , (FFI.DwTag_pointer_type, A.PointerType)
-  , (FFI.DwTag_ptr_to_member_type, A.PtrToMemberType)
-  , (FFI.DwTag_reference_type, A.ReferenceType)
-  , (FFI.DwTag_rvalue_reference_type, A.RValueReferenceType)
-  , (FFI.DwTag_const_type, A.ConstType)
-  , (FFI.DwTag_volatile_type, A.VolatileType)
-  , (FFI.DwTag_restrict_type, A.RestrictType)
-  , (FFI.DwTag_atomic_type, A.AtomicType)
-  , (FFI.DwTag_member, A.Member)
-  , (FFI.DwTag_inheritance, A.Inheritance)
-  , (FFI.DwTag_friend, A.Friend)
-  ]
-
 instance EncodeM EncodeAST A.DIVariable (Ptr FFI.DIVariable) where
   encodeM (A.DIGlobalVariable v) = do
     ptr <- encodeM v
@@ -769,11 +786,6 @@ instance EncodeM EncodeAST A.DILocalVariable (Ptr FFI.DILocalVariable) where
     Context c <- gets encodeStateContext
     FFI.upCast <$> liftIO (FFI.getDILocalVariable c scope name file line type' arg flags alignInBits)
 
-genCodingInstance [t|A.TemplateValueParameterTag|] ''FFI.DwTag
-  [ (FFI.DwTag_template_value_parameter, A.TemplateValueParameter)
-  , (FFI.DwTag_GNU_template_template_param, A.GNUTemplateTemplateParam)
-  , (FFI.DwTag_GNU_template_parameter_pack, A.GNUTemplateParameterPack)
-  ]
 
 instance EncodeM EncodeAST A.DITemplateParameter (Ptr FFI.DITemplateParameter) where
   encodeM p = do
@@ -802,11 +814,6 @@ instance DecodeM DecodeAST A.DITemplateParameter (Ptr FFI.DITemplateParameter) w
         pure (A.DITemplateValueParameter name ty value tag)
       _ -> throwM (DecodeException ("Unknown subclass id for DITemplateParameter: " <> show sId))
 
-genCodingInstance [t|A.Virtuality|] ''FFI.DwVirtuality
-  [ (FFI.DwVirtuality_none, A.NoVirtuality)
-  , (FFI.DwVirtuality_virtual, A.Virtual)
-  , (FFI.DwVirtuality_pure_virtual, A.PureVirtual)
-  ]
 
 instance DecodeM DecodeAST A.DISubprogram (Ptr FFI.DISubprogram) where
   decodeM p = do
@@ -1045,8 +1052,6 @@ instance DecodeM DecodeAST A.Operand (Ptr FFI.MDValue) where
 instance DecodeM DecodeAST A.Metadata (Ptr FFI.MetadataAsVal) where
   decodeM = decodeM <=< liftIO . FFI.getMetadataOperand
 
-genCodingInstance [t|A.DIMacroInfo|] ''FFI.Macinfo [ (FFI.DW_Macinfo_Define, A.Define), (FFI.DW_Macinfo_Undef, A.Undef) ]
-
 decodeMDNode :: Ptr FFI.MDNode -> DecodeAST (Either String A.MDNode)
 decodeMDNode p = scopeAnyCont $ do
   sId <- liftIO $ FFI.getMetadataClassId p
@@ -1164,10 +1169,6 @@ instance DecodeM DecodeAST A.DIGlobalVariableExpression (Ptr FFI.DIGlobalVariabl
     expr <- decodeM =<< liftIO (FFI.getDIGlobalVariableExpressionExpression p)
     pure (A.GlobalVariableExpression var expr)
 
-genCodingInstance [t|A.ImportedEntityTag|] ''FFI.DwTag
-  [ (FFI.DwTag_imported_module, A.ImportedModule)
-  , (FFI.DwTag_imported_declaration, A.ImportedDeclaration)
-  ]
 
 instance EncodeM EncodeAST A.DIImportedEntity (Ptr FFI.DIImportedEntity) where
   encodeM A.ImportedEntity {..} = do

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/CompileLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/CompileLayer.hs
@@ -32,7 +32,7 @@ class CompileLayer l where
 -- | Mangle a symbol according to the data layout stored in the
 -- 'CompileLayer'.
 mangleSymbol :: CompileLayer l => l -> ShortByteString -> IO MangledSymbol
-mangleSymbol compileLayer symbol = flip runAnyContT return $ do
+mangleSymbol compileLayer symbol = (\cont -> runAnyContT cont return) $ do
   mangledSymbol <- alloca
   symbol' <- encodeM symbol
   anyContToM $ bracket
@@ -44,7 +44,7 @@ mangleSymbol compileLayer symbol = flip runAnyContT return $ do
 -- @symbol@ in all modules added to @layer@. If @exportedSymbolsOnly@
 -- is 'True' only exported symbols are searched.
 findSymbol :: CompileLayer l => l -> MangledSymbol -> Bool -> IO (Either JITSymbolError JITSymbol)
-findSymbol compileLayer symbol exportedSymbolsOnly = flip runAnyContT return $ do
+findSymbol compileLayer symbol exportedSymbolsOnly = (\cont -> runAnyContT cont return) $ do
   symbol' <- encodeM symbol
   exportedSymbolsOnly' <- encodeM exportedSymbolsOnly
   symbol <- anyContToM $ bracket
@@ -55,7 +55,7 @@ findSymbol compileLayer symbol exportedSymbolsOnly = flip runAnyContT return $ d
 -- @symbol@ in the context of the module represented by @handle@. If
 -- @exportedSymbolsOnly@ is 'True' only exported symbols are searched.
 findSymbolIn :: CompileLayer l => l -> FFI.ModuleKey -> MangledSymbol -> Bool -> IO (Either JITSymbolError JITSymbol)
-findSymbolIn compileLayer handle symbol exportedSymbolsOnly = flip runAnyContT return $ do
+findSymbolIn compileLayer handle symbol exportedSymbolsOnly = (\cont -> runAnyContT cont return) $ do
   symbol' <- encodeM symbol
   exportedSymbolsOnly' <- encodeM exportedSymbolsOnly
   symbol <- anyContToM $ bracket
@@ -68,7 +68,7 @@ findSymbolIn compileLayer handle symbol exportedSymbolsOnly = flip runAnyContT r
 -- /Note:/ This function consumes the module passed to it and it must
 -- not be used after calling this method.
 addModule :: CompileLayer l => l -> FFI.ModuleKey -> Module -> IO ()
-addModule compileLayer k mod = flip runAnyContT return $ do
+addModule compileLayer k mod = (\cont -> runAnyContT cont return) $ do
   mod' <- liftIO $ readModule mod
   liftIO $ deleteModule mod
   errMsg <- alloca

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/CompileOnDemandLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/CompileOnDemandLayer.hs
@@ -75,7 +75,7 @@ newIndirectStubsManagerBuilder ::
   ShortByteString {- ^ target triple -} ->
   IO IndirectStubsManagerBuilder
 newIndirectStubsManagerBuilder triple =
-  flip runAnyContT return $ do
+  (\cont -> runAnyContT cont return) $ do
     triple' <- encodeM triple
     stubsMgr <- liftIO (FFI.createLocalIndirectStubsManagerBuilder triple')
     return (StubsMgr stubsMgr)
@@ -105,7 +105,7 @@ newJITCompileCallbackManager ::
   ShortByteString {- ^ target triple -} ->
   Maybe (IO ()) {- ^ called on compilation errors -} ->
   IO JITCompileCallbackManager
-newJITCompileCallbackManager (ExecutionSession es) triple errorHandler = flip runAnyContT return $ do
+newJITCompileCallbackManager (ExecutionSession es) triple errorHandler = (\cont -> runAnyContT cont return) $ do
   triple' <- encodeM triple
   (errorHandler', cleanup) <- encodeM errorHandler
   callbackMgr <- liftIO (FFI.createLocalCompileCallbackManager es triple' errorHandler')
@@ -145,7 +145,7 @@ newCompileOnDemandLayer :: CompileLayer l =>
   Bool {- ^ clone stubs into partitions -} ->
   IO (CompileOnDemandLayer l)
 newCompileOnDemandLayer (ExecutionSession es) baseLayer tm getSymbolResolver setSymbolResolver partition (CallbackMgr callbackMgr _) (StubsMgr stubsMgr) cloneStubs =
-  flip runAnyContT return $ do
+  (\cont -> runAnyContT cont return) $ do
     cleanups <- liftIO (newIORef [])
     dl <- createRegisteredDataLayout tm cleanups
     getSymbolResolver' <- liftIO (allocFunPtr cleanups (FFI.wrapGetSymbolResolver getSymbolResolver))

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/IRCompileLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/IRCompileLayer.hs
@@ -37,7 +37,7 @@ instance CompileLayer (IRCompileLayer l) where
 --
 -- When the layer is no longer needed, it should be disposed using 'disposeCompileLayer.
 newIRCompileLayer :: LinkingLayer l => l -> TargetMachine -> IO (IRCompileLayer l)
-newIRCompileLayer linkingLayer (TargetMachine tm) = flip runAnyContT return $ do
+newIRCompileLayer linkingLayer (TargetMachine tm) = (\cont -> runAnyContT cont return) $ do
   cleanups <- liftIO (newIORef [])
   dl <- createRegisteredDataLayout (TargetMachine tm) cleanups
   cl <- anyContToM $

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/IRTransformLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/IRTransformLayer.hs
@@ -41,7 +41,7 @@ newIRTransformLayer
   -> (Ptr FFI.Module -> IO (Ptr FFI.Module)) {- ^ module transformation -}
   -> IO (IRTransformLayer l)
 newIRTransformLayer compileLayer tm moduleTransform =
-  flip runAnyContT return $ do
+  (\cont -> runAnyContT cont return) $ do
     cleanups <- liftIO (newIORef [])
     dl <- createRegisteredDataLayout tm cleanups
     let encodedModuleTransform =

--- a/llvm-hs/src/LLVM/Internal/OrcJIT/LinkingLayer.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT/LinkingLayer.hs
@@ -30,7 +30,7 @@ disposeLinkingLayer l = do
 
 -- | Add an object file to the 'LinkingLayer'.
 addObjectFile :: LinkingLayer l => l -> FFI.ModuleKey -> ObjectFile -> IO ()
-addObjectFile linkingLayer k (ObjectFile obj) = flip runAnyContT return $ do
+addObjectFile linkingLayer k (ObjectFile obj) = (\cont -> runAnyContT cont return) $ do
   errMsg <- alloca
   liftIO $
     FFI.addObjectFile
@@ -68,7 +68,7 @@ withObjectLinkingLayer es resolver = bracket (newObjectLinkingLayer es resolver)
 findSymbol :: LinkingLayer l => l -> ShortByteString -> Bool -> IO (Either JITSymbolError JITSymbol)
 findSymbol linkingLayer symbol exportedSymbolsOnly =
   SBS.useAsCString symbol $ \symbol' ->
-    flip runAnyContT return $ do
+    (\cont -> runAnyContT cont return) $ do
       exportedSymbolsOnly' <- encodeM exportedSymbolsOnly
       symbol <- anyContToM $ bracket
         (FFI.findSymbol (getLinkingLayer linkingLayer) symbol' exportedSymbolsOnly') FFI.disposeSymbol
@@ -80,7 +80,7 @@ findSymbol linkingLayer symbol exportedSymbolsOnly =
 findSymbolIn :: LinkingLayer l => l -> FFI.ModuleKey -> ShortByteString -> Bool -> IO (Either JITSymbolError JITSymbol)
 findSymbolIn linkingLayer handle symbol exportedSymbolsOnly =
   SBS.useAsCString symbol $ \symbol' ->
-    flip runAnyContT return $ do
+    (\cont -> runAnyContT cont return) $ do
       exportedSymbolsOnly' <- encodeM exportedSymbolsOnly
       symbol <- anyContToM $ bracket
         (FFI.findSymbolIn (getLinkingLayer linkingLayer) handle symbol' exportedSymbolsOnly') FFI.disposeSymbol

--- a/llvm-hs/src/LLVM/Internal/PassManager.hs
+++ b/llvm-hs/src/LLVM/Internal/PassManager.hs
@@ -93,7 +93,7 @@ instance (Monad m, MonadThrow m, MonadAnyCont IO m) => EncodeM m GCOVVersion CSt
     | otherwise = throwM (EncodeException "GCOVVersion should consist of exactly 4 characters")
 
 createPassManager :: HasCallStack => PassSetSpec -> IO (Ptr FFI.PassManager)
-createPassManager pss = flip runAnyContT return $ do
+createPassManager pss = (\cont -> runAnyContT cont return) $ do
   pm <- liftIO $ FFI.createPassManager
   forM_ (targetLibraryInfo pss) $ \(TargetLibraryInfo tli) -> do
     liftIO $ FFI.addTargetLibraryInfoPass pm tli


### PR DESCRIPTION
Hello,

This bunch of commits fix support for GHC 9.0 to GHC 9.4.

I've tested the build with the three versions, and also `cabal test all`.

See individual commits for details of each changes.

Note: I've based my work on top of the `llvm-9` branch, because that's what we are using at work. It is unclear if I must rebase on top of the other branch, or if the other branchs are pulling this branch. Please tell me if I need to do something else.
