### PR TITLE
Add support for ObjectLinkingLayer

### DIFF
--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJIT.hs
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJIT.hs
@@ -53,6 +53,9 @@ foreign import ccall safe "LLVM_Hs_disposeThreadSafeModule" disposeThreadSafeMod
 foreign import ccall safe "LLVM_Hs_createRTDyldObjectLinkingLayer" createRTDyldObjectLinkingLayer ::
   Ptr ExecutionSession -> IO (Ptr ObjectLayer)
 
+foreign import ccall safe "LLVM_Hs_createObjectLinkingLayer" createObjectLinkingLayer ::
+  Ptr ExecutionSession -> IO (Ptr ObjectLayer)
+
 foreign import ccall safe "LLVM_Hs_ObjectLayerAddObjectFile" objectLayerAddObjectFile ::
   Ptr ObjectLayer -> Ptr JITDylib -> CString -> IO ()
 

--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <memory>
 
 #include <llvm/ExecutionEngine/Orc/CompileUtils.h>
 #include <llvm/ExecutionEngine/Orc/Core.h>
@@ -6,6 +7,8 @@
 #include <llvm/ExecutionEngine/Orc/Mangling.h>
 #include <llvm/ExecutionEngine/Orc/IRCompileLayer.h>
 #include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>
+#include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
+#include <llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h>
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
 #include <llvm/Bitcode/BitcodeReader.h>
@@ -105,6 +108,10 @@ ObjectLayer* LLVM_Hs_createRTDyldObjectLinkingLayer(ExecutionSession* es) {
     return new RTDyldObjectLinkingLayer(*es, []() {
         return std::make_unique<SectionMemoryManager>();
     });
+}
+
+ObjectLayer* LLVM_Hs_createObjectLinkingLayer(ExecutionSession* es) {
+    return new ObjectLinkingLayer(*es, std::make_unique<jitlink::InProcessMemoryManager>());
 }
 
 void LLVM_Hs_ObjectLayerAddObjectFile(ObjectLayer* ol, JITDylib* dylib, const char* path) {

--- a/llvm-hs/src/LLVM/Internal/OrcJIT.hs
+++ b/llvm-hs/src/LLVM/Internal/OrcJIT.hs
@@ -248,6 +248,17 @@ createRTDyldObjectLinkingLayer (ExecutionSession es cleanups) = do
   modifyIORef' cleanups (FFI.disposeObjectLayer ol :)
   return $ RTDyldObjectLinkingLayer ol
 
+data ObjectLinkingLayer = ObjectLinkingLayer !(Ptr FFI.ObjectLayer)
+
+instance ObjectLayer ObjectLinkingLayer where
+  getObjectLayer (ObjectLinkingLayer ol) = ol
+
+createObjectLinkingLayer :: ExecutionSession -> IO ObjectLinkingLayer
+createObjectLinkingLayer (ExecutionSession es cleanups) = do
+  ol <- FFI.createObjectLinkingLayer es
+  modifyIORef' cleanups (FFI.disposeObjectLayer ol :)
+  return $ ObjectLinkingLayer ol
+
 addObjectFile :: ObjectLayer l => l -> JITDylib -> FilePath -> IO ()
 addObjectFile ol (JITDylib dylib) path = do
   withCString path $ \cStr ->

--- a/llvm-hs/src/LLVM/OrcJIT.hs
+++ b/llvm-hs/src/LLVM/OrcJIT.hs
@@ -37,6 +37,9 @@ module LLVM.OrcJIT (
     -- * Object layers
     ObjectLayer,
     addObjectFile,
+    -- ** ObjectLinkingLayer
+    ObjectLinkingLayer,
+    createObjectLinkingLayer,
     -- ** RTDyldObjectLinkingLayer
     RTDyldObjectLinkingLayer,
     createRTDyldObjectLinkingLayer,


### PR DESCRIPTION
As far as I understand, it's the recommended implementation of the ObjectLayer at the moment. RuntimeDyld was designed for MCJIT and is being phased out (I think).