### PR TITLE
Build with GHC 9.4.2 on llvm-12 branch.

### DIFF
--- a/llvm-hs-pure/llvm-hs-pure.cabal
+++ b/llvm-hs-pure/llvm-hs-pure.cabal
@@ -30,7 +30,7 @@ library
   build-depends:
     base >= 4.9 && < 5,
     attoparsec >= 0.13,
-    bytestring >= 0.10 && < 0.11,
+    bytestring >= 0.10 && < 0.12,
     fail,
     transformers >= 0.3 && < 0.6,
     mtl >= 2.1,

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -34,7 +34,7 @@ import Control.Monad.Fail (MonadFail)
 #endif
 
 import Data.Bifunctor
-import Data.ByteString.Short as BS
+import Data.ByteString.Short (ShortByteString)
 import Data.Char
 import Data.Data
 import Data.Foldable

--- a/llvm-hs-pure/src/LLVM/Triple.hs
+++ b/llvm-hs-pure/src/LLVM/Triple.hs
@@ -14,7 +14,7 @@ import Control.Monad.Trans.Except
 import Data.Attoparsec.ByteString
 import Data.Attoparsec.ByteString.Char8
 import Data.ByteString.Char8 as ByteString hiding (map, foldr)
-import Data.ByteString.Short hiding (pack)
+import Data.ByteString.Short hiding (pack, foldr)
 
 import Data.Map (Map, (!))
 import qualified Data.Map as Map

--- a/llvm-hs/Setup.hs
+++ b/llvm-hs/Setup.hs
@@ -18,6 +18,9 @@ import System.Environment
 #if MIN_VERSION_Cabal(2,0,0)
 #define MIN_VERSION_Cabal_2_0_0
 #endif
+#if MIN_VERSION_Cabal(3,8,1)
+#define MIN_VERSION_Cabal_3_8_1
+#endif
 #endif
 
 -- define these selectively in C files (we are _not_ using HsFFI.h),
@@ -171,6 +174,9 @@ main = do
 #endif
               PreProcessor {
                   platformIndependent = platformIndependent (origHsc buildInfo),
+#ifdef MIN_VERSION_Cabal_3_8_1
+                  ppOrdering = \_ _ modules -> pure modules,
+#endif
                   runPreProcessor = \inFiles outFiles verbosity -> do
                       llvmConfig <- getLLVMConfig (configFlags localBuildInfo)
                       llvmCFlags <- do


### PR DESCRIPTION
This pull request makes this package buildable with GHC 9.4.2, on the active llvm-12 branch (would be a better start point to support latest LLVM and latest GHC).

Part of the change is borrowed from https://github.com/llvm-hs/llvm-hs/pull/406