### PR TITLE
Compile with bytestring-0.11

### DIFF
--- a/llvm-hs-pure/llvm-hs-pure.cabal
+++ b/llvm-hs-pure/llvm-hs-pure.cabal
@@ -30,7 +30,7 @@ library
   build-depends:
     base >= 4.9 && < 5,
     attoparsec >= 0.13,
-    bytestring >= 0.10 && < 0.11,
+    bytestring >= 0.10 && < 0.12,
     fail,
     transformers >= 0.3 && < 0.6,
     mtl >= 2.1,

--- a/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
+++ b/llvm-hs-pure/src/LLVM/IRBuilder/Module.hs
@@ -34,7 +34,7 @@ import Control.Monad.Fail (MonadFail)
 #endif
 
 import Data.Bifunctor
-import Data.ByteString.Short as BS
+import Data.ByteString.Short (ShortByteString)
 import Data.Char
 import Data.Data
 import Data.Foldable

--- a/llvm-hs-pure/src/LLVM/Triple.hs
+++ b/llvm-hs-pure/src/LLVM/Triple.hs
@@ -14,7 +14,7 @@ import Control.Monad.Trans.Except
 import Data.Attoparsec.ByteString
 import Data.Attoparsec.ByteString.Char8
 import Data.ByteString.Char8 as ByteString hiding (map, foldr)
-import Data.ByteString.Short hiding (pack)
+import Data.ByteString.Short (toShort, fromShort)
 
 import Data.Map (Map, (!))
 import qualified Data.Map as Map


### PR DESCRIPTION
The bounds in the cabal file for llvm-hs-pure exclude `bytestring-0.11.0.0`, which is correct since it doesn't compile with `bytestring-0.11.0.0`.

However, the rest of the world is transitioning to it, so for compatibility it would be nice if `llvm-hs-pure` also compiled with `bytestring-0.11.0.0`. This PR provides that compatibility by restricting imports (the relevant changes seem to simply be that newer `bytestring` exports more stuff, which now collides with things `llvm-hs-pure` imports from elsewhere).

Thanks!