### PR TITLE
GHC 9.4.2 support. 

### DIFF
--- a/llvm-hs-pure/llvm-hs-pure.cabal
+++ b/llvm-hs-pure/llvm-hs-pure.cabal
@@ -30,7 +30,7 @@ library
   build-depends:
     base >= 4.9 && < 5,
     attoparsec >= 0.13,
-    bytestring >= 0.10 && < 0.11,
+    bytestring >= 0.10 && < 0.12,
     fail,
     transformers >= 0.3 && < 0.6,
     mtl >= 2.1,

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Monad.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE UndecidableInstances       #-} -- For MonadState s (ModuleBuilderT m) instance
+{-# LANGUAGE TypeOperators #-}
 
 module LLVM.IRBuilder.Monad where
 

--- a/llvm-hs-pure/src/LLVM/Triple.hs
+++ b/llvm-hs-pure/src/LLVM/Triple.hs
@@ -376,5 +376,5 @@ parseTriple triple = do
    in
     case parseOnly (parseSpec `sepBy` char '-') tripleStr of
       Left _ -> throwE $ "ill-formed triple: " ++ show tripleStr
-      Right fs -> pure $ foldr ($) unknownTriple fs
+      Right fs -> pure $ LLVM.Prelude.foldr ($) unknownTriple fs
 

--- a/llvm-hs/Setup.hs
+++ b/llvm-hs/Setup.hs
@@ -170,6 +170,7 @@ main = do
           newHsc buildInfo localBuildInfo =
 #endif
               PreProcessor {
+                  ppOrdering = unsorted,
                   platformIndependent = platformIndependent (origHsc buildInfo),
                   runPreProcessor = \inFiles outFiles verbosity -> do
                       llvmConfig <- getLLVMConfig (configFlags localBuildInfo)

--- a/llvm-hs/llvm-hs.cabal
+++ b/llvm-hs/llvm-hs.cabal
@@ -265,7 +265,7 @@ test-suite test
   type: exitcode-stdio-1.0
   build-depends:
     base >= 4.9 && < 5,
-    bytestring >= 0.10 && < 0.11,
+    bytestring >= 0.10 && < 0.12,
     tasty >= 0.11,
     tasty-hunit >= 0.9,
     tasty-quickcheck >= 0.8,

--- a/llvm-hs/src/LLVM/Internal/FFI/Builder.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/Builder.hs
@@ -9,12 +9,6 @@ import Foreign.Ptr
 import Foreign.C
 import GHC.Stack
 
-import qualified Data.List as List
-import qualified Data.Map as Map
-
-import qualified LLVM.AST.Instruction as A
-import LLVM.Internal.InstructionDefs as ID
-
 import LLVM.Internal.FFI.Context
 import LLVM.Internal.FFI.LLVMCTypes
 import LLVM.Internal.FFI.PtrHierarchy

--- a/llvm-hs/src/LLVM/Internal/Operand.hs
+++ b/llvm-hs/src/LLVM/Internal/Operand.hs
@@ -43,6 +43,7 @@ import LLVM.Internal.Metadata (getByteStringFromFFI)
 
 import qualified LLVM.AST as A hiding (GlobalVariable, Module, PointerType, type')
 import qualified LLVM.AST.Operand as A
+import qualified LLVM.AST.Operand as DT (DITemplateParameter(type', name))
 import qualified LLVM.AST.Constant as A (Constant(Int, integerBits, integerValue))
 
 import LLVM.Internal.FFI.LLVMCTypes (mdSubclassIdP)
@@ -837,8 +838,8 @@ instance EncodeM EncodeAST A.DILocalVariable (Ptr FFI.DILocalVariable) where
 
 instance EncodeM EncodeAST A.DITemplateParameter (Ptr FFI.DITemplateParameter) where
   encodeM p = do
-    name' <- encodeM (A.name (p :: A.DITemplateParameter)) :: EncodeAST (Ptr FFI.MDString)
-    ty <- encodeM (A.type' (p :: A.DITemplateParameter))
+    name' <- encodeM (DT.name (p :: A.DITemplateParameter)) :: EncodeAST (Ptr FFI.MDString)
+    ty <- encodeM (DT.type' (p :: A.DITemplateParameter))
     Context c <- gets encodeStateContext
     case p of
       A.DITemplateTypeParameter {} ->


### PR DESCRIPTION
## Plan

- [x] `bytestring` version bumped: `0.11` -> `0.12`.
- [x] `ppOrdering` missing fixed: [link](https://hackage.haskell.org/package/Cabal-3.8.1.0/docs/Distribution-Simple-PreProcess.html#v:PreProcessor).
- [x] Unused imports removed.
- [x] Import resolving fixed (i am not sure that my workaround is correct).

## Tests

- [x] Cabal tests passed.
- [ ] All GHC warnings fixed.