### PR TITLE
Fix compilation error with OrcJITC.cpp

### DIFF
--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -47,7 +47,6 @@ import GHC.Generics(Generic)
 import LLVM.AST hiding (function)
 import LLVM.AST.Global
 import LLVM.AST.Linkage
-import LLVM.AST.Type (ptr)
 import qualified LLVM.AST.Constant as C
 
 import LLVM.IRBuilder.Internal.SnocList

--- a/llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp
+++ b/llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp
@@ -111,7 +111,13 @@ ObjectLayer* LLVM_Hs_createRTDyldObjectLinkingLayer(ExecutionSession* es) {
 }
 
 ObjectLayer* LLVM_Hs_createObjectLinkingLayer(ExecutionSession* es) {
-    return new ObjectLinkingLayer(*es, std::make_unique<jitlink::InProcessMemoryManager>());
+    auto memMgr = jitlink::InProcessMemoryManager::Create();
+    if (auto err = memMgr.takeError()) {
+        llvm::errs() << err << "\n";
+        // FIXME: Better error handling
+        exit(1);
+    }
+    return new ObjectLinkingLayer(*es, std::move(*memMgr));
 }
 
 void LLVM_Hs_ObjectLayerAddObjectFile(ObjectLayer* ol, JITDylib* dylib, const char* path) {


### PR DESCRIPTION
Problem: With LLVM 15.0.7 on my machine, `llvm-hs` does not compile the C++ module at `llvm-hs/src/LLVM/Internal/FFI/OrcJITC.cpp`. This is because `InProcessMemoryManager` now expects a page size as its argument.

Furthermore, the import of `LLVM.AST.Type` is redudant so I removed it.

Solution: There is now `InProcessMemoryManager::Create` that tries to automatically detect the page size, so we can use it to resolve the problem. Also, delete the redundant import.