### PR TITLE
Build with GHC 9.4.2 on llvm-15 branch, and adapt to LLVM-15.

### DIFF
--- a/llvm-hs-pure/llvm-hs-pure.cabal
+++ b/llvm-hs-pure/llvm-hs-pure.cabal
@@ -30,7 +30,7 @@ library
   build-depends:
     base >= 4.9 && < 5,
     attoparsec >= 0.13,
-    bytestring >= 0.10 && < 0.11,
+    bytestring >= 0.10 && < 0.12,
     fail,
     transformers >= 0.3 && < 0.6,
     mtl >= 2.1,

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -34,7 +34,7 @@ import Control.Monad.Fail (MonadFail)
 #endif
 
 import Data.Bifunctor
-import Data.ByteString.Short as BS
+import Data.ByteString.Short (ShortByteString)
 import Data.Char
 import Data.Data
 import Data.Foldable

--- a/llvm-hs-pure/src/LLVM/Triple.hs
+++ b/llvm-hs-pure/src/LLVM/Triple.hs
@@ -14,7 +14,7 @@ import Control.Monad.Trans.Except
 import Data.Attoparsec.ByteString
 import Data.Attoparsec.ByteString.Char8
 import Data.ByteString.Char8 as ByteString hiding (map, foldr)
-import Data.ByteString.Short hiding (pack)
+import Data.ByteString.Short hiding (pack, foldr)
 
 import Data.Map (Map, (!))
 import qualified Data.Map as Map

--- a/llvm-hs/Setup.hs
+++ b/llvm-hs/Setup.hs
@@ -18,6 +18,9 @@ import System.Environment
 #if MIN_VERSION_Cabal(2,0,0)
 #define MIN_VERSION_Cabal_2_0_0
 #endif
+#if MIN_VERSION_Cabal(3,8,1)
+#define MIN_VERSION_Cabal_3_8_1
+#endif
 #endif
 
 -- define these selectively in C files (we are _not_ using HsFFI.h),
@@ -171,6 +174,9 @@ main = do
 #endif
               PreProcessor {
                   platformIndependent = platformIndependent (origHsc buildInfo),
+#ifdef MIN_VERSION_Cabal_3_8_1
+                  ppOrdering = \_ _ modules -> pure modules,
+#endif
                   runPreProcessor = \inFiles outFiles verbosity -> do
                       llvmConfig <- getLLVMConfig (configFlags localBuildInfo)
                       llvmCFlags <- do

--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp
@@ -111,7 +111,11 @@ ObjectLayer* LLVM_Hs_createRTDyldObjectLinkingLayer(ExecutionSession* es) {
 }
 
 ObjectLayer* LLVM_Hs_createObjectLinkingLayer(ExecutionSession* es) {
-    return new ObjectLinkingLayer(*es, std::make_unique<jitlink::InProcessMemoryManager>());
+    auto IPMM = jitlink::InProcessMemoryManager::Create();
+    if (!IPMM) {
+        return nullptr;
+    }
+    return new ObjectLinkingLayer(*es, std::move(*IPMM));
 }
 
 void LLVM_Hs_ObjectLayerAddObjectFile(ObjectLayer* ol, JITDylib* dylib, const char* path) {

--- a/llvm-hs/src/LLVM/Internal/Operand.hs
+++ b/llvm-hs/src/LLVM/Internal/Operand.hs
@@ -837,8 +837,19 @@ instance EncodeM EncodeAST A.DILocalVariable (Ptr FFI.DILocalVariable) where
 
 instance EncodeM EncodeAST A.DITemplateParameter (Ptr FFI.DITemplateParameter) where
   encodeM p = do
-    name' <- encodeM (A.name (p :: A.DITemplateParameter)) :: EncodeAST (Ptr FFI.MDString)
-    ty <- encodeM (A.type' (p :: A.DITemplateParameter))
+    -- As of GHC 9.4.1, selector names have to be entirely unambiguous (under the
+    -- usual name resolution rules)
+    -- However, this type is ambiguous for reason not yet understood.
+    -- One solution would be to use OverloadedRecordDot, using p.name and p.type',
+    -- but it requires GHC 9.2.
+    -- The solution here is to just extract the values
+    --
+    -- (Referred from: https://github.com/llvm-hs/llvm-hs/pull/406)
+    let (name, type') = case p of
+               A.DITemplateTypeParameter{name, type'} -> (name, type')
+               A.DITemplateValueParameter{name, type'} -> (name, type')
+    name' <- encodeM name :: EncodeAST (Ptr FFI.MDString)
+    ty <- encodeM type'
     Context c <- gets encodeStateContext
     case p of
       A.DITemplateTypeParameter _ _ -> do


### PR DESCRIPTION
The "build with GHC 9.4.2" part is the same as #410.

See https://github.com/llvm/llvm-project/commit/962a2479b57f5e0454b472f9c233cda3f89415b1 (which is included afterwords LLVM-14) for the `jitlink::InProcessMemoryManager` API changes.

Tested on windows with MSYS2.