### PR TITLE
Update llvm-15 to base 4.19

### DIFF
--- a/llvm-hs-pure/src/LLVM/Prelude.hs
+++ b/llvm-hs-pure/src/LLVM/Prelude.hs
@@ -30,6 +30,7 @@ import Prelude hiding (
     minimum, maximum, sum, product, all, any, and, or,
     concatMap,
     elem, notElem,
+    unzip,
   )
 import Data.Data (Data, Typeable)
 import GHC.Generics (Generic)


### PR DESCRIPTION
`base 4.19` adds a function `unzip` to `Data.Functor` which was clashing with the `unzip` in `Prelude`.

I have hidden `Prelude.unzip` since it is less general.