### PR TITLE
Update Prelude.hs

### DIFF
--- a/llvm-hs-pure/src/LLVM/Prelude.hs
+++ b/llvm-hs-pure/src/LLVM/Prelude.hs
@@ -30,6 +30,7 @@ import Prelude hiding (
     minimum, maximum, sum, product, all, any, and, or,
     concatMap,
     elem, notElem,
+    unzip
   )
 import Data.Data (Data, Typeable)
 import GHC.Generics (Generic)


### PR DESCRIPTION
When compiling llvm-hs-pure for accelerate, the GHC complains that both Prelude and Data.Functor export unzip. That's why I added unzip to the hiding list of the Prelude import (that takes place before exporting it again).